### PR TITLE
Fix the privacy policy link

### DIFF
--- a/apps/website/src/app/pricing/page.tsx
+++ b/apps/website/src/app/pricing/page.tsx
@@ -123,7 +123,7 @@ export default function Page() {
                   are also actively working towards SOC 2 Type II compliance. We
                   encrypt data at rest, and sensitive data on row level. We also
                   support 2FA authentication.
-                  <Link href="/privacy">midday.co/privacy</Link>.
+                  <Link href="/policy">midday.ai/policy</Link>.
                 </AccordionContent>
               </AccordionItem>
 


### PR DESCRIPTION
The privacy policy link currently links to `/privacy` when the URL is in fact `/policy`. It also has the wrong domain in the text.