### PR TITLE
Fix the typo in upload message appeared in toast

### DIFF
--- a/apps/dashboard/src/components/tables/vault/upload-zone.tsx
+++ b/apps/dashboard/src/components/tables/vault/upload-zone.tsx
@@ -96,7 +96,7 @@ export function UploadZone({ children }) {
 
       setProgress(0);
       toast({
-        title: "Upload successfull.",
+        title: "Upload successful.",
         variant: "success",
         duration: 2000,
       });


### PR DESCRIPTION
Fixed the typo in upload message from `Upload successfull.` to `Upload successful.`