### PR TITLE
fix: resolve issue #225 - Cancel button acting as submit

### DIFF
--- a/apps/dashboard/src/components/modals/create-team-modal.tsx
+++ b/apps/dashboard/src/components/modals/create-team-modal.tsx
@@ -81,7 +81,7 @@ export function CreateTeamModal({ onOpenChange }: Props) {
             <div className="mt-6 mb-6">
               <DialogFooter>
                 <div className="space-x-4">
-                  <Button variant="outline" onClick={() => onOpenChange(false)}>
+                  <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                     Cancel
                   </Button>
                   <Button


### PR DESCRIPTION
## Description
This PR addresses a bug [#225] where the cancel button in the "Create Team" modal was unintentionally submitting the form, instead of simply closing the modal. The cancel button now behaves as expected and closes the modal without triggering any form submission.

## Changes
Updated the cancel button to have type="button" to prevent it from submitting the form.

## Testing
This fix hasn't been tested yet, so please give it a thorough review and test it before merging.