### PR TITLE
fix: ensure cancel button closes the create team dialog

### DIFF
--- a/apps/dashboard/src/components/tables/teams/table.tsx
+++ b/apps/dashboard/src/components/tables/teams/table.tsx
@@ -246,8 +246,9 @@ export function TeamsSkeleton() {
 }
 
 export function DataTableHeader({ table }) {
+  const [isOpen, onOpenChange] = React.useState(false);
   return (
-    <Dialog>
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <div className="flex items-center pb-4 space-x-4">
         <Input
           className="flex-1"
@@ -264,7 +265,7 @@ export function DataTableHeader({ table }) {
         <DialogTrigger asChild>
           <Button>Create team</Button>
         </DialogTrigger>
-        <CreateTeamModal />
+        <CreateTeamModal onOpenChange={onOpenChange} />
       </div>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
This PR fixes the Cancel button in the dialog to ensure it properly closes the dialog.

## Changes
Fixed the Cancel button behavior in `apps/dashboard/src/components/tables/teams/table.tsx:248`

## Related Issue
Follow-up to commit resolving issue #225.

## Testing
The fix hasn't been tested.
I've just got to look at the codebase two hours ago, didn't have time to set it up in my local environment. 😅