### PR TITLE
fix: adjust the css so the link dropdown isn't outside the nav

### DIFF
--- a/apps/website/src/components/header.tsx
+++ b/apps/website/src/components/header.tsx
@@ -264,7 +264,7 @@ export function Header() {
                 {children && (
                   <div
                     className={cn(
-                      "absolute top-[48px] w-[676px] -left-[1px] bg-[#121212] flex h-0 group-hover:h-[250px] overflow-hidden transition-all duration-300 ease-in-out border-l-[1px] border-r-[1px]",
+                      "absolute top-[48px] -ml-[0.8px] -right-[0.8px] bg-[#121212] flex h-0 group-hover:h-[250px] overflow-hidden transition-all duration-300 ease-in-out border-l border-r",
                       hidden && "hidden"
                     )}
                   >

--- a/apps/website/src/components/header.tsx
+++ b/apps/website/src/components/header.tsx
@@ -20,7 +20,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import menuAssistant from "public/menu-assistant.jpg";
 import menuEngine from "public/menu-engine.png";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FaDiscord, FaGithub } from "react-icons/fa";
 import {
   MdOutlineDescription,
@@ -51,9 +51,20 @@ export function Header() {
   const [isOpen, setOpen] = useState(false);
   const [showBlur, setShowBlur] = useState(false);
   const [hidden, setHidden] = useState(false);
-
   const lastPath = `/${pathname.split("/").pop()}`;
 
+  useEffect(() => {
+    const setPixelRatio = () => {
+      const pixelRatio = window.devicePixelRatio || 1;
+      document.documentElement.style.setProperty('--pixel-ratio', `${1 / pixelRatio}`);
+    };
+  
+    setPixelRatio();
+    window.addEventListener('resize', setPixelRatio);
+  
+    return () => window.removeEventListener('resize', setPixelRatio);
+  }, []);
+  
   const handleToggleMenu = () => {
     setOpen((prev) => {
       document.body.style.overflow = prev ? "" : "hidden";
@@ -264,8 +275,8 @@ export function Header() {
                 {children && (
                   <div
                     className={cn(
-                      "absolute top-[48px] -ml-[0.8px] -right-[0.8px] bg-[#121212] flex h-0 group-hover:h-[250px] overflow-hidden transition-all duration-300 ease-in-out border-l border-r",
-                      hidden && "hidden"
+                      "absolute top-[48px] left-0 -mx-[calc(var(--pixel-ratio)_*_1px)] bg-[#121212] flex h-0 group-hover:h-[250px] overflow-hidden transition-all duration-300 ease-in-out border-l border-r",
+                      hidden && "hidden",
                     )}
                   >
                     <ul className="p-4 w-[200px] flex-0 space-y-5 mt-2">


### PR DESCRIPTION
When there is a display that is scaled (most 4k monitors have a default scale of 150%), the css acts differently and causes the dropdown to be extended beyond the nav width. This solution looks for the users device pixel ratio and adjusts the margin to align with the navbar. 

Not sure if this change would be necessary, but I think it's always good to make sure the landing page is consistent across screen sizes and scales.

This also allows you to remove or add links without having to readjust the previously fixed width. 

Old behavior:
![image](https://github.com/user-attachments/assets/19e09c22-5778-4cb9-b552-3359ccd42076)

Fix to make it consistent:
![image](https://github.com/user-attachments/assets/fb4fcaeb-fc29-4696-a331-f2e5448e1641)
