### PR TITLE
Fix Invite Code Redirect in Middleware #185

### DIFF
--- a/apps/dashboard/src/middleware.ts
+++ b/apps/dashboard/src/middleware.ts
@@ -54,6 +54,11 @@ export async function middleware(request: NextRequest) {
     session &&
     !session?.user?.user_metadata?.full_name
   ) {
+    // Check if the URL contains an invite code
+    const inviteCodeMatch = newUrl.pathname.startsWith("/teams/invite/");
+    if (inviteCodeMatch) {
+      return NextResponse.redirect(`${url.origin}${newUrl.pathname}`);
+    }
     return NextResponse.redirect(`${url.origin}/setup`);
   }
 


### PR DESCRIPTION
### Description

This PR addresses the issue where invited users are redirected to the `/setup` page instead of the `/teams/invite/[code]` page after login. The middleware has been updated to correctly handle the invite code redirection.

### Changes
- Updated the invite code check in the middleware to ensure users are redirected to the correct invite page.

### Flow Diagram
<img width="1568" alt="flow" src="https://github.com/user-attachments/assets/b7b4b589-4c3a-402e-838e-437bbef69c19">

### Note
As I don't have this project running locally, I'm coming up with a quick fix. It might have other side effects that we need to look out for.

### Related Issue
Fixes #185

### Checklist
- [x] Ensure the invite code redirection works as expected.
- [x] Verify there are no unintended side effects.
- [ ] Add tests to cover the changes if applicable.

### Additional Context ⚠️
For the setup page, we should check if the user is already in a team. Currently, the user will still be forced to create a team even though they are already in a team. This needs to be addressed to improve the user experience.

### Testing
Please ensure to test the following scenarios:
1. Invited users are redirected to the `/teams/invite/[code]` page after login.
2. Users without a full name are redirected to the `/setup` page.
3. Users with MFA enrolled but not verified are redirected to the `/mfa/verify` page.