### PR TITLE
Fix bank logo component

### DIFF
--- a/apps/dashboard/src/components/bank-logo.tsx
+++ b/apps/dashboard/src/components/bank-logo.tsx
@@ -9,8 +9,8 @@ type Props = {
 export function BankLogo({ src, alt, size = 34 }: Props) {
   return (
     <Avatar style={{ width: size, height: size }}>
-      {src && <AvatarImage src={src} alt={alt} />}
-      <AvatarImage src="https://cdn-engine.midday.ai/default.jpg" alt={alt} />
+      {src && <AvatarImage src={src} alt={alt} className="text-transparent" />}
+      <AvatarImage src="https://cdn-engine.midday.ai/default.jpg" alt={alt} className="absolute -z-10" />
     </Avatar>
   );
 }


### PR DESCRIPTION
Currently the bank logos look quite funny:
![image](https://github.com/user-attachments/assets/35018f89-a4d0-4cec-9107-de94c140fb24)

If I understood correctly, the default image should act as a placeholder. So I have fixed it with these styles:
- `text-transparent` for the actual logo: if it doesn't load the alt text shouldn't come over the placeholder
- `absolute -z-10` for the placeholder: making sure it goes under the actual logo

![image](https://github.com/user-attachments/assets/737cd30f-2d71-4766-a06c-f914a7f5c9de)
