### PR TITLE
fix: brand menu ui

### DIFF
--- a/apps/website/src/components/header.tsx
+++ b/apps/website/src/components/header.tsx
@@ -205,7 +205,7 @@ export function Header() {
           </ContextMenuTrigger>
 
           <ContextMenuContent
-            className="w-[200px] dark:bg-[]dark:bg-[#121212] bg-[#fff] rounded-none"
+            className="w-[200px] rounded-none"
             alignOffset={20}
           >
             <div className="divide-y">


### PR DESCRIPTION
# Why

Removed redundant styling for dark mode since it's already handled.

# How

Removed the explicit dark mode and background styling, making it consistent with the rest of the theme.

# Test Plan

Before

<img width="265" alt="Screenshot 2025-03-31 at 8 37 46 PM" src="https://github.com/user-attachments/assets/0daffb97-70af-4ae4-9fca-883fd5005632" />

After

<img width="257" alt="Screenshot 2025-03-31 at 8 37 38 PM" src="https://github.com/user-attachments/assets/8ae0fb05-37d6-4908-9bc4-bf9e5b7d9528" />
