### PR TITLE
fix: update step value in QuantityInput component from 0.1 to 0.01

### DIFF
--- a/packages/ui/src/components/quantity-input.tsx
+++ b/packages/ui/src/components/quantity-input.tsx
@@ -79,7 +79,7 @@ export function QuantityInput({
           min={min}
           max={max}
           autoComplete="off"
-          step={0.1}
+          step={0.01}
           value={rawValue}
           onInput={handleInput}
           onBlur={onBlur}


### PR DESCRIPTION
## What
Related to https://github.com/midday-ai/midday/issues/381
This PR allows for a value with two decimal places in the [QuantityInput](https://github.com/midday-ai/midday/blob/main/packages/ui/src/components/quantity-input.tsx); the main problem here is that with a `step` of 0.1, values like `5.55` are not allowed, and the browser suggests either `5.5` or `5.6`, but nothing in between.

To overcome this issue, I increased the precision of the step from `0.1` to `0.01`