### PR TITLE
fix(website): ensure icons are properly aligned within lists

### DIFF
--- a/apps/website/src/components/section-five.tsx
+++ b/apps/website/src/components/section-five.tsx
@@ -32,13 +32,13 @@ export function SectionFive() {
             place.
           </p>
 
-          <div className="flex flex-col space-y-2 h-full">
-            <div className="flex space-x-2 items-center mt-8 text-sm">
+          <div className="flex flex-col space-y-2 h-full mt-8">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
@@ -49,12 +49,12 @@ export function SectionFive() {
                 Automatic classification of documents for easy search & find
               </span>
             </div>
-            <div className="flex space-x-2 items-center text-sm">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"

--- a/apps/website/src/components/section-four.tsx
+++ b/apps/website/src/components/section-four.tsx
@@ -26,13 +26,13 @@ export function SectionFour() {
             balance, track overdue payments and send reminders.
           </p>
 
-          <div className="flex flex-col space-y-2">
-            <div className="flex space-x-2 items-center mt-8 text-sm">
+          <div className="flex flex-col space-y-2 mt-8">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
@@ -41,12 +41,12 @@ export function SectionFour() {
               </svg>
               <span className="text-primary">Create Customers</span>
             </div>
-            <div className="flex space-x-2 items-center text-sm">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
@@ -56,12 +56,12 @@ export function SectionFour() {
               <span className="text-primary">Add Vat & Sales tax</span>
             </div>
 
-            <div className="flex space-x-2 items-center text-sm">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
@@ -71,12 +71,12 @@ export function SectionFour() {
               <span className="text-primary">Add discount</span>
             </div>
 
-            <div className="flex space-x-2 items-center text-sm">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
@@ -86,12 +86,12 @@ export function SectionFour() {
               <span className="text-primary">Add Logo</span>
             </div>
 
-            <div className="flex space-x-2 items-center text-sm">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
@@ -101,12 +101,12 @@ export function SectionFour() {
               <span className="text-primary">Send web invoices</span>
             </div>
 
-            <div className="flex space-x-2 items-center text-sm">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
@@ -116,12 +116,12 @@ export function SectionFour() {
               <span className="text-primary">Export as PDF</span>
             </div>
 
-            <div className="flex space-x-2 items-center text-sm">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
@@ -202,13 +202,13 @@ export function SectionFour() {
           </li>
         </ul>
 
-        <div className="flex flex-col space-y-2 mb-6">
-          <div className="flex space-x-2 items-center mt-8 text-sm">
+        <div className="flex flex-col space-y-2 mb-6 mt-8">
+          <div className="flex space-x-2 text-sm">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width={18}
-              height={13}
+              viewBox="0 0 18 13"
               fill="none"
+              className="flex-none w-[1.125rem] h-[1lh]"
             >
               <path
                 fill="currentColor"
@@ -217,12 +217,12 @@ export function SectionFour() {
             </svg>
             <span className="text-primary">Personalized email</span>
           </div>
-          <div className="flex space-x-2 items-center text-sm">
+          <div className="flex space-x-2 text-sm">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width={18}
-              height={13}
+              viewBox="0 0 18 13"
               fill="none"
+              className="flex-none w-[1.125rem] h-[1lh]"
             >
               <path
                 fill="currentColor"
@@ -234,12 +234,12 @@ export function SectionFour() {
             </span>
           </div>
 
-          <div className="flex space-x-2 items-center text-sm">
+          <div className="flex space-x-2 text-sm">
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width={18}
-              height={13}
+              viewBox="0 0 18 13"
               fill="none"
+              className="flex-none w-[1.125rem] h-[1lh]"
             >
               <path
                 fill="currentColor"

--- a/apps/website/src/components/section-three.tsx
+++ b/apps/website/src/components/section-three.tsx
@@ -26,13 +26,13 @@ export function SectionThree() {
               invoices from your recorded hours.
             </p>
 
-            <div className="flex flex-col space-y-2">
-              <div className="flex space-x-2 items-center mt-8 text-sm">
+            <div className="flex flex-col space-y-2 mt-8">
+              <div className="flex space-x-2 text-sm">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  width={18}
-                  height={13}
+                  viewBox="0 0 18 13"
                   fill="none"
+                  className="flex-none w-[1.125rem] h-[1lh]"
                 >
                   <path
                     fill="currentColor"
@@ -43,12 +43,12 @@ export function SectionThree() {
                   Get a monthly overview of tracked hours
                 </span>
               </div>
-              <div className="flex space-x-2 items-center text-sm">
+              <div className="flex space-x-2 text-sm">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  width={18}
-                  height={13}
+                  viewBox="0 0 18 13"
                   fill="none"
+                  className="flex-none w-[1.125rem] h-[1lh]"
                 >
                   <path
                     fill="currentColor"
@@ -60,12 +60,12 @@ export function SectionThree() {
                 </span>
               </div>
 
-              <div className="flex space-x-2 items-center text-sm">
+              <div className="flex space-x-2 text-sm">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  width={18}
-                  height={13}
+                  viewBox="0 0 18 13"
                   fill="none"
+                  className="flex-none w-[1.125rem] h-[1lh]"
                 >
                   <path
                     fill="currentColor"
@@ -77,12 +77,12 @@ export function SectionThree() {
                 </span>
               </div>
 
-              <div className="flex space-x-2 items-center text-sm">
+              <div className="flex space-x-2 text-sm">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  width={18}
-                  height={13}
+                  viewBox="0 0 18 13"
                   fill="none"
+                  className="flex-none w-[1.125rem] h-[1lh]"
                 >
                   <path
                     fill="currentColor"
@@ -94,12 +94,12 @@ export function SectionThree() {
                 </span>
               </div>
 
-              <div className="flex space-x-2 items-center text-sm">
+              <div className="flex space-x-2 text-sm">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  width={18}
-                  height={13}
+                  viewBox="0 0 18 13"
                   fill="none"
+                  className="flex-none w-[1.125rem] h-[1lh]"
                 >
                   <path
                     fill="currentColor"

--- a/apps/website/src/components/section-two.tsx
+++ b/apps/website/src/components/section-two.tsx
@@ -30,64 +30,64 @@ export function SectionTwo() {
           </p>
 
           <div className="flex flex-col space-y-2">
-            <div className="flex space-x-2 items-center ">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
                   d="M6.55 13 .85 7.3l1.425-1.425L6.55 10.15 15.725.975 17.15 2.4 6.55 13Z"
                 />
               </svg>
-              <span className="text-primary text-sm">Revenue</span>
+              <span className="text-primary">Revenue</span>
             </div>
 
-            <div className="flex space-x-2 items-center">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
                   d="M6.55 13 .85 7.3l1.425-1.425L6.55 10.15 15.725.975 17.15 2.4 6.55 13Z"
                 />
               </svg>
-              <span className="text-primary text-sm">Burnrate</span>
+              <span className="text-primary">Burnrate</span>
             </div>
 
-            <div className="flex space-x-2 items-center">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
                   d="M6.55 13 .85 7.3l1.425-1.425L6.55 10.15 15.725.975 17.15 2.4 6.55 13Z"
                 />
               </svg>
-              <span className="text-primary text-sm">Expenses</span>
+              <span className="text-primary">Expenses</span>
             </div>
 
-            <div className="flex space-x-2 items-center">
+            <div className="flex space-x-2 text-sm">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width={18}
-                height={13}
+                viewBox="0 0 18 13"
                 fill="none"
+                className="flex-none w-[1.125rem] h-[1lh]"
               >
                 <path
                   fill="currentColor"
                   d="M6.55 13 .85 7.3l1.425-1.425L6.55 10.15 15.725.975 17.15 2.4 6.55 13Z"
                 />
               </svg>
-              <span className="text-primary text-sm">
+              <span className="text-primary">
                 Unified currency overview across all your accounts
               </span>
             </div>


### PR DESCRIPTION
- Ensure icons are aligned on the first line vs being vertically centered within the whole item.
- Ensure icons don't shrink when the content is longer than one line.

| BEFORE | AFTER |
|--------|--------|
| <img width="415" height="199" alt="Screenshot 2025-09-06 at 8 53 44 AM" src="https://github.com/user-attachments/assets/77f80a75-950e-42a7-a801-30b70aa2c3b2" /> | <img width="426" height="176" alt="Screenshot 2025-09-06 at 8 54 10 AM" src="https://github.com/user-attachments/assets/d2b4f27d-063a-4e5c-9d89-c8ca9362c122" /> | 