### PR TITLE
Refactor OAuth components: DRY with shared hook and Supabase abstraction

### DIFF
--- a/apps/dashboard/src/components/apple-sign-in.tsx
+++ b/apps/dashboard/src/components/apple-sign-in.tsx
@@ -1,51 +1,18 @@
 "use client";
 
-import { getUrl } from "@/utils/environment";
-import { isDesktopApp } from "@midday/desktop-client/platform";
-import { createClient } from "@midday/supabase/client";
+import { useOAuthSignIn } from "@/hooks/use-oauth-signin";
 import { Icons } from "@midday/ui/icons";
 import { SubmitButton } from "@midday/ui/submit-button";
-import { useState } from "react";
 
 export function AppleSignIn() {
-  const [isLoading, setLoading] = useState(false);
-  const supabase = createClient();
-
-  const handleSignIn = async () => {
-    setLoading(true);
-
-    if (isDesktopApp()) {
-      const redirectTo = new URL("/api/auth/callback", getUrl());
-
-      redirectTo.searchParams.append("provider", "apple");
-      redirectTo.searchParams.append("client", "desktop");
-
-      await supabase.auth.signInWithOAuth({
-        provider: "apple",
-        options: {
-          redirectTo: redirectTo.toString(),
-          queryParams: {
-            client: "desktop",
-          },
-        },
-      });
-    } else {
-      await supabase.auth.signInWithOAuth({
-        provider: "apple",
-        options: {
-          redirectTo: `${getUrl()}/api/auth/callback?provider=apple`,
-        },
-      });
-    }
-
-    setTimeout(() => {
-      setLoading(false);
-    }, 2000);
-  };
+  const { isLoading, signIn } = useOAuthSignIn({
+    provider: "apple",
+    useReturnTo: false,
+  });
 
   return (
     <SubmitButton
-      onClick={handleSignIn}
+      onClick={signIn}
       className="bg-primary px-6 py-4 text-secondary font-medium h-[40px] w-full"
       isSubmitting={isLoading}
     >

--- a/apps/dashboard/src/components/github-sign-in.tsx
+++ b/apps/dashboard/src/components/github-sign-in.tsx
@@ -1,62 +1,18 @@
 "use client";
 
-import { getUrl } from "@/utils/environment";
-import { isDesktopApp } from "@midday/desktop-client/platform";
-import { createClient } from "@midday/supabase/client";
+import { useOAuthSignIn } from "@/hooks/use-oauth-signin";
 import { Icons } from "@midday/ui/icons";
 import { SubmitButton } from "@midday/ui/submit-button";
-import { useSearchParams } from "next/navigation";
-import { useState } from "react";
 
 export function GithubSignIn() {
-  const [isLoading, setLoading] = useState(false);
-  const supabase = createClient();
-  const searchParams = useSearchParams();
-  const returnTo = searchParams.get("return_to");
-
-  const handleSignIn = async () => {
-    setLoading(true);
-
-    if (isDesktopApp()) {
-      const redirectTo = new URL("/api/auth/callback", getUrl());
-
-      redirectTo.searchParams.append("provider", "github");
-      redirectTo.searchParams.append("client", "desktop");
-
-      await supabase.auth.signInWithOAuth({
-        provider: "github",
-        options: {
-          redirectTo: redirectTo.toString(),
-          queryParams: {
-            client: "desktop",
-          },
-        },
-      });
-    } else {
-      const redirectTo = new URL("/api/auth/callback", getUrl());
-
-      if (returnTo) {
-        redirectTo.searchParams.append("return_to", returnTo);
-      }
-
-      redirectTo.searchParams.append("provider", "github");
-
-      await supabase.auth.signInWithOAuth({
-        provider: "github",
-        options: {
-          redirectTo: redirectTo.toString(),
-        },
-      });
-    }
-
-    setTimeout(() => {
-      setLoading(false);
-    }, 2000);
-  };
+  const { isLoading, signIn } = useOAuthSignIn({
+    provider: "github",
+    useReturnTo: true,
+  });
 
   return (
     <SubmitButton
-      onClick={handleSignIn}
+      onClick={signIn}
       className="bg-primary px-6 py-4 text-secondary font-medium h-[40px] w-full"
       isSubmitting={isLoading}
     >

--- a/apps/dashboard/src/components/google-sign-in.tsx
+++ b/apps/dashboard/src/components/google-sign-in.tsx
@@ -1,66 +1,21 @@
 "use client";
 
-import { getUrl } from "@/utils/environment";
-import { isDesktopApp } from "@midday/desktop-client/platform";
-import { createClient } from "@midday/supabase/client";
+import { useOAuthSignIn } from "@/hooks/use-oauth-signin";
 import { Icons } from "@midday/ui/icons";
 import { SubmitButton } from "@midday/ui/submit-button";
-import { useSearchParams } from "next/navigation";
-import { useState } from "react";
 
 export function GoogleSignIn() {
-  const [isLoading, setLoading] = useState(false);
-  const supabase = createClient();
-  const searchParams = useSearchParams();
-  const returnTo = searchParams.get("return_to");
-
-  const handleSignIn = async () => {
-    setLoading(true);
-
-    if (isDesktopApp()) {
-      const redirectTo = new URL("/api/auth/callback", getUrl());
-
-      redirectTo.searchParams.append("provider", "google");
-      redirectTo.searchParams.append("client", "desktop");
-
-      await supabase.auth.signInWithOAuth({
-        provider: "google",
-        options: {
-          redirectTo: redirectTo.toString(),
-          queryParams: {
-            prompt: "select_account",
-            client: "desktop",
-          },
-        },
-      });
-    } else {
-      const redirectTo = new URL("/api/auth/callback", getUrl());
-
-      if (returnTo) {
-        redirectTo.searchParams.append("return_to", returnTo);
-      }
-
-      redirectTo.searchParams.append("provider", "google");
-
-      await supabase.auth.signInWithOAuth({
-        provider: "google",
-        options: {
-          redirectTo: redirectTo.toString(),
-          queryParams: {
-            prompt: "select_account",
-          },
-        },
-      });
-    }
-
-    setTimeout(() => {
-      setLoading(false);
-    }, 2000);
-  };
+  const { isLoading, signIn } = useOAuthSignIn({
+    provider: "google",
+    useReturnTo: true,
+    extraQueryParams: {
+      prompt: "select_account",
+    },
+  });
 
   return (
     <SubmitButton
-      onClick={handleSignIn}
+      onClick={signIn}
       className="bg-primary px-6 py-4 text-secondary font-medium h-[40px] w-full"
       isSubmitting={isLoading}
     >

--- a/apps/dashboard/src/components/otp-sign-in.tsx
+++ b/apps/dashboard/src/components/otp-sign-in.tsx
@@ -9,6 +9,7 @@ import { Input } from "@midday/ui/input";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@midday/ui/input-otp";
 import { Spinner } from "@midday/ui/spinner";
 import { SubmitButton } from "@midday/ui/submit-button";
+import { useToast } from "@midday/ui/use-toast";
 import { useAction } from "next-safe-action/hooks";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
@@ -29,6 +30,7 @@ export function OTPSignIn({ className }: Props) {
   const [isSent, setSent] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false);
   const [email, setEmail] = useState<string>();
+  const { toast } = useToast();
   const supabase = createClient();
   const searchParams = useSearchParams();
 
@@ -43,9 +45,15 @@ export function OTPSignIn({ className }: Props) {
     setLoading(true);
 
     setEmail(email);
+    const { error } = await supabase.auth.signInWithOtp({ email });
+    if (error) {
+      
+      console.error("Error sending OTP:", error.message);
+      toast({title: error.message, variant: "destructive", duration: 3500});
 
-    await supabase.auth.signInWithOtp({ email });
-
+      setLoading(false);
+      return;
+    }
     setSent(true);
     setLoading(false);
   }

--- a/apps/dashboard/src/hooks/use-oauth-signin.ts
+++ b/apps/dashboard/src/hooks/use-oauth-signin.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { getUrl } from "@/utils/environment";
+import { isDesktopApp } from "@midday/desktop-client/platform";
+import { createClient } from "@midday/supabase/client";
+import { useToast } from "@midday/ui/use-toast";
+import { useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+type OAuthProvider = "apple" | "github" | "google";
+
+interface OAuthOptions {
+  provider: OAuthProvider;
+  useReturnTo?: boolean;
+  extraQueryParams?: Record<string, string>;
+}
+
+interface OAuthSignInResult {
+  isLoading: boolean;
+  signIn: () => Promise<void>;
+}
+
+export function useOAuthSignIn(options: OAuthOptions): OAuthSignInResult {
+  const { provider, useReturnTo = false, extraQueryParams = {} } = options;
+  const [isLoading, setLoading] = useState(false);
+  const supabase = createClient();
+  const searchParams = useSearchParams();
+  const returnTo = searchParams.get("return_to");
+  const { toast } = useToast();
+
+  const signIn = async () => {
+    const startTime = performance.now();
+    setLoading(true);
+
+    try {
+      const redirectTo = new URL("/api/auth/callback", getUrl());
+      
+      // Add provider to redirect URL
+      redirectTo.searchParams.append("provider", provider);
+
+      // Handle returnTo parameter for supported providers
+      if (useReturnTo && returnTo) {
+        redirectTo.searchParams.append("return_to", returnTo);
+      }
+
+      // Desktop-specific configuration
+      if (isDesktopApp()) {
+        redirectTo.searchParams.append("client", "desktop");
+      }
+
+      // Prepare OAuth options
+      const oauthOptions: any = {
+        redirectTo: redirectTo.toString(),
+        queryParams: {
+          ...extraQueryParams,
+          ...(isDesktopApp() && { client: "desktop" }),
+        },
+      };
+
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider,
+        options: oauthOptions,
+      });
+
+      if (error) {
+        console.error(`${provider} OAuth sign-in failed`, error, {
+          action: "oauth_signin_failed",
+          provider,
+          errorMessage: error.message,
+          isDesktop: isDesktopApp(),
+        });
+
+        toast({
+          title: "Sign-in Error",
+          description: error.message,
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      
+      console.error(`${provider} OAuth sign-in exception`, error as Error, {
+        action: "oauth_signin_exception",
+        provider,
+        errorMessage,
+        isDesktop: isDesktopApp(),
+      });
+
+      toast({
+        title: "Sign-in Error",
+        description: errorMessage,
+        variant: "destructive",
+      });
+    } finally {
+      // Reset loading state after OAuth redirect delay
+      setTimeout(() => {
+        setLoading(false);
+      }, 2000);
+    }
+  };
+
+  return {
+    isLoading,
+    signIn,
+  };
+}


### PR DESCRIPTION
Eliminated code duplication across Apple, GitHub, and Google OAuth sign-in components
Created reusable `useOAuthSignIn` hook with unified Supabase abstraction layer
Show toaster for sign-in error