### PR TITLE
fix: resolve SEO issue - update sitemap and metadata URLs to use /upd…

### DIFF
--- a/apps/website/src/app/sitemap.ts
+++ b/apps/website/src/app/sitemap.ts
@@ -5,7 +5,7 @@ export const baseUrl = "https://midday.ai";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const blogs = getBlogPosts().map((post) => ({
-    url: `${baseUrl}/blog/${post.slug}`,
+    url: `${baseUrl}/updates/${post.slug}`,
     lastModified: post.metadata.publishedAt,
   }));
 

--- a/apps/website/src/app/updates/[slug]/page.tsx
+++ b/apps/website/src/app/updates/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata(props): Promise<Metadata | undefined> {
       description,
       type: "article",
       publishedTime,
-      url: `${baseUrl}/blog/${post.slug}`,
+      url: `${baseUrl}/updates/${post.slug}`,
       images: [
         {
           url: image,


### PR DESCRIPTION
…ates/ instead of /blog/

- Sitemap URLs now point to actual /updates/ routes
- Fixed metadata Open Graph URLs to match real routes
- Prevents 404 errors and crawl budget waste