### PR TITLE
Support system theme in PDFs

### DIFF
--- a/apps/dashboard/src/components/canvas/base/canvas-header.tsx
+++ b/apps/dashboard/src/components/canvas/base/canvas-header.tsx
@@ -23,7 +23,7 @@ interface CanvasHeaderProps {
 }
 
 export function CanvasHeader({ title }: CanvasHeaderProps) {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const { toast } = useToast();
 
   const filename = `${title.toLowerCase().replace(/\s+/g, "-")}-report.pdf`;
@@ -32,7 +32,7 @@ export function CanvasHeader({ title }: CanvasHeaderProps) {
     try {
       await generateCanvasPdf({
         filename,
-        theme,
+        theme: resolvedTheme,
       });
     } catch {}
   };
@@ -49,7 +49,7 @@ export function CanvasHeader({ title }: CanvasHeaderProps) {
       // Generate PDF blob silently
       const blob = await generateCanvasPdfBlob({
         filename,
-        theme,
+        theme: resolvedTheme,
       });
 
       // Create File object from blob

--- a/apps/dashboard/src/utils/canvas-to-pdf.ts
+++ b/apps/dashboard/src/utils/canvas-to-pdf.ts
@@ -25,9 +25,19 @@ export async function generateCanvasPdf(
     theme,
   } = options;
 
-  const backgroundColor = theme === "dark" ? "#0c0c0c" : "#ffffff";
+  // Resolve theme: if "system" or undefined, check system preference
+  const resolvedTheme =
+    theme === "system" || !theme
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
+      : theme;
+
+  const backgroundColor = resolvedTheme === "dark" ? "#0c0c0c" : "#ffffff";
   const backgroundRgb =
-    theme === "dark" ? { r: 12, g: 12, b: 12 } : { r: 255, g: 255, b: 255 };
+    resolvedTheme === "dark"
+      ? { r: 12, g: 12, b: 12 }
+      : { r: 255, g: 255, b: 255 };
 
   try {
     // Find the canvas content
@@ -140,9 +150,19 @@ export async function generateCanvasPdfBlob(
     theme,
   } = options;
 
-  const backgroundColor = theme === "dark" ? "#0c0c0c" : "#ffffff";
+  // Resolve theme: if "system" or undefined, check system preference
+  const resolvedTheme =
+    theme === "system" || !theme
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
+      : theme;
+
+  const backgroundColor = resolvedTheme === "dark" ? "#0c0c0c" : "#ffffff";
   const backgroundRgb =
-    theme === "dark" ? { r: 12, g: 12, b: 12 } : { r: 255, g: 255, b: 255 };
+    resolvedTheme === "dark"
+      ? { r: 12, g: 12, b: 12 }
+      : { r: 255, g: 255, b: 255 };
 
   try {
     // Find the canvas content


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Canvas PDF generation now resolves and applies the effective (including system) theme; header uses resolvedTheme for download/share actions.
> 
> - **PDF Generation (`apps/dashboard/src/utils/canvas-to-pdf.ts`)**
>   - Resolve `theme` to an effective `resolvedTheme` (handles `system` via `matchMedia`).
>   - Use `resolvedTheme` to set PDF background color and RGB in `generateCanvasPdf` and `generateCanvasPdfBlob`.
> - **UI (`apps/dashboard/src/components/canvas/base/canvas-header.tsx`)**
>   - Use `useTheme().resolvedTheme` and pass it to `generateCanvasPdf`/`generateCanvasPdfBlob` for download/share.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9943bbb2bd9d8d7673ba845af11fb6001435db10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->