### PR TITLE
Metrics settings

### DIFF
--- a/apps/dashboard/src/components/metrics/cards/category-expenses-card.tsx
+++ b/apps/dashboard/src/components/metrics/cards/category-expenses-card.tsx
@@ -121,8 +121,8 @@ export function CategoryExpensesCard({
             locale={locale}
           />
         ) : (
-          <div className="flex items-center justify-center h-full text-muted-foreground">
-            No expense data available
+          <div className="flex items-center justify-center h-full text-xs text-muted-foreground -mt-10">
+            No expense data available.
           </div>
         )}
       </div>

--- a/apps/dashboard/src/components/metrics/cards/expenses-card.tsx
+++ b/apps/dashboard/src/components/metrics/cards/expenses-card.tsx
@@ -65,8 +65,8 @@ export function ExpensesCard({
         {expenseData?.result && expenseData.result.length > 0 ? (
           <StackedBarChart data={expenseData} height={320} />
         ) : (
-          <div className="flex items-center justify-center h-full text-muted-foreground">
-            No expense data available
+          <div className="flex items-center justify-center h-full text-xs text-muted-foreground -mt-10">
+            No expense data available.
           </div>
         )}
       </div>

--- a/apps/dashboard/src/components/metrics/cards/runway-card.tsx
+++ b/apps/dashboard/src/components/metrics/cards/runway-card.tsx
@@ -191,11 +191,8 @@ export function RunwayCard({
       </div>
       <div className="h-80">
         {hasNoData ? (
-          <div className="w-full h-full flex items-center justify-center">
-            <div className="text-xs text-muted-foreground text-center px-4">
-              Unable to calculate runway. Connect bank accounts and ensure cash
-              balance data is available.
-            </div>
+          <div className="flex items-center justify-center h-full text-xs text-muted-foreground -mt-10">
+            No balance data available.
           </div>
         ) : (
           <RunwayChart

--- a/apps/dashboard/src/components/metrics/components/metrics-header.tsx
+++ b/apps/dashboard/src/components/metrics/components/metrics-header.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import { useTRPC } from "@/trpc/client";
 import { Button } from "@midday/ui/button";
 import { Icons } from "@midday/ui/icons";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@midday/ui/tooltip";
-import { useQuery } from "@tanstack/react-query";
-import Link from "next/link";
 import { MetricsDatePicker } from "./metrics-date-picker";
+import { MetricsSettings } from "./metrics-settings";
 
 interface MetricsHeaderProps {
   from: string;
@@ -20,6 +12,9 @@ interface MetricsHeaderProps {
   isCustomizing: boolean;
   onCustomizeToggle: () => void;
   onDateRangeChange: (from: string, to: string) => void;
+  baseCurrency?: string;
+  selectedCurrency: string | null;
+  onCurrencyChange: (currency: string | null) => void;
 }
 
 export function MetricsHeader({
@@ -29,53 +24,16 @@ export function MetricsHeader({
   isCustomizing,
   onCustomizeToggle,
   onDateRangeChange,
+  baseCurrency,
+  selectedCurrency,
+  onCurrencyChange,
 }: MetricsHeaderProps) {
-  const trpc = useTRPC();
-  const { data: currencies } = useQuery(
-    trpc.bankAccounts.currencies.queryOptions(),
-  );
-
-  const hasMultipleCurrencies =
-    currencies && currencies.length > 1
-      ? new Set(currencies.map((c) => c.currency)).size > 1
-      : false;
-
   return (
     <div className="flex items-center justify-between pt-6">
       <div>
         <h1 className="text-2xl font-normal mb-1 font-serif">Metrics</h1>
       </div>
       <div className="flex items-center gap-2">
-        {/* Multi-Currency Alert */}
-        {hasMultipleCurrencies && (
-          <TooltipProvider delayDuration={100}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="outline" size="icon">
-                  <Icons.Info size={16} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent
-                className="w-[280px] text-xs"
-                side="bottom"
-                sideOffset={10}
-              >
-                <p className="mb-2">
-                  Since you have accounts in different currencies, we're showing
-                  everything converted to your base currency so you can see the
-                  full picture.
-                </p>
-                <Link
-                  href="/settings"
-                  className="text-primary hover:underline font-medium underline"
-                >
-                  Change base currency
-                </Link>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-
         {/* Customize Button */}
         <Button
           variant="outline"
@@ -97,6 +55,13 @@ export function MetricsHeader({
           to={to}
           fiscalYearStartMonth={fiscalYearStartMonth}
           onDateRangeChange={onDateRangeChange}
+        />
+
+        {/* Settings Menu */}
+        <MetricsSettings
+          baseCurrency={baseCurrency}
+          selectedCurrency={selectedCurrency}
+          onCurrencyChange={onCurrencyChange}
         />
       </div>
     </div>

--- a/apps/dashboard/src/components/metrics/components/metrics-settings.tsx
+++ b/apps/dashboard/src/components/metrics/components/metrics-settings.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useTRPC } from "@/trpc/client";
+import { Button } from "@midday/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@midday/ui/dropdown-menu";
+import { Icons } from "@midday/ui/icons";
+import { useQuery } from "@tanstack/react-query";
+
+interface MetricsSettingsProps {
+  baseCurrency?: string;
+  selectedCurrency: string | null;
+  onCurrencyChange: (currency: string | null) => void;
+}
+
+export function MetricsSettings({
+  baseCurrency,
+  selectedCurrency,
+  onCurrencyChange,
+}: MetricsSettingsProps) {
+  const trpc = useTRPC();
+  const { data: currencies } = useQuery(
+    trpc.bankAccounts.currencies.queryOptions(),
+  );
+
+  // Get unique currencies from bank accounts
+  const uniqueCurrencies = currencies
+    ? [...new Set(currencies.map((c) => c.currency))].sort()
+    : [];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Icons.Settings className="w-4 h-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56" align="end" sideOffset={10}>
+        <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+          Currency
+        </DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={selectedCurrency ?? "base"}
+          onValueChange={(value) => {
+            onCurrencyChange(value === "base" ? null : value);
+          }}
+        >
+          <DropdownMenuRadioItem value="base">
+            Base currency{baseCurrency ? ` (${baseCurrency})` : ""}
+          </DropdownMenuRadioItem>
+          {uniqueCurrencies.map((currency) => (
+            <DropdownMenuRadioItem key={currency} value={currency}>
+              {currency}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/dashboard/src/components/metrics/metrics-view.tsx
+++ b/apps/dashboard/src/components/metrics/metrics-view.tsx
@@ -27,9 +27,14 @@ export function MetricsView() {
     "metrics-chart-order",
     DEFAULT_CHART_ORDER,
   );
+  const [selectedCurrency, setSelectedCurrency] = useLocalStorage<
+    string | null
+  >("metrics-display-currency", null);
   const gridRef = useRef<HTMLDivElement>(null!);
 
-  const currency = team?.baseCurrency ?? undefined;
+  const baseCurrency = team?.baseCurrency ?? undefined;
+  // Use selected currency if set, otherwise fall back to base currency
+  const currency = selectedCurrency ?? baseCurrency;
   const locale = user?.locale ?? undefined;
 
   // Ensure all charts are in the order (handle new charts being added)
@@ -121,6 +126,9 @@ export function MetricsView() {
         isCustomizing={isCustomizing}
         onCustomizeToggle={() => setIsCustomizing(!isCustomizing)}
         onDateRangeChange={handleDateRangeChange}
+        baseCurrency={baseCurrency}
+        selectedCurrency={selectedCurrency}
+        onCurrencyChange={setSelectedCurrency}
       />
 
       <MetricsGrid

--- a/apps/dashboard/src/hooks/use-metrics-params.ts
+++ b/apps/dashboard/src/hooks/use-metrics-params.ts
@@ -1,6 +1,9 @@
-import { formatISO, subMonths, subYears } from "date-fns";
+import { formatISO, subYears } from "date-fns";
 import { useQueryStates } from "nuqs";
 import { parseAsString } from "nuqs/server";
+import { useEffect, useRef } from "react";
+
+const STORAGE_KEY = "metrics-date-range";
 
 const getDefaultDateRange = () => {
   const now = new Date();
@@ -11,32 +14,64 @@ const getDefaultDateRange = () => {
   };
 };
 
+const getStoredDateRange = (): { from: string; to: string } | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : null;
+  } catch {
+    return null;
+  }
+};
+
+const saveDateRange = (from: string, to: string) => {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ from, to }));
+  } catch {
+    // Ignore errors
+  }
+};
+
 export const metricsParamsSchema = {
   from: parseAsString.withDefault(getDefaultDateRange().from),
   to: parseAsString.withDefault(getDefaultDateRange().to),
 };
 
 export function useMetricsParams() {
+  const defaults = getDefaultDateRange();
   const [params, setParams] = useQueryStates(metricsParamsSchema, {
     clearOnDefault: true,
   });
 
-  // Map kebab-case URL params to camelCase for easier usage
+  const initialized = useRef(false);
+
+  // Restore from localStorage on mount if URL is at defaults
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
+    const stored = getStoredDateRange();
+    const isAtDefaults =
+      params.from === defaults.from && params.to === defaults.to;
+
+    if (stored && isAtDefaults) {
+      setParams({ from: stored.from, to: stored.to });
+    }
+  }, [params.from, params.to, defaults.from, defaults.to, setParams]);
+
+  // Save to localStorage when params change
+  useEffect(() => {
+    if (!initialized.current) return;
+    saveDateRange(params.from, params.to);
+  }, [params.from, params.to]);
+
   return {
     from: params.from,
     to: params.to,
-    setParams: (updates: {
-      from?: string;
-      to?: string;
-    }) => {
-      const mappedUpdates: Record<string, string | null> = {};
-      if (updates.from !== undefined) {
-        mappedUpdates.from = updates.from;
-      }
-      if (updates.to !== undefined) {
-        mappedUpdates.to = updates.to;
-      }
-      setParams(mappedUpdates);
+    setParams: (updates: { from?: string; to?: string }) => {
+      initialized.current = true;
+      setParams(updates);
     },
   };
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a settings menu to select display currency (base or specific) and persists the metrics date range in localStorage; standardizes empty-state messages.
> 
> - **Metrics settings**
>   - Introduces `MetricsSettings` with a currency dropdown (base or unique account currencies) powered by `trpc.bankAccounts.currencies`.
>   - Integrates settings into `MetricsHeader`; removes prior multi-currency tooltip and related queries.
>   - `MetricsView` stores `selectedCurrency` in localStorage and uses it (fallback to base) across all charts.
> - **Date range persistence**
>   - `use-metrics-params` now restores/saves date range to `localStorage` and simplifies `setParams` handling.
> - **UI tweaks**
>   - Standardizes empty-state placeholders in `category-expenses`, `expenses`, and `runway` cards (smaller text, slight offset, punctuation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 064778dce0fd9641cdc61332bf1612834deaf483. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->