### PR TITLE
fix amount range

### DIFF
--- a/apps/api/src/ai/tools/get-transactions.ts
+++ b/apps/api/src/ai/tools/get-transactions.ts
@@ -133,7 +133,7 @@ export const getTransactionsTool = tool({
         assignees: assignees ?? null,
         type: type ?? null,
         recurring: recurring ?? null,
-        amount_range:
+        amountRange:
           amountRange?.filter((val): val is number => val !== null) ?? null,
         amount: amount ?? null,
         currency: currency ?? null,

--- a/apps/dashboard/src/app/[locale]/(app)/(sidebar)/transactions/page.tsx
+++ b/apps/dashboard/src/app/[locale]/(app)/(sidebar)/transactions/page.tsx
@@ -31,6 +31,7 @@ export default async function Transactions(props: Props) {
   await queryClient.fetchInfiniteQuery(
     trpc.transactions.get.infiniteQueryOptions({
       ...filter,
+      amountRange: filter.amount_range ?? null,
       sort,
     }),
   );

--- a/apps/dashboard/src/components/tables/transactions/data-table.tsx
+++ b/apps/dashboard/src/components/tables/transactions/data-table.tsx
@@ -64,6 +64,7 @@ export function DataTable({
   const infiniteQueryOptions = trpc.transactions.get.infiniteQueryOptions(
     {
       ...filter,
+      amountRange: filter.amount_range ?? null,
       q: deferredSearch,
       sort: params.sort,
       // When filters are active, load all results for analysis/export

--- a/packages/db/src/queries/transactions.ts
+++ b/packages/db/src/queries/transactions.ts
@@ -58,7 +58,7 @@ export type GetTransactionsParams = {
   start?: string | null;
   end?: string | null;
   recurring?: string[] | null;
-  amount_range?: number[] | null;
+  amountRange?: number[] | null;
   amount?: string[] | null;
   manual?: "include" | "exclude" | null;
 };
@@ -89,7 +89,7 @@ export async function getTransactions(
     assignees: filterAssignees,
     recurring: filterRecurring,
     amount: filterAmount,
-    amount_range: filterAmountRange,
+    amountRange: filterAmountRange,
     manual: filterManual,
   } = params;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames `amount_range` to `amountRange` and wires it through API tool, DB query params, and dashboard queries.
> 
> - **Filters**
>   - Rename `amount_range` → `amountRange` and propagate usage.
> - **Backend**
>   - Update `apps/api/src/ai/tools/get-transactions.ts` to send `amountRange` (filtered for non-null values).
>   - Update `packages/db/src/queries/transactions.ts`:
>     - `GetTransactionsParams` now uses `amountRange`.
>     - `getTransactions` destructuring/usage updated to `amountRange` for range filtering.
> - **Frontend**
>   - Update TRPC query options to pass `amountRange` from `filter.amount_range` in:
>     - `apps/dashboard/src/app/[locale]/(app)/(sidebar)/transactions/page.tsx`.
>     - `apps/dashboard/src/components/tables/transactions/data-table.tsx`.}】`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c571fb50cfd717f5cbf13df327f7ac2f15a65ad6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->