### PR TITLE
Clear match on delete

### DIFF
--- a/apps/dashboard/src/components/tables/transactions/data-table.tsx
+++ b/apps/dashboard/src/components/tables/transactions/data-table.tsx
@@ -110,6 +110,15 @@ export function DataTable({
     trpc.transactions.deleteMany.mutationOptions({
       onSuccess: () => {
         refetch();
+
+        // Invalidate inbox queries since matched inbox items are cleared
+        queryClient.invalidateQueries({
+          queryKey: trpc.inbox.get.infiniteQueryKey(),
+        });
+
+        queryClient.invalidateQueries({
+          queryKey: trpc.inbox.getById.queryKey(),
+        });
       },
     }),
   );

--- a/apps/dashboard/src/components/transactions-actions.tsx
+++ b/apps/dashboard/src/components/transactions-actions.tsx
@@ -33,6 +33,15 @@ export function TransactionsActions() {
           queryKey: trpc.transactions.get.infiniteQueryKey(),
         });
 
+        // Invalidate inbox queries since matched inbox items are cleared
+        queryClient.invalidateQueries({
+          queryKey: trpc.inbox.get.infiniteQueryKey(),
+        });
+
+        queryClient.invalidateQueries({
+          queryKey: trpc.inbox.getById.queryKey(),
+        });
+
         setRowSelection({});
       },
     }),

--- a/packages/db/src/queries/transactions.ts
+++ b/packages/db/src/queries/transactions.ts
@@ -761,6 +761,21 @@ export async function deleteTransactions(
   db: Database,
   params: DeleteTransactionsParams,
 ) {
+  // Clear inbox items that reference these transactions before deleting
+  await db
+    .update(inbox)
+    .set({
+      transactionId: null,
+      attachmentId: null,
+      status: "pending",
+    })
+    .where(
+      and(
+        eq(inbox.teamId, params.teamId),
+        inArray(inbox.transactionId, params.ids),
+      ),
+    );
+
   return db
     .delete(transactions)
     .where(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Deleting transactions now clears matched inbox references and invalidates inbox queries to reflect changes immediately.
> 
> - **Backend**:
>   - Update `deleteTransactions` in `packages/db/src/queries/transactions.ts` to clear related `inbox` references (`transactionId`, `attachmentId`) and reset `status` to `pending` before deleting transactions.
> - **Frontend**:
>   - Invalidate inbox queries after transaction deletions to keep UI in sync:
>     - `apps/dashboard/src/components/tables/transactions/data-table.tsx`: invalidate `trpc.inbox.get.infiniteQueryKey()` and `trpc.inbox.getById.queryKey()` on delete success.
>     - `apps/dashboard/src/components/transactions-actions.tsx`: also invalidate `trpc.inbox.get.infiniteQueryKey()` and `trpc.inbox.getById.queryKey()` on bulk delete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77c1a930ba30a8a7e4ee7cd1be560ea85b4647ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->