### PR TITLE
Small fixes

### DIFF
--- a/packages/invoice/src/templates/pdf/components/summary.tsx
+++ b/packages/invoice/src/templates/pdf/components/summary.tsx
@@ -83,7 +83,7 @@ export function Summary({
         </Text>
       </View>
 
-      {includeDiscount && discount && (
+      {includeDiscount && discount != null && discount !== 0 && (
         <View style={{ flexDirection: "row", marginBottom: 5, width: "100%" }}>
           <Text style={{ fontSize: 9, flex: 1 }}>{discountLabel}</Text>
           <Text style={{ fontSize: 9, textAlign: "right" }}>
@@ -101,7 +101,7 @@ export function Summary({
       {includeVat && (
         <View style={{ flexDirection: "row", marginBottom: 5, width: "100%" }}>
           <Text style={{ fontSize: 9, flex: 1 }}>
-            {vatLabel} ({vatRate}%)
+            {vatLabel} ({String(vatRate ?? 0)}%)
           </Text>
           <Text style={{ fontSize: 9, textAlign: "right" }}>
             {currency &&
@@ -118,7 +118,7 @@ export function Summary({
       {includeTax && (
         <View style={{ flexDirection: "row", marginBottom: 5, width: "100%" }}>
           <Text style={{ fontSize: 9, flex: 1 }}>
-            {taxLabel} ({taxRate}%)
+            {taxLabel} ({String(taxRate ?? 0)}%)
           </Text>
           <Text style={{ fontSize: 9, textAlign: "right" }}>
             {currency &&


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Show discount in PDF summary only when non‑null and non‑zero; display VAT/Tax rates as string with 0% fallback.
> 
> - **Invoice PDF – `templates/pdf/components/summary.tsx`**:
>   - **Discount row logic**: Render `discountLabel`/amount only when `includeDiscount && discount != null && discount !== 0` (was `discount && ...`).
>   - **Rate labels**: Display percent labels using `String(vatRate ?? 0)` and `String(taxRate ?? 0)` to avoid undefined and ensure `0%` when rates are absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad8b5d6b450bea65599766469cfe25879167adce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->