### PR TITLE
Fallback to unpdf

### DIFF
--- a/apps/worker/src/processors/transactions/process-attachment.ts
+++ b/apps/worker/src/processors/transactions/process-attachment.ts
@@ -71,9 +71,11 @@ export class ProcessTransactionAttachmentProcessor extends BaseProcessor<Process
 
     const filename = filePath.at(-1);
 
+    // Use 10 minutes expiration to ensure URL doesn't expire during processing
+    // (document processing can take up to 120s, plus buffer for retries)
     const { data: signedUrlData } = await supabase.storage
       .from("vault")
-      .createSignedUrl(filePath.join("/"), 60);
+      .createSignedUrl(filePath.join("/"), 600);
 
     if (!signedUrlData) {
       throw new Error("File not found");

--- a/apps/worker/src/queues/inbox.config.ts
+++ b/apps/worker/src/queues/inbox.config.ts
@@ -27,14 +27,15 @@ const inboxQueueOptions: QueueOptions = {
  * Worker options for inbox queue
  * Concurrency: 100 (increased from 50 for faster processing)
  * Optimized to reduce duplicate downloads and overhead
- * Lock duration: 300000ms (5 minutes) for long-running process-attachment jobs
- * Stalled interval: 360000ms (6 minutes) to allow jobs to complete before marking as stalled
+ * Lock duration: 660000ms (11 minutes) for long-running process-attachment jobs
+ * Document processing timeout is 10 minutes, plus buffer for other operations
+ * Stalled interval: 720000ms (12 minutes) to allow jobs to complete before marking as stalled
  */
 const inboxWorkerOptions: WorkerOptions = {
   connection: getRedisConnection(),
   concurrency: 100, // Increased from 50 for better throughput
-  lockDuration: 300000, // 5 minutes - process-attachment jobs can take up to 2+ minutes (document processing + HEIC conversion + file ops)
-  stalledInterval: 360000, // 6 minutes - longer than lockDuration to avoid false stalls
+  lockDuration: 660000, // 11 minutes - document processing can take up to 10 minutes (multi-pass extraction + retries), plus buffer
+  stalledInterval: 720000, // 12 minutes - longer than lockDuration to avoid false stalls
   limiter: {
     max: 200, // Increased from 100 for higher throughput
     duration: 1000, // 200 jobs per second max

--- a/apps/worker/src/utils/error-classification.ts
+++ b/apps/worker/src/utils/error-classification.ts
@@ -100,6 +100,23 @@ export function classifyError(error: unknown): ClassifiedError {
       };
     }
 
+    // Expired signed URL errors (retryable - can regenerate URL)
+    // Check for download errors with 400 status on signed URLs
+    if (
+      (message.includes("download") || message.includes("downloaderror")) &&
+      (message.includes("400") || message.includes("bad request")) &&
+      (message.includes("token") ||
+        message.includes("sign") ||
+        message.includes("signed"))
+    ) {
+      return {
+        category: "network",
+        retryable: true,
+        retryDelay: 1000,
+        maxRetries: 3,
+      };
+    }
+
     // Validation errors (non-retryable)
     if (
       message.includes("validation") ||

--- a/apps/worker/src/utils/timeout.ts
+++ b/apps/worker/src/utils/timeout.ts
@@ -52,7 +52,9 @@ export async function withTimeout<T>(
  */
 export const TIMEOUTS = {
   EMBEDDING: 30_000, // 30 seconds for embedding generation
-  DOCUMENT_PROCESSING: 120_000, // 2 minutes for document processing
+  DOCUMENT_PROCESSING: 600_000, // 10 minutes for document processing
+  // Multi-pass extraction can take time: Pass 1 (primary), Pass 2 (fallback),
+  // Pass 3 (field re-extraction), Pass 4 (consistency validation), plus retries
   FILE_DOWNLOAD: 60_000, // 1 minute for file downloads
   FILE_UPLOAD: 60_000, // 1 minute for file uploads
   DATABASE_QUERY: 15_000, // 15 seconds for database queries

--- a/bun.lock
+++ b/bun.lock
@@ -355,6 +355,7 @@
         "langchain": "^1.0.5",
         "mammoth": "^1.11.0",
         "officeparser": "5.2.2",
+        "unpdf": "^1.4.0",
         "zod": "^4.1.13",
       },
       "devDependencies": {
@@ -4689,6 +4690,8 @@
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "unpdf": ["unpdf@1.4.0", "", { "peerDependencies": { "@napi-rs/canvas": "^0.1.69" }, "optionalPeers": ["@napi-rs/canvas"] }, "sha512-TahIk0xdH/4jh/MxfclzU79g40OyxtP00VnEUZdEkJoYtXAHWLiir6t3FC6z3vDqQTzc2ZHcla6uEiVTNjejuA=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -28,6 +28,7 @@
     "langchain": "^1.0.5",
     "mammoth": "^1.11.0",
     "officeparser": "5.2.2",
+    "unpdf": "^1.4.0",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/packages/documents/src/config/extraction-config.ts
+++ b/packages/documents/src/config/extraction-config.ts
@@ -31,7 +31,7 @@ export const invoiceConfig: ExtractionConfig<typeof invoiceSchema> = {
   schema: invoiceSchema,
   primaryModel: "gemini-2.5-flash",
   fallbackModel: "gemini-2.5-pro",
-  timeout: 60000, // 60s for PDF processing
+  timeout: 180000, // 3 minutes
   retries: 2, // 2 retries (3 total attempts)
   contentType: "file",
   mediaType: "application/pdf",

--- a/packages/documents/src/utils/pdf-text-extract.ts
+++ b/packages/documents/src/utils/pdf-text-extract.ts
@@ -1,0 +1,52 @@
+import { extractText, getDocumentProxy } from "unpdf";
+
+const MAX_TEXT_LENGTH = 50_000; // Limit text length for very large PDFs
+
+/**
+ * Extract text from PDF using unpdf
+ * @param pdfUrl - Signed URL or direct URL to PDF
+ * @param pdfBuffer - Optional PDF buffer (if already downloaded)
+ * @returns Extracted text string or null if extraction fails
+ */
+export async function extractTextFromPdf(
+  pdfUrl: string,
+  pdfBuffer?: ArrayBuffer,
+): Promise<string | null> {
+  try {
+    let buffer: ArrayBuffer;
+
+    // Download PDF if buffer not provided
+    if (!pdfBuffer) {
+      const response = await fetch(pdfUrl);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to download PDF: ${response.status} ${response.statusText}`,
+        );
+      }
+      buffer = await response.arrayBuffer();
+    } else {
+      buffer = pdfBuffer;
+    }
+
+    // Load PDF document using unpdf
+    const pdf = await getDocumentProxy(new Uint8Array(buffer));
+
+    // Extract text from all pages using unpdf's extractText function
+    const { text } = await extractText(pdf, { mergePages: true });
+
+    if (!text || !text.trim()) {
+      return null;
+    }
+
+    // Limit text length if PDF is extremely large
+    let extractedText = text.trim();
+    if (extractedText.length > MAX_TEXT_LENGTH) {
+      extractedText = extractedText.substring(0, MAX_TEXT_LENGTH);
+    }
+
+    return extractedText;
+  } catch (error) {
+    // Return null on any error (corrupted PDF, image-based PDF, etc.)
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds unpdf-based text fallback for PDF extraction, increases processing timeouts/queue locks, and extends signed URL TTL to 10 minutes with improved error classification.
> 
> - **Documents extraction**:
>   - **PDF text fallback**: Introduces `extractTextFromPdf` using `unpdf` and uses it in `BaseExtractionEngine` when PDF processing times out, sending extracted text to Gemini.
>   - **Timeout tweaks**: Increases invoice extraction timeout to `180000ms`; raises field re-extraction abort for critical fields to `90000ms`.
>   - **Dependency**: Adds `unpdf` to `@midday/documents`.
> - **Worker processing**:
>   - **Signed URL TTL**: Extends Supabase `createSignedUrl` expiry from `60` to `600` seconds in `inbox/process-attachment.ts` and `transactions/process-attachment.ts` with logging.
>   - **Global timeouts**: Sets `TIMEOUTS.DOCUMENT_PROCESSING` to `600000ms`.
>   - **Queue config**: In `inbox.config.ts`, increases `lockDuration` to `660000ms` and `stalledInterval` to `720000ms`.
> - **Error handling**:
>   - Classifies expired signed URL download errors (400 Bad Request with signed token) as retryable `network` errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81bce94046283f66d6b4c9e67a72529a9e55503b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->