### PR TITLE
Exclude category default

### DIFF
--- a/packages/categories/src/categories.ts
+++ b/packages/categories/src/categories.ts
@@ -180,6 +180,7 @@ const RAW_CATEGORIES = [
     children: [
       { slug: "uncategorized", name: "Uncategorized" },
       { slug: "other", name: "Other" },
+      { slug: "internal-transfer", name: "Internal Transfer", excluded: true },
     ],
   },
 ] as const;
@@ -198,7 +199,7 @@ function applyColorsToCategories(
       parentSlug: parent.slug, // Automatically add parentSlug
       color: getCategoryColor(child.slug),
       system: true,
-      excluded: false, // Default to not excluded
+      excluded: "excluded" in child ? child.excluded : false, // Respect excluded flag if set
     })),
   }));
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an `internal-transfer` child category under `system` marked as excluded, and updates category processing to propagate a child's `excluded` flag instead of always defaulting to `false`.
> 
> - New `system/internal-transfer` category with `excluded: true`
> - `applyColorsToCategories` now preserves `child.excluded` when present (defaults to `false` otherwise)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b05a06ba3cd07ebd61e23b0babac67f9d9d7ed3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->