### PR TITLE
Invoice Attachments

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -55,6 +55,7 @@
     "date-fns": "^4.1.0",
     "hono": "4.11.4",
     "hono-rate-limiter": "0.4.2",
+    "jszip": "^3.10.1",
     "jose": "^6.1.3",
     "nanoid": "^5.1.6",
     "parse-duration": "^2.1.4",

--- a/apps/api/src/schemas/files.ts
+++ b/apps/api/src/schemas/files.ts
@@ -136,4 +136,19 @@ export const downloadInvoiceSchema = z.object({
         name: "type",
       },
     }),
+  includeAttachments: z
+    .preprocess(
+      (val) => val === "true" || val === true,
+      z.boolean().default(false),
+    )
+    .optional()
+    .openapi({
+      description:
+        "If true and the invoice has attachments, returns a ZIP containing the invoice PDF and all attachments. If false or no attachments exist, returns only the invoice PDF.",
+      example: false,
+      param: {
+        in: "query",
+        name: "includeAttachments",
+      },
+    }),
 });

--- a/apps/api/src/schemas/invoice-attachments.ts
+++ b/apps/api/src/schemas/invoice-attachments.ts
@@ -1,0 +1,22 @@
+import { z } from "@hono/zod-openapi";
+
+export const createInvoiceAttachmentsSchema = z.array(
+  z.object({
+    path: z.array(z.string()),
+    name: z.string(),
+    size: z.number(),
+    invoiceId: z.string().uuid(),
+  }),
+);
+
+export const deleteInvoiceAttachmentSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const getInvoiceAttachmentsSchema = z.object({
+  invoiceId: z.string().uuid(),
+});
+
+export const getInvoiceAttachmentsByTokenSchema = z.object({
+  token: z.string(),
+});

--- a/apps/api/src/trpc/routers/_app.ts
+++ b/apps/api/src/trpc/routers/_app.ts
@@ -16,6 +16,7 @@ import { inboxRouter } from "./inbox";
 import { inboxAccountsRouter } from "./inbox-accounts";
 import { institutionsRouter } from "./institutions";
 import { invoiceRouter } from "./invoice";
+import { invoiceAttachmentsRouter } from "./invoice-attachments";
 import { invoicePaymentsRouter } from "./invoice-payments";
 import { invoiceProductsRouter } from "./invoice-products";
 import { invoiceRecurringRouter } from "./invoice-recurring";
@@ -56,6 +57,7 @@ export const appRouter = createTRPCRouter({
   inboxAccounts: inboxAccountsRouter,
   institutions: institutionsRouter,
   invoice: invoiceRouter,
+  invoiceAttachments: invoiceAttachmentsRouter,
   invoicePayments: invoicePaymentsRouter,
   invoiceProducts: invoiceProductsRouter,
   invoiceRecurring: invoiceRecurringRouter,

--- a/apps/api/src/trpc/routers/invoice-attachments.ts
+++ b/apps/api/src/trpc/routers/invoice-attachments.ts
@@ -1,0 +1,111 @@
+import {
+  createInvoiceAttachmentsSchema,
+  deleteInvoiceAttachmentSchema,
+  getInvoiceAttachmentsSchema,
+  getInvoiceAttachmentsByTokenSchema,
+} from "@api/schemas/invoice-attachments";
+import {
+  createTRPCRouter,
+  protectedProcedure,
+  publicProcedure,
+} from "@api/trpc/init";
+import {
+  createInvoiceAttachments,
+  deleteInvoiceAttachment,
+  getInvoiceAttachments,
+  getInvoiceAttachmentsByInvoiceId,
+  getInvoiceById,
+} from "@midday/db/queries";
+import { verify } from "@midday/invoice/token";
+import { remove } from "@midday/supabase/storage";
+import { TRPCError } from "@trpc/server";
+
+export const invoiceAttachmentsRouter = createTRPCRouter({
+  createMany: protectedProcedure
+    .input(createInvoiceAttachmentsSchema)
+    .mutation(async ({ input, ctx: { db, supabase, teamId } }) => {
+      // Validate that all attachments are PDFs
+      for (const attachment of input) {
+        if (!attachment.name.toLowerCase().endsWith(".pdf")) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Only PDF files are allowed as invoice attachments",
+          });
+        }
+      }
+
+      return createInvoiceAttachments(db, {
+        teamId: teamId!,
+        attachments: input,
+      });
+    }),
+
+  delete: protectedProcedure
+    .input(deleteInvoiceAttachmentSchema)
+    .mutation(async ({ input, ctx: { db, supabase, teamId } }) => {
+      const result = await deleteInvoiceAttachment(db, {
+        id: input.id,
+        teamId: teamId!,
+      });
+
+      // Delete the file from storage
+      if (result?.path && result.path.length > 0) {
+        try {
+          await remove(supabase, {
+            bucket: "vault",
+            path: result.path,
+          });
+        } catch (error) {
+          // Log error but don't fail the deletion if file doesn't exist in storage
+          console.error(
+            `Failed to delete file from storage for ${result.id}:`,
+            error,
+          );
+        }
+      }
+
+      return result;
+    }),
+
+  getByInvoiceId: protectedProcedure
+    .input(getInvoiceAttachmentsSchema)
+    .query(async ({ input, ctx: { db, teamId } }) => {
+      return getInvoiceAttachments(db, {
+        invoiceId: input.invoiceId,
+        teamId: teamId!,
+      });
+    }),
+
+  // Public endpoint for accessing attachments via invoice token
+  getByToken: publicProcedure
+    .input(getInvoiceAttachmentsByTokenSchema)
+    .query(async ({ input, ctx: { db } }) => {
+      // Verify the token and extract the invoice ID
+      const { id: invoiceId } = (await verify(
+        decodeURIComponent(input.token),
+      )) as {
+        id: string;
+      };
+
+      if (!invoiceId) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Invoice not found",
+        });
+      }
+
+      // Get the invoice to verify it exists
+      const invoice = await getInvoiceById(db, { id: invoiceId });
+
+      if (!invoice) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Invoice not found",
+        });
+      }
+
+      return getInvoiceAttachmentsByInvoiceId(db, {
+        invoiceId,
+      });
+    }),
+});

--- a/apps/dashboard/src/components/invoice-details.tsx
+++ b/apps/dashboard/src/components/invoice-details.tsx
@@ -43,6 +43,14 @@ export function InvoiceDetails() {
     enabled: isOpen,
   });
 
+  // Fetch attachments for the invoice
+  const { data: attachments = [] } = useQuery({
+    ...trpc.invoiceAttachments.getByInvoiceId.queryOptions({
+      invoiceId: invoiceId!,
+    }),
+    enabled: isOpen,
+  });
+
   // Fetch upcoming invoices for recurring series
   const { data: upcomingInvoices } = useQuery({
     ...trpc.invoiceRecurring.getUpcoming.queryOptions({
@@ -444,6 +452,48 @@ export function InvoiceDetails() {
                   </div>
                 </Button>
               )}
+            </div>
+          </div>
+        )}
+
+        {attachments.length > 0 && (
+          <div className="mt-6 border-t border-border pt-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Icons.Attachments className="size-4 text-muted-foreground" />
+              <span className="text-sm font-medium">
+                Attachments ({attachments.length})
+              </span>
+            </div>
+            <div className="space-y-2">
+              {attachments.map((attachment) => (
+                <div
+                  key={attachment.id}
+                  className="flex items-center justify-between bg-muted/50 rounded-md px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <Icons.PdfOutline className="size-4 shrink-0 text-red-500" />
+                    <span className="text-sm truncate">{attachment.name}</span>
+                  </div>
+                  {user?.fileKey && attachment.path && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0"
+                      onClick={() => {
+                        const path = attachment.path?.join("/");
+                        if (path) {
+                          downloadFile(
+                            `${process.env.NEXT_PUBLIC_API_URL}/files/download/file?path=${encodeURIComponent(path)}&fk=${user.fileKey}`,
+                            attachment.name,
+                          );
+                        }
+                      }}
+                    >
+                      <Icons.ArrowCoolDown className="size-3.5" />
+                    </Button>
+                  )}
+                </div>
+              ))}
             </div>
           </div>
         )}

--- a/apps/dashboard/src/components/invoice/attachments-menu.tsx
+++ b/apps/dashboard/src/components/invoice/attachments-menu.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useInvoiceParams } from "@/hooks/use-invoice-params";
+import { useUpload } from "@/hooks/use-upload";
+import { useUserQuery } from "@/hooks/use-user";
+import { useTRPC } from "@/trpc/client";
+import { Button } from "@midday/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@midday/ui/dropdown-menu";
+import { Icons } from "@midday/ui/icons";
+import { Spinner } from "@midday/ui/spinner";
+import { useToast } from "@midday/ui/use-toast";
+import { cn } from "@midday/ui/cn";
+import { stripSpecialCharacters } from "@midday/utils";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef } from "react";
+
+const MAX_ATTACHMENTS = 5;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+export function AttachmentsMenu() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { invoiceId } = useInvoiceParams();
+  const { data: user } = useUserQuery();
+  const { uploadFile, isLoading: isUploading } = useUpload();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Fetch existing attachments
+  const { data: attachments = [], isLoading: isLoadingAttachments } = useQuery({
+    ...trpc.invoiceAttachments.getByInvoiceId.queryOptions({
+      invoiceId: invoiceId!,
+    }),
+    enabled: !!invoiceId,
+  });
+
+  const createAttachmentsMutation = useMutation(
+    trpc.invoiceAttachments.createMany.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: trpc.invoiceAttachments.getByInvoiceId.queryKey({
+            invoiceId: invoiceId!,
+          }),
+        });
+        toast({
+          title: "Attachment uploaded",
+          description: "The file has been attached to the invoice.",
+        });
+      },
+      onError: (error) => {
+        toast({
+          title: "Upload failed",
+          description: error.message || "Failed to attach file to invoice.",
+          variant: "error",
+        });
+      },
+    }),
+  );
+
+  const deleteAttachmentMutation = useMutation(
+    trpc.invoiceAttachments.delete.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: trpc.invoiceAttachments.getByInvoiceId.queryKey({
+            invoiceId: invoiceId!,
+          }),
+        });
+        toast({
+          title: "Attachment removed",
+          description: "The file has been removed from the invoice.",
+        });
+      },
+      onError: () => {
+        toast({
+          title: "Failed to remove attachment",
+          variant: "error",
+        });
+      },
+    }),
+  );
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    // Validate we haven't exceeded the limit
+    const remainingSlots = MAX_ATTACHMENTS - attachments.length;
+    if (remainingSlots <= 0) {
+      toast({
+        title: "Maximum attachments reached",
+        description: `You can only attach up to ${MAX_ATTACHMENTS} files per invoice.`,
+        variant: "error",
+      });
+      return;
+    }
+
+    // Filter and validate files
+    const validFiles: File[] = [];
+    for (const file of Array.from(files)) {
+      // Check file type
+      if (file.type !== "application/pdf") {
+        toast({
+          title: "Invalid file type",
+          description: `"${file.name}" is not a PDF. Only PDF files are allowed.`,
+          variant: "error",
+        });
+        continue;
+      }
+
+      // Check file size
+      if (file.size > MAX_FILE_SIZE) {
+        toast({
+          title: "File too large",
+          description: `"${file.name}" exceeds the 10MB limit.`,
+          variant: "error",
+        });
+        continue;
+      }
+
+      validFiles.push(file);
+    }
+
+    if (validFiles.length === 0) return;
+
+    // Only take files up to the remaining slots
+    const filesToUpload = validFiles.slice(0, remainingSlots);
+
+    try {
+      // Upload files to storage
+      const uploadedFiles = await Promise.all(
+        filesToUpload.map(async (file) => {
+          const filename = stripSpecialCharacters(file.name);
+          const path = [
+            user?.teamId ?? "",
+            "invoice-attachments",
+            invoiceId!,
+            `${Date.now()}-${filename}`,
+          ];
+
+          await uploadFile({
+            bucket: "vault",
+            path,
+            file,
+          });
+
+          return {
+            name: filename,
+            path,
+            size: file.size,
+            invoiceId: invoiceId!,
+          };
+        }),
+      );
+
+      // Create database records
+      createAttachmentsMutation.mutate(uploadedFiles);
+    } catch (error) {
+      toast({
+        title: "Upload failed",
+        description: "Failed to upload file. Please try again.",
+        variant: "error",
+      });
+    }
+
+    // Reset file input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleDelete = (attachmentId: string) => {
+    deleteAttachmentMutation.mutate({ id: attachmentId });
+  };
+
+  const formatFileSize = (bytes: number | null) => {
+    if (!bytes) return "";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  // Don't render if there's no invoice ID (new invoice that hasn't been saved yet)
+  if (!invoiceId) {
+    return (
+      <button
+        type="button"
+        className="h-9 w-9 flex items-center justify-center border border-border text-muted-foreground cursor-not-allowed opacity-50"
+        disabled
+        title="Save invoice first to add attachments"
+      >
+        <Icons.Attachments className="size-4" />
+      </button>
+    );
+  }
+
+  const isPending =
+    isUploading ||
+    createAttachmentsMutation.isPending ||
+    deleteAttachmentMutation.isPending;
+
+  const canAddMore = attachments.length < MAX_ATTACHMENTS;
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/pdf"
+        multiple
+        className="hidden"
+        onChange={handleFileSelect}
+        disabled={isPending || !canAddMore}
+      />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "h-9 w-9 flex items-center justify-center border border-border hover:bg-accent transition-colors relative",
+              isPending && "opacity-50",
+            )}
+            disabled={isPending}
+          >
+            {isPending ? (
+              <Spinner size={16} />
+            ) : (
+              <>
+                <Icons.Attachments className="size-4" />
+                {attachments.length > 0 && (
+                  <span className="absolute -top-1 -right-1 h-4 w-4 rounded-full bg-primary text-[10px] text-primary-foreground flex items-center justify-center">
+                    {attachments.length}
+                  </span>
+                )}
+              </>
+            )}
+          </button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align="start" className="w-64">
+          {isLoadingAttachments ? (
+            <div className="flex items-center justify-center py-4">
+              <Spinner size={16} />
+            </div>
+          ) : (
+            <>
+              {attachments.length > 0 && (
+                <>
+                  {attachments.map((attachment) => (
+                    <DropdownMenuItem
+                      key={attachment.id}
+                      className="flex items-center justify-between group cursor-default"
+                      onSelect={(e) => e.preventDefault()}
+                    >
+                      <div className="flex items-center gap-2 min-w-0 flex-1">
+                        <Icons.PdfOutline className="size-4 shrink-0 text-red-500" />
+                        <span className="text-xs truncate">{attachment.name}</span>
+                        {attachment.size && (
+                          <span className="text-[10px] text-muted-foreground shrink-0">
+                            {formatFileSize(attachment.size)}
+                          </span>
+                        )}
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 opacity-0 group-hover:opacity-100 shrink-0"
+                        onClick={() => handleDelete(attachment.id)}
+                        disabled={deleteAttachmentMutation.isPending}
+                      >
+                        <Icons.Delete className="size-3 text-destructive" />
+                      </Button>
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuSeparator />
+                </>
+              )}
+
+              <DropdownMenuItem
+                onClick={() => fileInputRef.current?.click()}
+                disabled={!canAddMore || isPending}
+                className="text-xs cursor-pointer"
+              >
+                <Icons.Add className="mr-2 size-4" />
+                {canAddMore
+                  ? `Add PDF (${attachments.length}/${MAX_ATTACHMENTS})`
+                  : `Maximum ${MAX_ATTACHMENTS} attachments`}
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  );
+}

--- a/apps/dashboard/src/components/invoice/form.tsx
+++ b/apps/dashboard/src/components/invoice/form.tsx
@@ -22,6 +22,7 @@ import { Logo } from "./logo";
 import { Meta } from "./meta";
 import { NoteDetails } from "./note-details";
 import { PaymentDetails } from "./payment-details";
+import { AttachmentsMenu } from "./attachments-menu";
 import { SettingsMenu } from "./settings-menu";
 import { SubmitButton } from "./submit-button";
 import { Summary } from "./summary";
@@ -386,6 +387,7 @@ export function Form() {
           <div className="flex justify-between items-center">
             <div className="flex gap-2">
               <SettingsMenu />
+              <AttachmentsMenu />
               <TemplateSelector />
             </div>
 

--- a/packages/db/migrations/0021_add_invoice_attachments.sql
+++ b/packages/db/migrations/0021_add_invoice_attachments.sql
@@ -1,0 +1,44 @@
+-- Migration: Add invoice attachments support
+-- Creates invoice_attachments table for storing PDF attachments on invoices
+-- Max 5 attachments per invoice, PDF only
+
+CREATE TABLE IF NOT EXISTS invoice_attachments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  invoice_id UUID NOT NULL,
+  team_id UUID NOT NULL,
+  name TEXT NOT NULL,
+  path TEXT[] NOT NULL,
+  size BIGINT,
+  CONSTRAINT invoice_attachments_invoice_id_fkey 
+    FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE,
+  CONSTRAINT invoice_attachments_team_id_fkey 
+    FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE
+);
+
+-- Indexes for efficient lookups
+CREATE INDEX IF NOT EXISTS invoice_attachments_invoice_id_idx 
+  ON invoice_attachments(invoice_id);
+CREATE INDEX IF NOT EXISTS invoice_attachments_team_id_idx 
+  ON invoice_attachments(team_id);
+
+-- RLS Policies
+ALTER TABLE invoice_attachments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Invoice attachments can be created by a member of the team"
+  ON invoice_attachments
+  FOR INSERT
+  TO public
+  WITH CHECK (team_id IN (SELECT private.get_teams_for_authenticated_user()));
+
+CREATE POLICY "Invoice attachments can be deleted by a member of the team"
+  ON invoice_attachments
+  FOR DELETE
+  TO public
+  USING (team_id IN (SELECT private.get_teams_for_authenticated_user()));
+
+CREATE POLICY "Invoice attachments can be selected by a member of the team"
+  ON invoice_attachments
+  FOR SELECT
+  TO public
+  USING (team_id IN (SELECT private.get_teams_for_authenticated_user()));

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -17,6 +17,7 @@ export * from "./inbox-accounts";
 export * from "./inbox-blocklist";
 export * from "./inbox-embeddings";
 export * from "./inbox-matching";
+export * from "./invoice-attachments";
 export * from "./invoice-products";
 export * from "./invoice-recurring";
 export * from "./invoice-templates";

--- a/packages/db/src/queries/invoice-attachments.ts
+++ b/packages/db/src/queries/invoice-attachments.ts
@@ -1,0 +1,190 @@
+import type { Database } from "@db/client";
+import { invoiceAttachments, invoices } from "@db/schema";
+import { and, count, eq } from "drizzle-orm";
+
+export type InvoiceAttachment = {
+  name: string;
+  size: number;
+  path: string[];
+  invoiceId: string;
+};
+
+type CreateInvoiceAttachmentsParams = {
+  attachments: InvoiceAttachment[];
+  teamId: string;
+};
+
+export async function createInvoiceAttachments(
+  db: Database,
+  params: CreateInvoiceAttachmentsParams,
+) {
+  const { attachments, teamId } = params;
+
+  // Check current attachment count for the invoice
+  if (attachments.length > 0) {
+    const invoiceId = attachments[0]!.invoiceId;
+    const [currentCount] = await db
+      .select({ count: count() })
+      .from(invoiceAttachments)
+      .where(
+        and(
+          eq(invoiceAttachments.invoiceId, invoiceId),
+          eq(invoiceAttachments.teamId, teamId),
+        ),
+      );
+
+    const existingCount = currentCount?.count ?? 0;
+    const totalAfterUpload = existingCount + attachments.length;
+
+    if (totalAfterUpload > 5) {
+      throw new Error(
+        `Cannot add ${attachments.length} attachment(s). Invoice already has ${existingCount} attachment(s). Maximum is 5.`,
+      );
+    }
+  }
+
+  const result = await db
+    .insert(invoiceAttachments)
+    .values(
+      attachments.map((attachment) => ({
+        ...attachment,
+        teamId,
+      })),
+    )
+    .returning();
+
+  return result;
+}
+
+type DeleteInvoiceAttachmentParams = {
+  id: string;
+  teamId: string;
+};
+
+export async function deleteInvoiceAttachment(
+  db: Database,
+  params: DeleteInvoiceAttachmentParams,
+) {
+  const { id, teamId } = params;
+
+  // Get the attachment first to return its path for storage deletion
+  const [result] = await db
+    .select({
+      id: invoiceAttachments.id,
+      invoiceId: invoiceAttachments.invoiceId,
+      name: invoiceAttachments.name,
+      path: invoiceAttachments.path,
+      teamId: invoiceAttachments.teamId,
+    })
+    .from(invoiceAttachments)
+    .where(
+      and(
+        eq(invoiceAttachments.id, id),
+        eq(invoiceAttachments.teamId, teamId),
+      ),
+    );
+
+  if (!result) {
+    throw new Error("Attachment not found");
+  }
+
+  // Delete the attachment
+  await db
+    .delete(invoiceAttachments)
+    .where(
+      and(
+        eq(invoiceAttachments.id, id),
+        eq(invoiceAttachments.teamId, teamId),
+      ),
+    );
+
+  return result;
+}
+
+type GetInvoiceAttachmentsParams = {
+  invoiceId: string;
+  teamId?: string;
+};
+
+export async function getInvoiceAttachments(
+  db: Database,
+  params: GetInvoiceAttachmentsParams,
+) {
+  const { invoiceId, teamId } = params;
+
+  const conditions = [eq(invoiceAttachments.invoiceId, invoiceId)];
+
+  if (teamId) {
+    conditions.push(eq(invoiceAttachments.teamId, teamId));
+  }
+
+  const result = await db
+    .select({
+      id: invoiceAttachments.id,
+      createdAt: invoiceAttachments.createdAt,
+      invoiceId: invoiceAttachments.invoiceId,
+      name: invoiceAttachments.name,
+      path: invoiceAttachments.path,
+      size: invoiceAttachments.size,
+      teamId: invoiceAttachments.teamId,
+    })
+    .from(invoiceAttachments)
+    .where(and(...conditions));
+
+  return result;
+}
+
+type GetInvoiceAttachmentCountParams = {
+  invoiceId: string;
+  teamId: string;
+};
+
+export async function getInvoiceAttachmentCount(
+  db: Database,
+  params: GetInvoiceAttachmentCountParams,
+) {
+  const { invoiceId, teamId } = params;
+
+  const [result] = await db
+    .select({ count: count() })
+    .from(invoiceAttachments)
+    .where(
+      and(
+        eq(invoiceAttachments.invoiceId, invoiceId),
+        eq(invoiceAttachments.teamId, teamId),
+      ),
+    );
+
+  return result?.count ?? 0;
+}
+
+type GetInvoiceAttachmentsByTokenParams = {
+  invoiceId: string;
+};
+
+/**
+ * Get invoice attachments by invoice ID (used for public access via token)
+ * No team ID required as access is validated via invoice token
+ */
+export async function getInvoiceAttachmentsByInvoiceId(
+  db: Database,
+  params: GetInvoiceAttachmentsByTokenParams,
+) {
+  const { invoiceId } = params;
+
+  const result = await db
+    .select({
+      id: invoiceAttachments.id,
+      createdAt: invoiceAttachments.createdAt,
+      invoiceId: invoiceAttachments.invoiceId,
+      name: invoiceAttachments.name,
+      path: invoiceAttachments.path,
+      size: invoiceAttachments.size,
+      teamId: invoiceAttachments.teamId,
+    })
+    .from(invoiceAttachments)
+    .innerJoin(invoices, eq(invoiceAttachments.invoiceId, invoices.id))
+    .where(eq(invoiceAttachments.invoiceId, invoiceId));
+
+  return result;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds first-class support for invoice PDF attachments across backend, API, and UI.
> 
> - **Data layer:** New `invoice_attachments` table (RLS, indexes) and queries (`createInvoiceAttachments`, `deleteInvoiceAttachment`, `getInvoiceAttachments*`).
> - **API/TRPC:**
>   - `GET /files/download/invoice` now accepts `includeAttachments`; returns PDF or ZIP with `attachments/*` plus invoice; supports token or `id`+`fk` access. Uses `jszip`.
>   - New `invoiceAttachments` TRPC router for creating/deleting/listing (team-protected) and public `getByToken`.
>   - Extended `downloadInvoiceSchema` and added `schemas/invoice-attachments.ts`.
> - **Dashboard UI:**
>   - New `AttachmentsMenu` to upload/delete PDFs (max 5, 10MB each) per invoice and show counts.
>   - `invoice-details` shows attachments with per-file download.
>   - Customer portal and toolbar downloads request `includeAttachments`; single/multi-downloads handle ZIPs; paid invoices bundle invoice + receipt (+ attachments) into ZIP.
> - **Email jobs:** Invoice emails attach the generated PDF and any invoice attachments (up to ~35MB total), with longer task timeout.
> - **Misc:** Added `jszip` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e836fe74db19ea91ed11b3af566c2bb3163871c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->