### PR TITLE
Correct Spelling Error in Engine health endpoint

### DIFF
--- a/apps/engine/src/routes/health/index.ts
+++ b/apps/engine/src/routes/health/index.ts
@@ -63,7 +63,7 @@ const app = new OpenAPIHono<{ Bindings: Bindings }>().openapi(
 
     return c.json(
       {
-        message: "Service unhelthy",
+        message: "Service unhealthy",
         code: "bad_request",
       },
       400,


### PR DESCRIPTION
Was admiring your code as usual, and found a small spelling error.