### PR TITLE
Fixes

### DIFF
--- a/apps/dashboard/src/app/[locale]/(public)/login/page.tsx
+++ b/apps/dashboard/src/app/[locale]/(public)/login/page.tsx
@@ -135,7 +135,7 @@ export default async function Page() {
             className="flex items-center gap-2 hover:opacity-80 active:opacity-80 transition-opacity duration-200 pointer-events-auto"
           >
             <div className="w-6 h-6">
-              <Icons.LogoSmall className="w-full h-full text-foreground" />
+              <Icons.LogoSmall className="w-full h-full text-foreground lg:text-white" />
             </div>
           </Link>
         </div>

--- a/apps/dashboard/src/components/invoice/form.tsx
+++ b/apps/dashboard/src/components/invoice/form.tsx
@@ -346,9 +346,13 @@ export function Form() {
         hideScrollbar
       >
         <div className="p-8 pb-4 h-full flex flex-col bg-[#fcfcfc] dark:bg-[#0f0f0f]">
-          <div className="flex justify-between">
-            <Meta />
-            <Logo />
+          <div className="flex justify-between items-start">
+            <div className="flex-1 min-w-0 mr-5">
+              <Meta />
+            </div>
+            <div className="flex-shrink-0">
+              <Logo />
+            </div>
           </div>
 
           <div className="grid grid-cols-2 gap-6 mt-8 mb-4">

--- a/apps/dashboard/src/components/invoice/invoice-title.tsx
+++ b/apps/dashboard/src/components/invoice/invoice-title.tsx
@@ -1,21 +1,77 @@
 "use client";
 
-import { useFormContext } from "react-hook-form";
+import { cn } from "@midday/ui/cn";
+import { useEffect, useRef, useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
 import { useTemplateUpdate } from "@/hooks/use-template-update";
-import { Input } from "./input";
 
 export function InvoiceTitle() {
-  const { watch } = useFormContext();
-  const invoiceTitle = watch("template.title");
+  const { control, watch } = useFormContext();
+  const invoiceTitle = watch("template.title") ?? "";
   const { updateTemplate } = useTemplateUpdate();
+  const [isFocused, setIsFocused] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const isPlaceholder = invoiceTitle.trim().length === 0 && !isFocused;
+  const SINGLE_LINE_HEIGHT = 24;
+  const TWO_LINES_HEIGHT = 48;
+  const GROW_THRESHOLD = 36;
+
+  const resize = () => {
+    const el = textareaRef.current;
+    if (!el) return;
+
+    el.style.height = `${SINGLE_LINE_HEIGHT}px`;
+    // Some browsers report one-line textarea scrollHeight > 24px because of font metrics.
+    // Only grow when we're clearly beyond one line.
+    const needsSecondLine = el.scrollHeight > GROW_THRESHOLD;
+    el.style.height = needsSecondLine
+      ? `${TWO_LINES_HEIGHT}px`
+      : `${SINGLE_LINE_HEIGHT}px`;
+  };
+
+  useEffect(() => {
+    resize();
+  }, [invoiceTitle]);
 
   return (
-    <Input
-      className="text-[21px] font-serif mb-2 w-fit min-w-[100px] !border-none"
-      name="template.title"
-      onBlur={() => {
-        updateTemplate({ title: invoiceTitle });
-      }}
-    />
+    <div className="relative w-full min-w-0">
+      <Controller
+        name="template.title"
+        control={control}
+        render={({ field }) => (
+          <textarea
+            ref={(el) => {
+              textareaRef.current = el;
+              field.ref(el);
+            }}
+            value={field.value ?? ""}
+            lang="en"
+            rows={1}
+            className={cn(
+              "block w-full min-w-0 text-[21px] leading-6 font-serif mb-2 h-6 max-h-12 bg-transparent p-0 border-0 outline-none resize-none overflow-hidden",
+              isPlaceholder && "opacity-0",
+            )}
+            style={{
+              wordBreak: "normal",
+              overflowWrap: "break-word",
+              hyphens: "auto",
+            }}
+            onInput={resize}
+            onChange={(e) => field.onChange(e.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={(e) => {
+              field.onBlur();
+              setIsFocused(false);
+              updateTemplate({ title: e.currentTarget.value });
+            }}
+          />
+        )}
+      />
+      {isPlaceholder && (
+        <div className="absolute left-0 top-0 h-6 w-[250px] pointer-events-none">
+          <div className="h-full w-full bg-[repeating-linear-gradient(-60deg,#DBDBDB,#DBDBDB_1px,transparent_1px,transparent_5px)] dark:bg-[repeating-linear-gradient(-60deg,#2C2C2C,#2C2C2C_1px,transparent_1px,transparent_5px)]" />
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/dashboard/src/components/invoice/meta.tsx
+++ b/apps/dashboard/src/components/invoice/meta.tsx
@@ -5,7 +5,7 @@ import { IssueDate } from "./issue-date";
 
 export function Meta() {
   return (
-    <div>
+    <div className="w-full min-w-0 overflow-hidden">
       <InvoiceTitle />
 
       <div className="flex flex-col gap-0.5">

--- a/packages/invoice/src/templates/html/components/meta.tsx
+++ b/packages/invoice/src/templates/html/components/meta.tsx
@@ -16,7 +16,19 @@ export function Meta({ template, invoiceNumber, issueDate, dueDate }: Props) {
 
   return (
     <div className="mb-2">
-      <h2 className="text-[21px] font-serif mb-1 w-fit min-w-[100px]">
+      <h2
+        lang="en"
+        className="text-[21px] font-serif mb-1 min-w-[100px] w-full max-w-full"
+        style={{
+          overflow: "hidden",
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          wordBreak: "normal",
+          overflowWrap: "break-word",
+          hyphens: "auto",
+        }}
+      >
         {template.title}
       </h2>
       <div className="flex flex-col gap-0.5">

--- a/packages/invoice/src/templates/html/index.tsx
+++ b/packages/invoice/src/templates/html/index.tsx
@@ -50,16 +50,20 @@ export function HtmlTemplate({ data, width, height }: Props) {
         className="p-4 sm:p-6 md:p-8 h-full flex flex-col"
         style={{ minHeight: height - 5 }}
       >
-        <div className="flex justify-between">
-          <Meta
-            template={template}
-            invoiceNumber={invoiceNumber}
-            issueDate={issueDate}
-            dueDate={dueDate}
-          />
+        <div className="flex justify-between items-start">
+          <div className="flex-1 min-w-0 mr-5">
+            <Meta
+              template={template}
+              invoiceNumber={invoiceNumber}
+              issueDate={issueDate}
+              dueDate={dueDate}
+            />
+          </div>
 
           {template.logoUrl && (
-            <Logo logo={template.logoUrl} customerName={customerName || ""} />
+            <div className="flex-shrink-0">
+              <Logo logo={template.logoUrl} customerName={customerName || ""} />
+            </div>
           )}
         </div>
 

--- a/packages/invoice/src/templates/pdf/components/meta.tsx
+++ b/packages/invoice/src/templates/pdf/components/meta.tsx
@@ -27,7 +27,9 @@ export function Meta({
 }: MetaProps) {
   return (
     <View>
-      <Text style={{ fontSize: 21, fontWeight: 500, marginBottom: 8 }}>
+      <Text
+        style={{ fontSize: 21, fontWeight: 500, marginBottom: 8, maxLines: 2 }}
+      >
         {title}
       </Text>
       <View style={{ flexDirection: "column", gap: 4 }}>

--- a/packages/invoice/src/templates/pdf/index.tsx
+++ b/packages/invoice/src/templates/pdf/index.tsx
@@ -112,22 +112,25 @@ export async function PdfTemplate(
             marginBottom: 20,
             flexDirection: "row",
             justifyContent: "space-between",
+            alignItems: "flex-start",
           }}
         >
-          <Meta
-            invoiceNoLabel={template.invoiceNoLabel}
-            issueDateLabel={template.issueDateLabel}
-            dueDateLabel={template.dueDateLabel}
-            invoiceNo={invoiceNumber}
-            issueDate={issueDate}
-            dueDate={dueDate}
-            timezone={template.timezone}
-            dateFormat={template.dateFormat}
-            title={title}
-          />
+          <View style={{ flex: 1, minWidth: 0, marginRight: 20 }}>
+            <Meta
+              invoiceNoLabel={template.invoiceNoLabel}
+              issueDateLabel={template.issueDateLabel}
+              dueDateLabel={template.dueDateLabel}
+              invoiceNo={invoiceNumber}
+              issueDate={issueDate}
+              dueDate={dueDate}
+              timezone={template.timezone}
+              dateFormat={template.dateFormat}
+              title={title}
+            />
+          </View>
 
           {template?.logoUrl && (
-            <div style={{ maxWidth: "300px" }}>
+            <View style={{ maxWidth: 300, flexShrink: 0 }}>
               <Image
                 src={template.logoUrl}
                 style={{
@@ -135,7 +138,7 @@ export async function PdfTemplate(
                   objectFit: "contain",
                 }}
               />
-            </div>
+            </View>
           )}
         </View>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily styling and input/rendering changes for invoice headers; low risk but could affect layout in edge cases (very long titles, logo sizes) across HTML/PDF outputs.
> 
> **Overview**
> **Invoice header layout and title handling** are updated to better support long titles. The dashboard invoice form now constrains `Meta` and `Logo` with flex sizing to prevent overflow, and `InvoiceTitle` replaces the single-line `Input` with an auto-resizing textarea that supports up to two lines and shows a placeholder hatch when empty.
> 
> Invoice rendering is aligned across formats: the HTML template clamps the title to two lines with proper wrapping/hyphenation, and the PDF template caps the title to two lines while also adjusting the header row to align items at the top and prevent the logo from shrinking. Separately, the login page logo now switches to white text on large screens (`lg:text-white`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ed21c57215a42df7c5dacde323ebdc692a0d23f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->