### PR TITLE
Fixes

### DIFF
--- a/apps/api/.env-template
+++ b/apps/api/.env-template
@@ -43,13 +43,7 @@ NODE_ENV=development
 # RAILWAY_ENVIRONMENT=production
 # RAILWAY_REPLICA_REGION=europe-west4-drams3a
 
-# Redis Cache (Railway Redis - per-region)
-# In production, each region has its own cache Redis. The app auto-selects
-# the local region's Redis using RAILWAY_REPLICA_REGION. Set these in Railway:
-#   REDIS_CACHE_US_WEST=${{cache-us-west.REDIS_URL}}
-#   REDIS_CACHE_US_EAST=${{cache-us-east.REDIS_URL}}
-#   REDIS_CACHE_EU_WEST=${{cache-eu-west.REDIS_URL}}
-# Falls back to REDIS_URL for local development.
+# Redis (Upstash — shared across all regions)
 REDIS_URL=redis://localhost:6379
 
 # Google

--- a/apps/dashboard/.env-example
+++ b/apps/dashboard/.env-example
@@ -11,13 +11,7 @@ RESEND_API_KEY=
 RESEND_AUDIENCE_ID=
 
 
-# Redis Cache (Railway Redis - per-region)
-# In production, each region has its own cache Redis. The app auto-selects
-# the local region's Redis using RAILWAY_REPLICA_REGION. Set these in Railway:
-#   REDIS_CACHE_US_WEST=${{cache-us-west.REDIS_URL}}
-#   REDIS_CACHE_US_EAST=${{cache-us-east.REDIS_URL}}
-#   REDIS_CACHE_EU_WEST=${{cache-eu-west.REDIS_URL}}
-# Falls back to REDIS_URL for local development.
+# Redis (Upstash — shared across all regions)
 REDIS_URL=redis://localhost:6379
 
 # Teller (Base 64 encoded certificate)

--- a/apps/dashboard/cache-handler.mjs
+++ b/apps/dashboard/cache-handler.mjs
@@ -4,43 +4,11 @@ const KEY_PREFIX = "next-cache:";
 const TAG_PREFIX = "next-tag:";
 
 /**
- * Map Railway region identifiers to per-region cache Redis env vars.
- * Set via Railway variable references, e.g.:
- *   REDIS_CACHE_US_WEST=${{cache-us-west.REDIS_URL}}
- *   REDIS_CACHE_US_EAST=${{cache-us-east.REDIS_URL}}
- *   REDIS_CACHE_EU_WEST=${{cache-eu-west.REDIS_URL}}
- */
-const REGION_REDIS_MAP = {
-  "us-west2": "REDIS_CACHE_US_WEST",
-  "us-east4-eqdc4a": "REDIS_CACHE_US_EAST",
-  "europe-west4-drams3a": "REDIS_CACHE_EU_WEST",
-};
-
-/**
- * Resolve the Redis URL for the current replica's region.
+ * Resolve the Redis URL.
  *
- * Resolution order:
- *  1. RAILWAY_REPLICA_REGION → mapped REDIS_CACHE_* env var (co-located cache)
- *  2. Any available REDIS_CACHE_* env var (fallback: at least a working cache)
- *  3. REDIS_URL (generic fallback)
- *  4. localhost for local development
+ * All regions share a single Upstash Redis instance via REDIS_URL.
  */
 function resolveRedisUrl() {
-  const region = process.env.RAILWAY_REPLICA_REGION;
-
-  if (region) {
-    const envVar = REGION_REDIS_MAP[region];
-    const regionUrl = envVar ? process.env[envVar] : undefined;
-
-    if (regionUrl) return regionUrl;
-  }
-
-  // Fall back to any available regional cache
-  for (const envVarName of Object.values(REGION_REDIS_MAP)) {
-    const url = process.env[envVarName];
-    if (url) return url;
-  }
-
   return process.env.REDIS_URL ?? "redis://localhost:6379";
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory contains technical documentation for the Midday.
 - **[inbox-matching.md](./inbox-matching.md)** - Detailed documentation of the AI-powered inbox matching algorithm that automatically matches receipts and invoices with bank transactions.
 - **[invoice-recurring.md](./invoice-recurring.md)** - Technical documentation of the recurring invoice system including architecture, state machine, generation flow, and key design decisions.
 - **[document-processing.md](./document-processing.md)** - Technical documentation of the document processing pipeline including AI classification, graceful degradation, retry functionality, and error handling.
+- **[database-connection-pooling.md](./database-connection-pooling.md)** - Database connection pooling setup with Supabase Supavisor (transaction mode), multi-region read replica mapping across Railway, pool configuration, and prepared statement constraints.
 
 ## About
 

--- a/docs/database-connection-pooling.md
+++ b/docs/database-connection-pooling.md
@@ -1,0 +1,83 @@
+# Database Connection Pooling
+
+Technical documentation for the database connection setup across Supabase and Railway.
+
+## Overview
+
+The application connects to Supabase Postgres through **Supavisor** (Supabase's shared connection pooler) in **transaction mode**. Each Railway region's API instance reads from the closest Supabase read replica and writes to the primary database in EU.
+
+## Connection Modes
+
+Supabase offers two pooling modes via `pooler.supabase.com`:
+
+| Mode | Port | Behavior |
+|------|------|----------|
+| **Session mode** | `5432` | 1:1 client-to-backend mapping. No real pooling — each app connection holds a dedicated Postgres connection for its entire lifetime. |
+| **Transaction mode** | `6543` | Real connection pooling. Backend connections are shared between clients and only held during a transaction, then returned to the pool. |
+
+**We use transaction mode (port 6543).** This is critical — session mode on port 5432 provides zero pooling benefit despite routing through `pooler.supabase.com`.
+
+### Connection String Format
+
+```
+postgresql://postgres.<project-ref>:<password>@aws-0-<region>.pooler.supabase.com:6543/postgres
+```
+
+## Dedicated Pooler (PgBouncer)
+
+Supabase also offers a dedicated PgBouncer co-located on the database machine at `db.<ref>.supabase.co:6543`. This has lower latency (no network hop to a separate server) but requires IPv6 connectivity or the Supabase IPv4 add-on ($4/mo per database).
+
+Railway does **not** support IPv6 to Supabase's direct endpoints, so the shared Supavisor pooler is the correct choice for our infrastructure.
+
+## Multi-Region Replica Mapping
+
+The API runs in 3 Railway regions. Each instance reads from the closest Supabase read replica via the `RAILWAY_REPLICA_REGION` environment variable:
+
+| Railway Region | Env Var | Supabase Region | Role |
+|----------------|---------|-----------------|------|
+| `europe-west4-drams3a` | `DATABASE_FRA_URL` | `eu-central-1` | Primary (reads + writes) |
+| `us-east4-eqdc4a` | `DATABASE_IAD_URL` | `us-east-1` | Read replica |
+| `us-west2` | `DATABASE_SJC_URL` | `us-west-1` | Read replica |
+
+- **Reads** are routed to the regional replica via `executeOnReplica` and the `withReplicas` wrapper in `packages/db/src/replicas.ts`.
+- **Writes** always go to `DATABASE_PRIMARY_URL` (the primary in `eu-central-1`).
+
+## Pool Configuration
+
+Defined in `packages/db/src/client.ts`:
+
+| Setting | Development | Production |
+|---------|-------------|------------|
+| `max` | 8 | 12 |
+| `idleTimeoutMillis` | 5,000ms | 60,000ms |
+| `connectionTimeoutMillis` | 5,000ms | 5,000ms |
+| `maxUses` | 100 | 0 (unlimited) |
+| `ssl` | disabled | enabled (rejectUnauthorized: false) |
+
+Each API instance creates up to 2 pools (primary + 1 regional replica), so the maximum backend connections per instance is `12 × 2 = 24`. With Supavisor transaction mode, these are multiplexed into a much smaller number of actual Postgres backend connections.
+
+## Prepared Statements
+
+Transaction mode does **not** support named prepared statements. The `node-postgres` (`pg`) package with Drizzle ORM uses unnamed parameterized queries (extended query protocol without a `name` field), which are compatible with transaction mode. No special configuration is needed.
+
+**Do not** add named queries like `pool.query({ name: 'my-query', text: '...' })` — these will fail through the pooler.
+
+## Environment Variables
+
+### API Service
+- `DATABASE_PRIMARY_URL` — Primary database (EU, writes + reads)
+- `DATABASE_FRA_URL` — EU read replica (same as primary)
+- `DATABASE_IAD_URL` — US East read replica
+- `DATABASE_SJC_URL` — US West read replica
+
+### Worker Service
+- `DATABASE_PRIMARY_POOLER_URL` — Primary database (EU)
+
+### Dashboard Service
+- No database variables — connects to the API via tRPC, not directly to Postgres.
+
+## Railway Deploy Configuration
+
+- **API**: 3 regions × 1 replica each (production), 3 regions × 1 replica each (staging)
+- **Dashboard**: 3 regions × 2 replicas each (production), 3 regions × 1 replica each (staging, with serverless/sleep enabled)
+- **Worker**: 1 region (EU) × 3 replicas (production)

--- a/packages/cache/src/shared-redis.ts
+++ b/packages/cache/src/shared-redis.ts
@@ -13,61 +13,11 @@ try {
 }
 
 /**
- * Map Railway region identifiers to per-region cache Redis env vars.
- * In Railway, each region has its own Redis cache service. The env vars
- * are set via Railway variable references, e.g.:
- *   REDIS_CACHE_US_WEST=${{cache-us-west.REDIS_URL}}
- *   REDIS_CACHE_US_EAST=${{cache-us-east.REDIS_URL}}
- *   REDIS_CACHE_EU_WEST=${{cache-eu-west.REDIS_URL}}
+ * Resolve the Redis URL.
  *
- * RAILWAY_REPLICA_REGION is a system-provided variable injected at runtime
- * by Railway for every deployment (see https://docs.railway.com/variables/reference).
- */
-const REGION_REDIS_MAP: Record<string, string> = {
-  "us-west2": "REDIS_CACHE_US_WEST",
-  "us-east4-eqdc4a": "REDIS_CACHE_US_EAST",
-  "europe-west4-drams3a": "REDIS_CACHE_EU_WEST",
-};
-
-/**
- * Resolve the Redis URL for the current replica's region.
- *
- * Resolution order:
- *  1. RAILWAY_REPLICA_REGION → mapped REDIS_CACHE_* env var (best: co-located cache)
- *  2. Any available REDIS_CACHE_* env var (fallback: at least a working cache)
- *  3. REDIS_URL (generic fallback for local dev / non-Railway environments)
+ * All regions share a single Upstash Redis instance via REDIS_URL.
  */
 function resolveRedisUrl(): string | undefined {
-  // 1. Prefer the region-local cache (lowest latency)
-  const region = process.env.RAILWAY_REPLICA_REGION;
-
-  if (region) {
-    const envVar = REGION_REDIS_MAP[region];
-    const regionUrl = envVar ? process.env[envVar] : undefined;
-
-    if (regionUrl) {
-      return regionUrl;
-    }
-
-    logger.warn(
-      `RAILWAY_REPLICA_REGION="${region}" but no matching REDIS_CACHE_* env var found (expected ${envVar ?? "unknown"})`,
-    );
-  }
-
-  // 2. Fall back to any available regional cache (better than no cache)
-  for (const envVarName of Object.values(REGION_REDIS_MAP)) {
-    const url = process.env[envVarName];
-    if (url) {
-      if (region === undefined) {
-        logger.warn(
-          `RAILWAY_REPLICA_REGION not set, falling back to ${envVarName}`,
-        );
-      }
-      return url;
-    }
-  }
-
-  // 3. Generic fallback for local dev / non-Railway environments
   return process.env.REDIS_URL;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Redis cache connection resolution across services; misconfigured `REDIS_URL` could disable caching or increase latency across regions. Otherwise the logic simplification is straightforward and mostly config/documentation driven.
> 
> **Overview**
> **Switches Redis caching from per-region Railway instances to a single shared Upstash Redis.** The region-based `REDIS_CACHE_*`/`RAILWAY_REPLICA_REGION` resolution logic is removed from both the dashboard Next.js cache handler and the shared cache client, and `.env` templates are updated to only reference `REDIS_URL`.
> 
> **Adds infrastructure documentation.** Introduces `docs/database-connection-pooling.md` and links it from `docs/README.md`, documenting Supabase Supavisor transaction-mode pooling and the multi-region read-replica env var mapping used by the API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c88e5ecba2e6a2113fed4b9522cf183b97cb078e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->