### PR TITLE
Replica

### DIFF
--- a/apps/dashboard/src/components/forms/create-team-form.tsx
+++ b/apps/dashboard/src/components/forms/create-team-form.tsx
@@ -52,82 +52,17 @@ export function CreateTeamForm({
 
   const createTeamMutation = useMutation(
     trpc.team.create.mutationOptions({
-      onSuccess: async (teamId) => {
-        const successId = `team_creation_success_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-
-        console.log(`[${successId}] Team creation mutation successful`, {
-          teamId,
-          timestamp: new Date().toISOString(),
-          url: window.location.href,
-        });
-
-        // Lock the form permanently - never reset on success
+      onSuccess: async () => {
+        // Lock the form permanently - user will be redirected
         setIsLoading(true);
         isSubmittedRef.current = true;
 
-        try {
-          // Invalidate all queries to ensure fresh data everywhere
-          console.log(`[${successId}] Invalidating queries`);
-          await queryClient.invalidateQueries();
-
-          // Revalidate server-side paths and redirect
-          console.log(`[${successId}] Revalidating server-side paths`);
-          await revalidateAfterTeamChange();
-
-          console.log(
-            `[${successId}] Team creation flow completed successfully`,
-          );
-        } catch (error) {
-          // Check if this is a Next.js redirect (expected behavior)
-          if (error instanceof Error && error.message === "NEXT_REDIRECT") {
-            console.log(
-              `[${successId}] Team creation completed successfully - redirecting to home`,
-            );
-            // This is expected - Next.js redirects work by throwing this error
-            return;
-          }
-
-          // Only log actual errors, not expected redirects
-          console.error(`[${successId}] Team creation flow failed:`, {
-            error: error instanceof Error ? error.message : String(error),
-            stack: error instanceof Error ? error.stack : undefined,
-            teamId,
-          });
-        }
-        // Note: We NEVER reset loading state on success - user should be redirected
+        await queryClient.invalidateQueries();
+        await revalidateAfterTeamChange();
       },
-      onError: (error) => {
-        const errorId = `team_creation_error_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-
-        const errorContext = {
-          error: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-          timestamp: new Date().toISOString(),
-          url: window.location.href,
-          userAgent: navigator.userAgent,
-        };
-
-        console.error(
-          `[${errorId}] Team creation mutation failed`,
-          errorContext,
-        );
-
-        // Capture error in Sentry for debugging
-        if (error instanceof Error && process.env.NODE_ENV === "production") {
-          import("@sentry/nextjs").then((Sentry) => {
-            Sentry.captureException(error, {
-              extra: {
-                ...errorContext,
-                errorId,
-                component: "CreateTeamForm",
-                action: "team_creation_mutation",
-              },
-            });
-          });
-        }
-
+      onError: () => {
         setIsLoading(false);
-        isSubmittedRef.current = false; // Reset on error to allow retry
+        isSubmittedRef.current = false;
       },
     }),
   );
@@ -156,35 +91,18 @@ export function CreateTeamForm({
 
   function onSubmit(values: FormValues) {
     if (isFormLocked) {
-      console.warn("Team creation form submission blocked - form is locked", {
-        isFormLocked,
-        isLoading,
-        isSubmittedRef: isSubmittedRef.current,
-        formValues: values,
-      });
       return;
     }
 
-    const submissionId = `form_submission_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-
-    console.log(`[${submissionId}] Team creation form submission started`, {
-      teamName: values.name,
-      baseCurrency: values.baseCurrency,
-      countryCode: values.countryCode,
-      timestamp: new Date().toISOString(),
-      userAgent: navigator.userAgent,
-      url: window.location.href,
-    });
-
     setIsLoading(true);
-    isSubmittedRef.current = true; // Permanent flag that survives re-renders
+    isSubmittedRef.current = true;
 
     createTeamMutation.mutate({
       name: values.name,
       baseCurrency: values.baseCurrency,
       countryCode: values.countryCode,
       fiscalYearStartMonth: values.fiscalYearStartMonth,
-      switchTeam: true, // Automatically switch to the new team
+      switchTeam: true,
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication callback flows and database read routing (primary vs replicas), which can affect login reliability and performance if misapplied; overall changes are small and targeted.
> 
> **Overview**
> Reduces read-after-write consistency issues by extending the `Cookies.ForcePrimary` window to 30s and setting it for OTP sign-ins, then explicitly forcing primary reads for the initial `user.me` query in the OAuth callback via `getTRPCClient({ forcePrimary: true })`.
> 
> Simplifies team creation flow by removing verbose logging/try-catch in the API `team.create` router and trimming client-side console/Sentry instrumentation in `CreateTeamForm`, while keeping the same mutation behavior (invalidate + revalidate after success).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8f8d90fe13ea7dcd7e624b35926779dba7fb568. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->