### PR TITLE
Change status if due date changes in the future

### DIFF
--- a/packages/db/src/queries/invoices.ts
+++ b/packages/db/src/queries/invoices.ts
@@ -836,6 +836,12 @@ export async function draftInvoice(
         token: useToken,
         templateId,
         ...restInput,
+        // Revert overdue to unpaid when due date is moved to the future
+        status: sql`CASE
+          WHEN ${invoices.status} = 'overdue' AND ${restInput.dueDate}::timestamp >= now()
+          THEN 'unpaid'
+          ELSE ${invoices.status}
+        END`,
         currency: template.currency?.toUpperCase(),
         template: camelcaseKeys(restTemplate, { deep: true }),
         paymentDetails: paymentDetails,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to invoice upsert logic; risk is limited to potential edge cases around timezone/timestamp comparisons when deciding whether a due date is “in the future.”
> 
> **Overview**
> When updating an existing draft invoice via `draftInvoice` (upsert), the DB now **automatically reverts** `status` from `overdue` to `unpaid` if the new `dueDate` is moved to a future date.
> 
> This is implemented as a conditional SQL `CASE` in the `onConflictDoUpdate` `set` clause so the status correction happens atomically with the update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf0647989926b14efcfe1b0bba89c9deafd1f089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->