### PR TITLE
Replicas

### DIFF
--- a/packages/cache/src/shared-redis.ts
+++ b/packages/cache/src/shared-redis.ts
@@ -10,7 +10,7 @@ const REGION_URL_MAP: Record<string, string> = {
 };
 
 function resolveRedisUrl(): string {
-  const region = process.env.RAILWAY_REGION;
+  const region = process.env.RAILWAY_REPLICA_REGION;
   if (region) {
     const envVar = REGION_URL_MAP[region];
     const url = envVar ? process.env[envVar] : undefined;
@@ -89,7 +89,7 @@ function createClient(): RedisClient {
 
 /**
  * Get or create a shared Bun RedisClient singleton.
- * Automatically selects the correct regional Redis URL based on RAILWAY_REGION.
+ * Automatically selects the correct regional Redis URL based on RAILWAY_REPLICA_REGION.
  *
  * Self-healing: if the client has been disconnected for longer than
  * MAX_DISCONNECT_MS (auto-reconnect exhausted), it is destroyed and a


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, isolated config-selection change; main risk is misrouting if the new env var isn’t set in some deploy environments.
> 
> **Overview**
> Updates Redis regional routing to use Railway’s `RAILWAY_REPLICA_REGION` env var (instead of `RAILWAY_REGION`) when selecting a region-specific `REDIS_URL_*`, and updates the inline docs to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f8f3c2c32f3f9ccc2b177b8429345974c685f9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->