### PR TITLE
Feature/resolve team

### DIFF
--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -10,11 +10,7 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import type { Context } from "hono";
 import superjson from "superjson";
 import { withPrimaryReadAfterWrite } from "./middleware/primary-read-after-write";
-import {
-  resolveTeamPermission,
-  type TeamResolution,
-  withTeamPermission,
-} from "./middleware/team-permission";
+import { withTeamPermission } from "./middleware/team-permission";
 
 type TRPCContext = {
   session: Session | null;
@@ -24,7 +20,6 @@ type TRPCContext = {
   teamId?: string;
   forcePrimary?: boolean;
   isInternalRequest?: boolean;
-  resolveTeam: () => Promise<TeamResolution>;
 };
 
 export const createTRPCContext = async (
@@ -49,17 +44,6 @@ export const createTRPCContext = async (
   // Check if client wants to force primary database reads (for replication lag handling)
   const forcePrimary = c.req.header("x-force-primary") === "true";
 
-  // Lazy team resolver — computed once on first access, shared across
-  // all procedures in a batched tRPC request (context is per HTTP request).
-  let teamPromise: Promise<TeamResolution> | null = null;
-  const resolveTeam = () => {
-    if (!teamPromise) {
-      teamPromise = resolveTeamPermission(session, db);
-    }
-
-    return teamPromise;
-  };
-
   return {
     session,
     supabase,
@@ -67,7 +51,6 @@ export const createTRPCContext = async (
     geo,
     forcePrimary,
     isInternalRequest,
-    resolveTeam,
   };
 };
 

--- a/apps/api/src/trpc/routers/user.ts
+++ b/apps/api/src/trpc/routers/user.ts
@@ -61,12 +61,8 @@ export const userRouter = createTRPCRouter({
 
       try {
         await Promise.all([
-          result.previousTeamId
-            ? teamCache.delete(
-                `user:${session.user.id}:team:${result.previousTeamId}`,
-              )
-            : Promise.resolve(),
-          teamCache.delete(`user:${session.user.id}:team:${input.teamId}`),
+          teamCache.invalidateForUser(session.user.id, result.previousTeamId),
+          teamCache.invalidateForUser(session.user.id, input.teamId),
         ]);
       } catch {
         // Non-fatal — cache will expire naturally

--- a/packages/cache/src/team-cache.ts
+++ b/packages/cache/src/team-cache.ts
@@ -1,10 +1,32 @@
 import { RedisCache } from "./redis-client";
+import { teamPermissionsCache } from "./team-permissions-cache";
 
-// Redis-based cache to check if a user has access to a team, shared across all server instances
+// Redis-based cache for team permission data, shared across all server instances
 const cache = new RedisCache("team", 30 * 60); // 30 minutes TTL
 
 export const teamCache = {
-  get: (key: string): Promise<boolean | undefined> => cache.get<boolean>(key),
-  set: (key: string, value: boolean): Promise<void> => cache.set(key, value),
+  get: <T = boolean>(key: string): Promise<T | undefined> => cache.get<T>(key),
+  set: (key: string, value: unknown): Promise<void> => cache.set(key, value),
   delete: (key: string): Promise<void> => cache.delete(key),
+
+  /**
+   * Invalidate all team-related cache entries for a user.
+   * Call this whenever team membership or active team changes.
+   * Clears: resolve cache, per-team access cache, and REST permissions cache.
+   */
+  invalidateForUser: (
+    userId: string,
+    teamId?: string | null,
+  ): Promise<void> => {
+    const deletes: Promise<void>[] = [
+      cache.delete(`resolve:${userId}`),
+      teamPermissionsCache.delete(`user:${userId}:team`),
+    ];
+
+    if (teamId) {
+      deletes.push(cache.delete(`user:${userId}:team:${teamId}`));
+    }
+
+    return Promise.all(deletes).then(() => undefined);
+  },
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authorization-adjacent middleware and caching behavior; incorrect invalidation or stale `resolve:${userId}` entries could lead to transient wrong-team access until TTL/invalidations occur.
> 
> **Overview**
> Team permission resolution is refactored to be cached and deduplicated: `withTeamPermission` now uses a per-request `WeakMap` plus a Redis-backed `resolve:${userId}` entry to avoid repeated DB lookups across batched calls and subsequent requests.
> 
> Team-related cache invalidation is centralized via `teamCache.invalidateForUser()` (also clearing `teamPermissionsCache`), and team/user routers are updated to call it when creating/leaving/deleting teams, removing members, or switching teams; the old context-level `resolveTeam` hook and direct `teamPermissionsCache` deletes are removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aad8630acb7b64f68c5c8aed46801b97443bfe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->