### PR TITLE
wip

### DIFF
--- a/apps/dashboard/src/trpc/server.tsx
+++ b/apps/dashboard/src/trpc/server.tsx
@@ -13,6 +13,7 @@ import { cookies, headers } from "next/headers";
 import { cache } from "react";
 import superjson from "superjson";
 import { Cookies } from "@/utils/constants";
+import { fetchWithRetry } from "@/utils/fetch-with-retry";
 import { makeQueryClient } from "./query-client";
 
 // IMPORTANT: Create a stable getter for the query client that
@@ -31,6 +32,7 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
       httpBatchLink({
         url: `${API_BASE_URL}/trpc`,
         transformer: superjson,
+        fetch: fetchWithRetry,
         async headers() {
           const [supabase, cookieStore, headersList] = await Promise.all([
             createClient(),
@@ -138,6 +140,7 @@ export async function getTRPCClient(options?: { forcePrimary?: boolean }) {
       httpBatchLink({
         url: `${API_BASE_URL}/trpc`,
         transformer: superjson,
+        fetch: fetchWithRetry,
         headers: {
           Authorization: `Bearer ${session?.access_token}`,
           "x-user-timezone": location.timezone,

--- a/apps/dashboard/src/utils/fetch-with-retry.ts
+++ b/apps/dashboard/src/utils/fetch-with-retry.ts
@@ -1,0 +1,30 @@
+const RETRYABLE_ERRORS = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "UND_ERR_SOCKET",
+]);
+const MAX_RETRIES = 2;
+
+/**
+ * Fetch wrapper that retries on transient connection errors (e.g. ECONNRESET
+ * after the API service redeploys while the dashboard keeps stale keep-alive
+ * connections to the old instances via Railway internal networking).
+ */
+export async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await fetch(input, init);
+    } catch (err: any) {
+      lastError = err;
+      const code = err?.cause?.code ?? err?.code ?? "";
+      if (!RETRYABLE_ERRORS.has(code) || attempt === MAX_RETRIES) throw err;
+      await new Promise((r) => setTimeout(r, 50 * (attempt + 1)));
+    }
+  }
+  throw lastError;
+}

--- a/packages/banking/src/providers/plaid/plaid-api.ts
+++ b/packages/banking/src/providers/plaid/plaid-api.ts
@@ -58,7 +58,7 @@ export class PlaidApi {
 
   #generateWebhookUrl(environment: "sandbox" | "production") {
     if (environment === "sandbox") {
-      return "https://staging.api.midday.ai/webhook/plaid";
+      return "https://api-staging.midday.ai/webhook/plaid";
     }
 
     return "https://api.midday.ai/webhook/plaid";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized changes: a bounded retry wrapper around `fetch` for tRPC calls and a single webhook URL tweak; main risk is unintended extra requests on retryable network errors.
> 
> **Overview**
> Dashboard server-side tRPC requests now use a new `fetchWithRetry` wrapper for `httpBatchLink` to automatically retry a few transient connection errors (e.g., stale keep-alive sockets during API redeploys).
> 
> Updates Plaid’s sandbox webhook URL from `staging.api.midday.ai` to `api-staging.midday.ai`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c94dbb2a3d2357af6b30ef90b66e8e16cdc3f3c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->