### PR TITLE
Fix table columns

### DIFF
--- a/apps/dashboard/src/components/tables/customers/data-table.tsx
+++ b/apps/dashboard/src/components/tables/customers/data-table.tsx
@@ -27,13 +27,15 @@ import { useUserQuery } from "@/hooks/use-user";
 import { useCustomersStore } from "@/store/customers";
 import { useTRPC } from "@/trpc/client";
 import { STICKY_COLUMNS, SUMMARY_GRID_HEIGHTS } from "@/utils/table-configs";
-import type { TableSettings } from "@/utils/table-settings";
+import { getColumnIds, type TableSettings } from "@/utils/table-settings";
 import { columns } from "./columns";
 import { EmptyState, NoResults } from "./empty-states";
 import { DataTableHeader } from "./table-header";
 
 // Stable reference for non-clickable columns (avoids recreation on each render)
 const NON_CLICKABLE_COLUMNS = new Set(["actions"]);
+
+const COLUMN_IDS = getColumnIds(columns);
 
 type Props = {
   initialSettings?: Partial<TableSettings>;
@@ -64,6 +66,7 @@ export function DataTable({ initialSettings }: Props) {
   } = useTableSettings({
     tableId: "customers",
     initialSettings,
+    columnIds: COLUMN_IDS,
   });
 
   const infiniteQueryOptions = trpc.customers.get.infiniteQueryOptions(

--- a/apps/dashboard/src/components/tables/invoices/data-table.tsx
+++ b/apps/dashboard/src/components/tables/invoices/data-table.tsx
@@ -21,7 +21,7 @@ import { useUserQuery } from "@/hooks/use-user";
 import { useInvoiceStore } from "@/store/invoice";
 import { useTRPC } from "@/trpc/client";
 import { STICKY_COLUMNS, SUMMARY_GRID_HEIGHTS } from "@/utils/table-configs";
-import type { TableSettings } from "@/utils/table-settings";
+import { getColumnIds, type TableSettings } from "@/utils/table-settings";
 import { BottomBar } from "./bottom-bar";
 import { columns } from "./columns";
 import { EmptyState, NoResults } from "./empty-states";
@@ -29,6 +29,8 @@ import { DataTableHeader } from "./table-header";
 
 // Stable reference for non-clickable columns (avoids recreation on each render)
 const NON_CLICKABLE_COLUMNS = new Set(["select", "actions"]);
+
+const COLUMN_IDS = getColumnIds(columns);
 
 type Props = {
   initialSettings?: Partial<TableSettings>;
@@ -58,6 +60,7 @@ export function DataTable({ initialSettings }: Props) {
   } = useTableSettings({
     tableId: "invoices",
     initialSettings,
+    columnIds: COLUMN_IDS,
   });
 
   const infiniteQueryOptions = trpc.invoice.get.infiniteQueryOptions(

--- a/apps/dashboard/src/components/tables/transactions/data-table-header.tsx
+++ b/apps/dashboard/src/components/tables/transactions/data-table-header.tsx
@@ -306,6 +306,7 @@ function getHeaderLabel(columnId: string): string {
     date: "Date",
     description: "Description",
     amount: "Amount",
+    baseAmount: "Base Amount",
     taxAmount: "Tax Amount",
     category: "Category",
     counterparty: "From / To",

--- a/apps/dashboard/src/components/tables/transactions/data-table.tsx
+++ b/apps/dashboard/src/components/tables/transactions/data-table.tsx
@@ -42,7 +42,7 @@ import {
 } from "@/store/transactions";
 import { useTRPC } from "@/trpc/client";
 import { STICKY_COLUMNS } from "@/utils/table-configs";
-import type { TableSettings } from "@/utils/table-settings";
+import { getColumnIds, type TableSettings } from "@/utils/table-settings";
 import { BulkEditBar } from "./bulk-edit-bar";
 import { columns } from "./columns";
 import { DataTableHeader } from "./data-table-header";
@@ -58,6 +58,8 @@ const NON_CLICKABLE_COLUMNS = new Set([
   "assigned",
   "tags",
 ]);
+
+const COLUMN_IDS = getColumnIds(columns);
 
 type Props = {
   initialSettings?: Partial<TableSettings>;
@@ -98,6 +100,7 @@ export function DataTable({ initialSettings, initialTab }: Props) {
   } = useTableSettings({
     tableId: "transactions",
     initialSettings,
+    columnIds: COLUMN_IDS,
   });
 
   // Use the current tab from URL, falling back to initial value

--- a/apps/dashboard/src/components/tables/vault/data-table.tsx
+++ b/apps/dashboard/src/components/tables/vault/data-table.tsx
@@ -29,13 +29,15 @@ import { useUserQuery } from "@/hooks/use-user";
 import { useDocumentsStore } from "@/store/vault";
 import { useTRPC } from "@/trpc/client";
 import { STICKY_COLUMNS } from "@/utils/table-configs";
-import type { TableSettings } from "@/utils/table-settings";
+import { getColumnIds, type TableSettings } from "@/utils/table-settings";
 import { BottomBar } from "./bottom-bar";
 import { columns } from "./columns";
 import { DataTableHeader } from "./data-table-header";
 
 // Stable reference for non-clickable columns (avoids recreation on each render)
 const NON_CLICKABLE_COLUMNS = new Set(["select", "tags", "actions"]);
+
+const COLUMN_IDS = getColumnIds(columns);
 
 type Props = {
   initialSettings?: Partial<TableSettings>;
@@ -65,6 +67,7 @@ export function DataTable({ initialSettings }: Props) {
   } = useTableSettings({
     tableId: "vault",
     initialSettings,
+    columnIds: COLUMN_IDS,
   });
 
   // Use the reusable table scroll hook

--- a/apps/dashboard/src/hooks/use-table-settings.ts
+++ b/apps/dashboard/src/hooks/use-table-settings.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { updateTableSettingsAction } from "@/actions/update-table-settings-action";
 import {
   mergeWithDefaults,
+  normalizeColumnOrder,
   TABLE_SETTINGS_COOKIE,
   type TableId,
   type TableSettings,
@@ -17,6 +18,7 @@ import {
 interface UseTableSettingsProps {
   tableId: TableId;
   initialSettings?: Partial<TableSettings>;
+  columnIds?: string[];
 }
 
 interface UseTableSettingsReturn {
@@ -35,6 +37,7 @@ interface UseTableSettingsReturn {
 export function useTableSettings({
   tableId,
   initialSettings,
+  columnIds,
 }: UseTableSettingsProps): UseTableSettingsReturn {
   // Merge initial settings with defaults
   const settings = mergeWithDefaults(initialSettings, tableId);
@@ -46,7 +49,9 @@ export function useTableSettings({
     settings.sizing,
   );
   const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(
-    settings.order,
+    columnIds
+      ? normalizeColumnOrder(settings.order, columnIds)
+      : settings.order,
   );
 
   // Track initial mount to skip first persist

--- a/apps/dashboard/src/utils/table-settings.ts
+++ b/apps/dashboard/src/utils/table-settings.ts
@@ -1,4 +1,5 @@
 import type {
+  ColumnDef,
   ColumnOrderState,
   ColumnSizingState,
   VisibilityState,
@@ -94,4 +95,50 @@ export function mergeWithDefaults(
     sizing: saved?.sizing ?? defaults.sizing,
     order: saved?.order ?? defaults.order,
   };
+}
+
+/**
+ * Extract column IDs from column definitions in definition order.
+ */
+export function getColumnIds<TData>(columns: ColumnDef<TData>[]): string[] {
+  return columns
+    .map(
+      (col) =>
+        col.id ??
+        (col as ColumnDef<TData> & { accessorKey?: string }).accessorKey ??
+        "",
+    )
+    .filter(Boolean);
+}
+
+/**
+ * Normalize a saved column order against the current column definitions.
+ * - Removes columns that no longer exist in definitions
+ * - Inserts new columns (not in saved order) before "actions"
+ * - Ensures "actions" is always the last column
+ */
+export function normalizeColumnOrder(
+  savedOrder: ColumnOrderState,
+  allColumnIds: string[],
+): ColumnOrderState {
+  if (savedOrder.length === 0) return savedOrder;
+
+  const definedIds = new Set(allColumnIds);
+  const savedIds = new Set(savedOrder);
+
+  const orderWithoutActions = savedOrder.filter(
+    (id) => id !== "actions" && definedIds.has(id),
+  );
+
+  const newColumns = allColumnIds.filter(
+    (id) => id !== "actions" && !savedIds.has(id),
+  );
+
+  const result = [...orderWithoutActions, ...newColumns];
+
+  if (definedIds.has("actions")) {
+    result.push("actions");
+  }
+
+  return result;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only changes to client-side table preferences and header labeling; low blast radius, with primary risk being unexpected column order for users with existing saved settings.
> 
> **Overview**
> Fixes issues where persisted table column order could drift from current column definitions (e.g., missing new columns or misplacing `actions`).
> 
> Adds `getColumnIds` + `normalizeColumnOrder` and wires `columnIds` through `useTableSettings` for customers/invoices/transactions/vault so saved orders are sanitized on load, and updates the transactions header label map to include `baseAmount`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 699840272bf07ca417f7abbb655a630d4b3741dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->