### PR TITLE
fix(security): prevent SSRF via logo URL validation bypass

### DIFF
--- a/apps/api/src/schemas/team.ts
+++ b/apps/api/src/schemas/team.ts
@@ -59,6 +59,24 @@ export const getTeamByIdSchema = z.object({
     }),
 });
 
+/**
+ * Validates that a URL is hosted on a trusted midday.ai domain.
+ * Prevents SSRF by checking the hostname, not just URL contents.
+ */
+function isValidMiddayUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    return (
+      hostname === "cdn.midday.ai" ||
+      hostname === "midday.ai" ||
+      hostname.endsWith(".midday.ai")
+    );
+  } catch {
+    return false;
+  }
+}
+
 export const updateTeamByIdSchema = z.object({
   name: z.string().min(2).max(32).optional().openapi({
     description:
@@ -72,8 +90,8 @@ export const updateTeamByIdSchema = z.object({
   logoUrl: z
     .string()
     .url()
-    .refine((url) => url.includes("midday.ai"), {
-      message: "logoUrl must be a midday.ai domain URL",
+    .refine(isValidMiddayUrl, {
+      message: "logoUrl must be hosted on midday.ai domain",
     })
     .optional()
     .openapi({

--- a/packages/invoice/src/utils/logo.ts
+++ b/packages/invoice/src/utils/logo.ts
@@ -1,9 +1,42 @@
+/**
+ * Allowed hosts for logo URLs.
+ * Prevents SSRF by only allowing trusted domains.
+ */
+const ALLOWED_LOGO_HOSTS = new Set([
+  "cdn.midday.ai",
+  "midday.ai",
+  "img.logo.dev", // Used for customer website logos
+]);
+
+function isAllowedLogoHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  return (
+    ALLOWED_LOGO_HOSTS.has(lower) ||
+    lower.endsWith(".midday.ai")
+  );
+}
+
 export async function isValidLogoUrl(url: string): Promise<boolean> {
   if (!url) return false;
 
   try {
-    const response = await fetch(url);
+    const parsed = new URL(url);
 
+    // SSRF protection: only allow trusted hosts
+    if (!isAllowedLogoHost(parsed.hostname)) {
+      return false;
+    }
+
+    // Use HEAD to avoid fetching body, with timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(url, {
+      method: "HEAD",
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
     return response.ok;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Fixes SSRF vulnerability in logo URL validation.

## Security Issue

The `logoUrl` validation uses `url.includes("midday.ai")` which can be bypassed:
- `https://evil.com/midday.ai` ✅ PASSES
- `https://169.254.169.254/midday.ai` ✅ PASSES (AWS metadata)

Combined with `isValidLogoUrl()` that fetches URLs server-side, this allows SSRF.

## Changes

### 1. `apps/api/src/schemas/team.ts`
- Replace `url.includes()` with proper hostname validation
- Only allow `cdn.midday.ai`, `midday.ai`, and `*.midday.ai`

### 2. `packages/invoice/src/utils/logo.ts`
- Add allowlist of trusted hosts
- Use HEAD request instead of GET
- Add timeout to prevent hanging

## Impact

- Prevents access to internal services
- Prevents access to cloud metadata endpoints
- No breaking changes for valid midday.ai URLs