### PR TITLE
Reduce staging

### DIFF
--- a/apps/api/railway.json
+++ b/apps/api/railway.json
@@ -20,9 +20,7 @@
     "staging": {
       "deploy": {
         "multiRegionConfig": {
-          "europe-west4-drams3a": { "numReplicas": 1 },
-          "us-east4-eqdc4a": { "numReplicas": 1 },
-          "us-west2": { "numReplicas": 1 }
+          "europe-west4-drams3a": { "numReplicas": 1 }
         }
       }
     }

--- a/apps/dashboard/railway.json
+++ b/apps/dashboard/railway.json
@@ -20,9 +20,7 @@
     "staging": {
       "deploy": {
         "multiRegionConfig": {
-          "europe-west4-drams3a": { "numReplicas": 1 },
-          "us-east4-eqdc4a": { "numReplicas": 1 },
-          "us-west2": { "numReplicas": 1 }
+          "europe-west4-drams3a": { "numReplicas": 1 }
         }
       }
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change limited to the `staging` environment, but it may reduce staging availability/latency parity by removing US regions.
> 
> **Overview**
> **Staging Railway deploys are scaled down.** For both `apps/api/railway.json` and `apps/dashboard/railway.json`, the `staging` `multiRegionConfig` is changed from 3 regions (EU + 2 US) to **only** `europe-west4-drams3a` with `numReplicas: 1`.
> 
> Production/default multi-region replica settings are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 370a002ba71f3c2f4d6257456fec3303023547b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->