### PR TITLE
Fix tracker timer restarting when trying to stop

### DIFF
--- a/apps/dashboard/src/components/tracker-timer.tsx
+++ b/apps/dashboard/src/components/tracker-timer.tsx
@@ -274,13 +274,15 @@ export function TrackerTimer({
                 )}
               </button>
             </TooltipTrigger>
-            <TooltipContent
-              side="top"
-              sideOffset={5}
-              className="text-xs px-2 py-1 text-[#878787]"
-            >
-              <p>{isThisProjectRunning ? "Stop timer" : "Start timer"}</p>
-            </TooltipContent>
+            {isThisProjectRunning && (
+              <TooltipContent
+                side="top"
+                sideOffset={5}
+                className="text-xs px-2 py-1 text-[#878787]"
+              >
+                <p>Stop timer</p>
+              </TooltipContent>
+            )}
           </Tooltip>
         </TooltipProvider>
       </div>


### PR DESCRIPTION
The hold-to-stop mechanism (1.5s hold) caused a race condition where the click event on button release would see isThisProjectRunning as false (from optimistic update) and immediately restart the timer. Replace with a simple single-click toggle and add a justStoppedRef guard against stale refetch edge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timer start/stop interaction logic and introduces a timing guard, which could affect time tracking correctness if edge cases are missed. Scope is limited to the dashboard `TrackerTimer` UI component.
> 
> **Overview**
> Fixes a race where stopping a running project timer could immediately restart it due to the previous *hold-to-stop* interaction and optimistic state flips.
> 
> The timer control is simplified to a single-click play/stop toggle, removing the hold-progress UI/handlers and adding a short `justStoppedRef` guard to ignore stale/refetch-driven state changes right after a stop. Tooltip text is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32839f92018b4405e75c529aab073b6c373f56d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->