### PR TITLE
Add Midday Computer website page and blog post

### DIFF
--- a/apps/website/src/app/computer/page.tsx
+++ b/apps/website/src/app/computer/page.tsx
@@ -1,0 +1,25 @@
+import { Computer } from "@/components/computer";
+import { createPageMetadata } from "@/lib/metadata";
+
+export const metadata = createPageMetadata({
+  title: "Computer — Autonomous AI agents for your business",
+  description:
+    "Describe what you need, and Midday deploys an autonomous agent that runs on your schedule, learns over time, and delivers results while you sleep.",
+  path: "/computer",
+  og: {
+    title: "Midday Computer",
+    description: "Your business runs even when you don't",
+  },
+  keywords: [
+    "autonomous agents",
+    "business automation",
+    "AI agents",
+    "Midday Computer",
+    "business workflows",
+    "scheduled agents",
+  ],
+});
+
+export default function Page() {
+  return <Computer />;
+}

--- a/apps/website/src/app/sitemap.ts
+++ b/apps/website/src/app/sitemap.ts
@@ -17,6 +17,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/about",
     "/bank-coverage",
     "/compare",
+    "/computer",
     "/customers",
     "/docs",
     "/download",

--- a/apps/website/src/app/updates/posts/cli.mdx
+++ b/apps/website/src/app/updates/posts/cli.mdx
@@ -34,7 +34,7 @@ The CLI and MCP server share the same API surface. Here's what's available:
 
 ### Works with everything
 
-The same 80+ tools are available to every client:
+The same 100+ tools are available to every client:
 
 - **[Cursor](/mcp/cursor)** — Track billable hours while you code, then invoice clients without leaving the editor.
 - **[Claude](/mcp/claude)** — Ask about runway, profit margins, or overdue invoices and get structured answers.

--- a/apps/website/src/app/updates/posts/midday-computer.mdx
+++ b/apps/website/src/app/updates/posts/midday-computer.mdx
@@ -1,0 +1,122 @@
+---
+title: "Midday Computer: Autonomous Agents for Your Business"
+publishedAt: "2026-04-15"
+summary: "Introducing the private beta of Midday Computer. Describe what you need in plain English and Midday deploys an autonomous agent that runs on your schedule, learns over time, and delivers results while you sleep."
+tag: "Updates"
+---
+
+We've been building Midday as an open-source business operating system. Banking, invoicing, transactions, time tracking, all in one place. Over the past year, we've made all of that accessible through 100+ MCP tools, powering the dashboard chat, the iMessage bot, and the public API.
+
+But we kept running into the same limitation: the assistant responds to you, it doesn't work for you. You still have to ask. You still have to be there.
+
+Today we're opening the **private beta** of **Midday Computer**. Describe what you need, and Midday deploys an autonomous agent that runs on your schedule, learns over time, and delivers results while you sleep.
+
+<br />
+
+### What it enables
+
+Instead of logging in every morning to check on things, imagine:
+
+- **"Chase my overdue invoices every Tuesday"** finds overdue invoices, prioritizes by amount and age, and proposes sending reminders. You approve before anything goes out.
+- **"Give me a weekly briefing every Monday"** delivers cash position, revenue trends, spending breakdown, and action items to your inbox before your first coffee.
+- **"Alert me about expenses over $5,000"** runs daily in the background, learns your spending patterns over time, and stays completely silent unless something looks wrong.
+
+You describe the outcome. Midday handles the rest.
+
+<br />
+
+### Works wherever you are
+
+You don't need to learn a new tool. Midday Computer meets you where you already work:
+
+- **Dashboard chat.** "Enable the invoice chaser" or "Create an agent that monitors my expenses." The assistant handles it conversationally.
+- **iMessage bot.** Get agent notifications and approve proposals right from your phone. No app to open.
+- **CLI.** `npx @midday-ai/cli@latest computer` for developers and power users who want full control from the terminal.
+- **REST API.** Build your own integrations, trigger runs programmatically, review proposals from any system.
+
+Every surface talks to the same engine. Create an agent from chat, approve a proposal from iMessage, check the results from the CLI. It all stays in sync.
+
+<br />
+
+### Agents that get smarter over time
+
+Most automations are stateless. They do the same thing every time. Midday Computer agents have **persistent memory** that compounds across runs:
+
+- The **Weekly Briefing** keeps a rolling 12-week trend history. Each Monday it compares against previous weeks and surfaces patterns you'd miss looking at a single snapshot.
+- The **Invoice Chaser** tracks how many times each invoice has been flagged. If a customer is consistently late, the agent adjusts its urgency.
+- The **Expense Detector** builds spending baselines by category over 90 days. The longer it runs, the better it gets at knowing what's normal for your business.
+
+This is the difference between a cron job and an agent. Agents learn.
+
+<br />
+
+### You stay in control
+
+We think trust is the product when it comes to agents handling your business data. That's why Midday Computer has approval mode built in:
+
+1. The agent analyzes your data and decides what needs to happen.
+2. It proposes actions like "Send reminder for INV-0091" and pauses.
+3. You get a notification via in-app, email, or iMessage.
+4. You review and approve, or reject. Nothing happens without your say.
+
+On top of that, every agent runs in a **secure sandbox** with no filesystem or network access, hard limits on resources, and a full step trace so you can see exactly what the agent did, what data it read, and what it decided.
+
+The agent does the work. You make the calls.
+
+<br />
+
+### Pre-built agents, ready to go
+
+We ship four agents you can enable immediately:
+
+- **Month-End Close** (28th–31st, 8 AM). Runs a close-the-books checklist: uncategorized transactions, pending inbox items, draft invoices, P&L comparison to last month.
+- **Invoice Chaser** (Tuesdays, 9 AM). Finds overdue invoices, prioritizes by urgency, proposes sending reminders. You approve before anything goes out.
+- **Weekly Briefing** (Mondays, 8 AM). Cash position, revenue trends, spending breakdown, action items with week-over-week comparison.
+- **Expense Detector** (Daily, 10 AM). Silent unless something's wrong. Flags duplicates, spending spikes, and unknown vendors.
+
+Or describe your own workflow and Midday generates a custom agent. Type-checked, compiled, and deployed in seconds.
+
+<br />
+
+### How it works under the hood
+
+When you describe a workflow, Midday:
+
+1. Looks at all 100+ available tools and generates typed code that knows exactly what data is available and how to access it.
+2. Type-checks the generated code and automatically repairs any issues before deploying.
+3. Runs agents in a secure sandbox on a schedule, adjusted for your timezone.
+4. Records every step for full transparency: what tools were called, what data was returned, what decisions were made.
+
+Agents can also connect to external services like Slack, Gmail, and Google Sheets through Composio, so results can flow wherever your team needs them.
+
+<br />
+
+### Why we're betting on this
+
+**Business operations are repetitive but judgment-heavy.** Month-end close, invoice follow-ups, expense monitoring. These happen on predictable schedules but require context and decisions. Important enough that you can't ignore them, routine enough that you resent doing them. Agents handle the routine and escalate the judgment calls.
+
+**The tool surface we already built is the foundation.** Every piece of Midday data is already accessible through well-typed tools. Midday Computer is the first consumer of that surface that isn't a human in a chat window. Every tool we add for the assistant automatically becomes available to every agent. The investment compounds.
+
+**Trust requires control.** Most agent platforms optimize for full autonomy. We think business data is different. Approval mode, sandbox constraints, step tracing, and concurrency guards aren't limitations. They're the product. The question isn't "can it act?" but "do you trust it to act?"
+
+<br />
+
+### Private beta
+
+Midday Computer is launching in **private beta**. We're onboarding teams gradually to make sure agents are reliable, the catalog is tuned for real-world usage, and we can iterate closely with early users.
+
+If you want early access, reach out directly or visit [midday.ai/computer](/computer). We're looking for teams that have repetitive workflows they'd like to automate: month-end close, collections, expense monitoring, reporting, or anything that happens on a schedule.
+
+<br />
+
+### What's next
+
+This is v1. The roadmap includes event-based triggers (fire when a new transaction lands, not just on cron), more notification channels, custom agent uploads, a dashboard UI for agent management and proposal review, and cross-agent communication.
+
+We're also expanding the catalog. Each new agent is a real workflow we've seen teams do manually every week.
+
+Midday Computer is open source, like everything else we build. The code is at [github.com/midday-ai/midday](https://github.com/midday-ai/midday).
+
+<br />
+
+[Request early access →](/computer)

--- a/apps/website/src/components/computer.tsx
+++ b/apps/website/src/components/computer.tsx
@@ -1,0 +1,1006 @@
+"use client";
+
+import { Button } from "@midday/ui/button";
+import { cn } from "@midday/ui/cn";
+import { Icons } from "@midday/ui/icons";
+import Link from "next/link";
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+function InfraDiagram() {
+  const d = (text: string) => (
+    <span className="text-muted-foreground">{text}</span>
+  );
+  return (
+    <>
+      {
+        "  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐\n"
+      }
+      {
+        "  │  Dashboard   │  │     Chat     │  │     CLI      │  │     API      │\n"
+      }
+      {
+        "  └──────┬───────┘  └──────┬───────┘  └───────┬──────┘  └───────┬──────┘\n"
+      }
+      {"         │                 │                  │                 │\n"}
+      {"         └─────────────────┴──────────────────┴─────────────────┘\n"}
+      {"                                    │\n"}
+      {"                             describe / trigger\n"}
+      {"                                    │\n"}
+      {
+        " ┌──────────────────────────────────┴──────────────────────────────────┐\n"
+      }
+      {" │"}
+      {d(
+        "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░",
+      )}
+      {"│\n"}
+      {" │"}
+      {d("░░░░░░░░░░░░░░░░░░░░░░░░░░░")}
+      {"  Midday Computer  "}
+      {d("░░░░░░░░░░░░░░░░░░░░░░░")}
+      {"│\n"}
+      {" │"}
+      {d(
+        "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░",
+      )}
+      {"│\n"}
+      {" │"}
+      {d("░░░░░░░░░░░░░░░░░░")}
+      {"  generate · schedule · execute  "}
+      {d("░░░░░░░░░░░░░░░░░░")}
+      {"│\n"}
+      {" │"}
+      {d(
+        "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░",
+      )}
+      {"│\n"}
+      {
+        " └──────┬──────────────┬───────────────┬───────────────┬───────────────┘\n"
+      }
+      {"        │              │               │               │\n"}
+      {"        ▼              ▼               ▼               ▼\n"}
+      {"\n"}
+      {
+        "   ┌──────────┐  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐\n"
+      }
+      {
+        "   │  100+    │  │    Agent     │  │ Notifications│  │   External   │\n"
+      }
+      {
+        "   │  MCP     │  │    Memory    │  │              │  │  Connectors  │\n"
+      }
+      {
+        "   │  Tools   │  │              │  │              │  │              │\n"
+      }
+      {
+        "   └──────────┘  └──────────────┘  └──────────────┘  └──────────────┘\n"
+      }
+    </>
+  );
+}
+
+function SectionDivider() {
+  return (
+    <div className="w-full py-1">
+      <div
+        className="h-4 w-full border-y border-border"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(-60deg, hsla(var(--border), 0.4), hsla(var(--border), 0.4) 1px, transparent 1px, transparent 6px)",
+        }}
+      />
+    </div>
+  );
+}
+
+function CopyInstall() {
+  const [copied, setCopied] = useState(false);
+
+  const copyCommand = () => {
+    navigator.clipboard.writeText("npx @midday-ai/cli@latest computer");
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copyCommand}
+      className="flex border border-border p-2 px-4 text-sm w-full relative cursor-pointer hover:bg-[hsl(0,0%,12%)] transition-colors"
+      style={{
+        backgroundImage:
+          "repeating-linear-gradient(-60deg, hsla(var(--border), 0.4), hsla(var(--border), 0.4) 1px, transparent 1px, transparent 6px)",
+      }}
+    >
+      <span className="text-foreground truncate">
+        $ npx @midday-ai/cli@latest computer
+      </span>
+
+      <div className="flex items-center space-x-2 ml-auto">
+        {copied ? (
+          <Icons.Check size={14} className="text-foreground" />
+        ) : (
+          <Icons.Copy size={14} className="text-foreground" />
+        )}
+      </div>
+
+      {copied && (
+        <div className="absolute left-1/2 -translate-x-1/2 -top-7 text-xs text-foreground animate-in fade-in slide-in-from-bottom-1">
+          Copied
+        </div>
+      )}
+    </button>
+  );
+}
+
+const ORA_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+type Phase =
+  | "typing-1"
+  | "spin-1"
+  | "result-1"
+  | "typing-2"
+  | "spin-2"
+  | "result-2"
+  | "done";
+
+const PHASES: Phase[] = [
+  "typing-1",
+  "spin-1",
+  "result-1",
+  "typing-2",
+  "spin-2",
+  "result-2",
+  "done",
+];
+
+type Scenario = {
+  label: string;
+  cmd1: string;
+  cmd2: string;
+  spin1: string;
+  spin2: string;
+  done2: string;
+  result1: React.ReactNode;
+  result2Line: React.ReactNode;
+};
+
+const g = (text: string) => <span className="text-foreground">{text}</span>;
+
+const SCENARIOS: Scenario[] = [
+  {
+    label: "Create agent",
+    cmd1: 'midday computer create "close my books at the end of every month"',
+    cmd2: "midday computer confirm",
+    spin1: "Generating agent...",
+    spin2: "Deploying agent...",
+    done2: "Deploying agent...",
+    result1: (
+      <div className="relative mt-3 border-[0.5px] border-foreground/20 text-foreground text-[12px]">
+        <span className="absolute -top-[10px] left-3 bg-background px-1.5 text-[11px] tracking-wide text-foreground">
+          Agent plan
+        </span>
+        <div className="p-3 pt-2 space-y-0.5">
+          <div>
+            Name: <span className="text-foreground">Month-End Close</span>
+          </div>
+          <div>
+            Schedule:{" "}
+            <span className="text-foreground">28th–31st at 8:00 AM</span>
+          </div>
+          <div>
+            What it does:{" "}
+            <span className="text-foreground">
+              Reviews transactions, flags issues, compares to last month
+            </span>
+          </div>
+          <div className="pt-1 text-[11px] text-muted-foreground">
+            Run `midday computer confirm` to deploy.
+          </div>
+        </div>
+      </div>
+    ),
+    result2Line: (
+      <div className="mt-1 text-foreground text-[12px]">
+        {g("✓")} Agent deployed. First run: April 28th at 8:00 AM
+      </div>
+    ),
+  },
+  {
+    label: "Weekly briefing",
+    cmd1: "midday computer run weekly-briefing --wait",
+    cmd2: "midday computer memory weekly-briefing",
+    spin1: "Running Weekly Briefing...",
+    spin2: "Fetching memory...",
+    done2: "Fetching memory...",
+    result1: (
+      <div className="mt-2 text-foreground text-[12px] space-y-0.5">
+        <div>{g("✓")} Run complete</div>
+        <div> Cash position: $142,800 across 2 accounts</div>
+        <div> Revenue (MTD): $28,400 (+8.2% vs last week)</div>
+        <div> Overdue invoices: 2 totaling $4,200</div>
+        <div> Top expense: Software subscriptions $3,840</div>
+        <div> Action: Follow up on INV-0091, INV-0087</div>
+      </div>
+    ),
+    result2Line: (
+      <div className="mt-1 text-foreground text-[12px] space-y-0.5">
+        <div> [Apr 7] Revenue trending +8% week over week</div>
+        <div> [Mar 31] Q1 close complete, 3 items flagged</div>
+        <div> [Mar 24] Contractor spend within budget</div>
+      </div>
+    ),
+  },
+  {
+    label: "Chase invoices",
+    cmd1: "midday computer proposals invoice-chaser",
+    cmd2: "midday computer approve invoice-chaser run_182",
+    spin1: "Fetching proposals...",
+    spin2: "Sending reminders...",
+    done2: "Sending reminders...",
+    result1: (
+      <div className="relative mt-3 border-[0.5px] border-foreground/20 text-foreground text-[12px]">
+        <span className="absolute -top-[10px] left-3 bg-background px-1.5 text-[11px] tracking-wide text-foreground">
+          Waiting for your approval
+        </span>
+        <table className="w-full mt-2 mb-1">
+          <thead>
+            <tr className="text-left border-b-[0.5px] border-foreground/20">
+              <th className="font-normal pl-3 pr-2 pb-1 text-foreground">
+                ACTION
+              </th>
+              <th className="font-normal pr-2 pb-1 text-foreground">INVOICE</th>
+              <th className="font-normal pr-3 pb-1 text-right text-foreground">
+                AMOUNT
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="pl-3 pr-2 py-[3px]">Send reminder</td>
+              <td className="pr-2 py-[3px]">INV-0091 (Acme Corp)</td>
+              <td className="pr-3 py-[3px] text-right">$2,340.00</td>
+            </tr>
+            <tr>
+              <td className="pl-3 pr-2 py-[3px]">Send reminder</td>
+              <td className="pr-2 py-[3px]">INV-0087 (Northwind)</td>
+              <td className="pr-3 py-[3px] text-right">$1,860.00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    ),
+    result2Line: (
+      <div className="mt-1 text-foreground text-[12px]">
+        {g("✓")} 2 reminders sent. $4,200 in overdue invoices followed up.
+      </div>
+    ),
+  },
+  {
+    label: "Expense alert",
+    cmd1: "midday computer run expense-detector --wait",
+    cmd2: "midday computer logs expense-detector",
+    spin1: "Running Expense Detector...",
+    spin2: "Fetching run history...",
+    done2: "Fetching run history...",
+    result1: (
+      <div className="mt-2 text-foreground text-[12px] space-y-0.5">
+        <div>{g("⚠")} Anomaly detected</div>
+        <div> Shopify: $4,120 (3.2x your daily average)</div>
+        <div> Possible duplicate: AWS $189 charged twice</div>
+        <div> New vendor: DesignStudio.co ($950)</div>
+        <div> Notification sent to your team</div>
+      </div>
+    ),
+    result2Line: (
+      <div className="mt-1 text-foreground text-[12px] space-y-0.5">
+        <div> [Apr 15] 3 anomalies flagged (notified)</div>
+        <div> [Apr 14] No anomalies. All clear.</div>
+        <div> [Apr 13] No anomalies. All clear.</div>
+        <div> [Apr 12] 1 duplicate charge flagged</div>
+      </div>
+    ),
+  },
+];
+
+function Terminal() {
+  const [activeTab, setActiveTab] = useState(0);
+  const [phase, setPhase] = useState<Phase>("typing-1");
+  const [typed1, setTyped1] = useState("");
+  const [typed2, setTyped2] = useState("");
+  const [frame, setFrame] = useState(0);
+  const [cursorOn, setCursorOn] = useState(true);
+  const termRef = useRef<HTMLDivElement>(null);
+
+  const scenario = SCENARIOS[activeTab] as Scenario;
+
+  const resetAnimation = useCallback(() => {
+    setPhase("typing-1");
+    setTyped1("");
+    setTyped2("");
+    setFrame(0);
+  }, []);
+
+  useEffect(() => {
+    resetAnimation();
+  }, [activeTab, resetAnimation]);
+
+  const handleTabClick = (idx: number) => {
+    setActiveTab(idx);
+  };
+
+  const past = (p: Phase) => PHASES.indexOf(phase) >= PHASES.indexOf(p);
+
+  useEffect(() => {
+    const id = setInterval(() => setCursorOn((v) => !v), 530);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (phase !== "typing-1") return;
+    let i = 0;
+    const id = setInterval(() => {
+      if (i <= scenario.cmd1.length) {
+        setTyped1(scenario.cmd1.slice(0, i));
+        i++;
+      } else {
+        clearInterval(id);
+        setTimeout(() => setPhase("spin-1"), 300);
+      }
+    }, 40);
+    return () => clearInterval(id);
+  }, [phase, scenario.cmd1]);
+
+  useEffect(() => {
+    if (phase !== "spin-1" && phase !== "spin-2") return;
+    const id = setInterval(
+      () => setFrame((f) => (f + 1) % ORA_FRAMES.length),
+      80,
+    );
+    const dur = phase === "spin-1" ? 2000 : 1400;
+    const t = setTimeout(() => {
+      clearInterval(id);
+      setPhase(phase === "spin-1" ? "result-1" : "result-2");
+    }, dur);
+    return () => {
+      clearInterval(id);
+      clearTimeout(t);
+    };
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "result-1") return;
+    const t = setTimeout(() => setPhase("typing-2"), 1500);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "typing-2") return;
+    let i = 0;
+    const id = setInterval(() => {
+      if (i <= scenario.cmd2.length) {
+        setTyped2(scenario.cmd2.slice(0, i));
+        i++;
+      } else {
+        clearInterval(id);
+        setTimeout(() => setPhase("spin-2"), 300);
+      }
+    }, 40);
+    return () => clearInterval(id);
+  }, [phase, scenario.cmd2]);
+
+  useEffect(() => {
+    if (phase !== "result-2") return;
+    const t = setTimeout(() => setPhase("done"), 800);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "done") return;
+    const t = setTimeout(() => {
+      setActiveTab((prev) => (prev + 1) % SCENARIOS.length);
+    }, 2500);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      termRef.current?.scrollTo({
+        top: termRef.current.scrollHeight,
+        behavior: "smooth",
+      });
+    }, 30);
+  }, [phase, typed1, typed2, frame]);
+
+  const cursor = (
+    <span
+      className={cn(
+        "inline-block w-[7px] h-[15px] ml-px align-middle bg-foreground",
+        cursorOn ? "opacity-100" : "opacity-0",
+      )}
+    />
+  );
+
+  const prompt = <span className="text-foreground">~ $ </span>;
+
+  const spin = (text: string) => (
+    <div className="text-foreground">
+      {ORA_FRAMES[frame]} {text}
+    </div>
+  );
+
+  return (
+    <div className="max-w-3xl w-full font-mono">
+      <div className="overflow-hidden border border-border">
+        <div className="select-none flex items-center h-7 px-3 border-b border-border bg-[hsl(0,0%,10%)]">
+          <div className="flex gap-[5px]">
+            <span className="block w-2 h-2 rounded-full bg-[hsl(0,0%,25%)]" />
+            <span className="block w-2 h-2 rounded-full bg-[hsl(0,0%,25%)]" />
+            <span className="block w-2 h-2 rounded-full bg-[hsl(0,0%,25%)]" />
+          </div>
+          <span className="flex-1 text-center text-[10px] tracking-wide text-foreground -ml-10">
+            midday computer — zsh
+          </span>
+        </div>
+
+        <div className="flex bg-muted/40">
+          {SCENARIOS.map((s, i) => (
+            <button
+              key={s.label}
+              type="button"
+              onClick={() => handleTabClick(i)}
+              className={cn(
+                "relative flex-1 px-4 py-1.5 text-[11px] tracking-wide transition-colors border-b",
+                i === activeTab
+                  ? "bg-background text-foreground border-b-transparent"
+                  : "text-[hsl(0,0%,55%)] hover:text-foreground border-b-border",
+                i > 0 && "border-l border-l-border",
+              )}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+
+        <div
+          ref={termRef}
+          className="overflow-y-auto h-[380px] md:h-[460px] scroll-smooth p-5 bg-background text-[13px] leading-[1.7] text-foreground"
+        >
+          <div className="text-[hsl(0,0%,55%)] text-[10px] tracking-widest mb-5">
+            midday computer v0.1.0 · agent@acme.corp
+          </div>
+
+          <div>
+            {prompt}
+            {typed1}
+            {phase === "typing-1" && cursor}
+          </div>
+
+          {phase === "spin-1" && (
+            <div className="mt-1">{spin(scenario.spin1)}</div>
+          )}
+
+          {past("result-1") && scenario.result1}
+
+          {past("typing-2") && (
+            <div className="mt-2">
+              {prompt}
+              {typed2}
+              {phase === "typing-2" && cursor}
+            </div>
+          )}
+
+          {phase === "spin-2" && (
+            <div className="mt-1">{spin(scenario.spin2)}</div>
+          )}
+
+          {past("result-2") && (
+            <>
+              <div className="mt-1">{scenario.result2Line}</div>
+            </>
+          )}
+
+          {phase === "done" && (
+            <div className="mt-3">
+              {prompt}
+              {cursor}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const features = [
+  {
+    title: "You describe, it builds",
+    description:
+      "Tell Midday what you need in plain English. It builds the agent, shows you the plan, and deploys when you're ready.",
+  },
+  {
+    title: "Ready-made agents",
+    description:
+      "Month-End Close, Invoice Chaser, Weekly Briefing, Expense Detector. Enable in one click. Already tuned for real workflows.",
+  },
+  {
+    title: "Runs on your schedule",
+    description:
+      "Every Tuesday at 9 AM. Last day of the month. Daily at 10. Set it once and your agents handle the rest.",
+  },
+  {
+    title: "Learns over time",
+    description:
+      "Agents remember across runs. Trends compound weekly. Baselines sharpen. The longer they run, the more useful they get.",
+  },
+  {
+    title: "You stay in control",
+    description:
+      "Agents propose actions, you review and approve. Nothing happens without your say. Built for trust.",
+  },
+  {
+    title: "Access to all your data",
+    description:
+      "Invoices, transactions, customers, reports, bank accounts, and more. Agents work with everything Midday knows about your business.",
+  },
+  {
+    title: "Thinks, not just executes",
+    description:
+      "Agents analyze your data, spot anomalies, compare trends, and make recommendations. Not just automation.",
+  },
+  {
+    title: "Secure and isolated",
+    description:
+      "Every agent runs in its own sandbox with no access to your filesystem or network. Hard limits on what it can do.",
+  },
+  {
+    title: "See everything it does",
+    description:
+      "Full trace of every step. What data it read, what it decided, what actions it took. Nothing is a black box.",
+  },
+  {
+    title: "Connected to your tools",
+    description:
+      "Post results to Slack, send emails via Gmail, update Google Sheets. Agents deliver wherever your team works.",
+  },
+  {
+    title: "Works wherever you are",
+    description:
+      "Dashboard, iMessage, chat, or CLI. Create agents, approve proposals, and check results from any surface.",
+  },
+  {
+    title: "Up and running in seconds",
+    description:
+      "One command. Sign in with your browser. No API keys, no config files. Your first agent is live in under a minute.",
+  },
+];
+
+const catalogAgents = [
+  {
+    name: "Month-End Close",
+    schedule: "Last days of month, 8 AM",
+    description:
+      "Runs through your books so you don't have to. Flags what needs attention before you close the month.",
+    details: [
+      "Reviews every transaction for the current month",
+      "Flags uncategorized items and pending inbox documents",
+      "Compares spending to last month and gives you a health check",
+    ],
+  },
+  {
+    name: "Invoice Chaser",
+    schedule: "Tuesdays 9 AM",
+    description:
+      "Finds overdue invoices and proposes sending reminders. You approve before anything goes out.",
+    details: [
+      "Prioritizes by amount and how long invoices have been outstanding",
+      "Tracks escalation history so repeat late payers get flagged",
+      "Proposes reminders for you to review. You decide what gets sent",
+    ],
+  },
+  {
+    name: "Weekly Briefing",
+    schedule: "Mondays 8 AM",
+    description:
+      "Delivers a clear picture of your business every Monday. Cash, revenue, spending, and what needs your attention.",
+    details: [
+      "Summarizes cash position across all accounts",
+      "Tracks revenue and spending trends week over week",
+      "Lists action items like overdue invoices and large expenses",
+    ],
+  },
+  {
+    name: "Expense Detector",
+    schedule: "Daily 10 AM",
+    description:
+      "Watches your expenses in the background. Learns what's normal and only alerts you when something looks off.",
+    details: [
+      "Builds spending baselines by category over 90 days",
+      "Catches duplicate charges, spikes, and unknown vendors",
+      "Stays completely silent on normal days",
+    ],
+  },
+];
+
+const howItWorks = [
+  {
+    step: "01",
+    title: "Describe",
+    description:
+      "Tell Midday what you need in plain English, or pick a ready-made agent from the catalog.",
+  },
+  {
+    step: "02",
+    title: "Review",
+    description:
+      "Midday builds the agent and shows you the plan. You confirm when it looks right.",
+  },
+  {
+    step: "03",
+    title: "Automate",
+    description:
+      "It runs on your schedule, learns from every run, and gets more useful over time.",
+  },
+  {
+    step: "04",
+    title: "Control",
+    description:
+      "See everything it does. Approve actions before they happen. You're always in the loop.",
+  },
+];
+
+const PROMPTS = [
+  "Chase my overdue invoices every Tuesday",
+  "Alert me when expenses look unusual",
+  "Give me a weekly briefing every Monday morning",
+  "Flag contractor spend when it exceeds budget",
+  "Post my weekly revenue summary to Slack",
+];
+
+function PromptShowcase() {
+  const [index, setIndex] = useState(0);
+  const [displayed, setDisplayed] = useState("");
+  const [cursorOn, setCursorOn] = useState(true);
+
+  useEffect(() => {
+    const id = setInterval(() => setCursorOn((v) => !v), 530);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const prompt = PROMPTS[index] as string;
+    let i = 0;
+    setDisplayed("");
+    const typeId = setInterval(() => {
+      if (i <= prompt.length) {
+        setDisplayed(prompt.slice(0, i));
+        i++;
+      } else {
+        clearInterval(typeId);
+        setTimeout(() => {
+          setIndex((prev) => (prev + 1) % PROMPTS.length);
+        }, 2500);
+      }
+    }, 50);
+    return () => clearInterval(typeId);
+  }, [index]);
+
+  const cursor = (
+    <span
+      className={cn(
+        "inline-block w-[7px] h-[15px] ml-px align-middle bg-foreground",
+        cursorOn ? "opacity-100" : "opacity-0",
+      )}
+    />
+  );
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div
+        className="border border-border p-6 font-mono text-foreground text-base md:text-lg"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(-60deg, hsla(var(--border), 0.4), hsla(var(--border), 0.4) 1px, transparent 1px, transparent 6px)",
+        }}
+      >
+        <span className="text-muted-foreground">$ midday computer create </span>
+        &quot;{displayed}
+        {cursor}&quot;
+      </div>
+      <p className="text-center mt-4 text-sm text-muted-foreground">
+        One sentence. That&apos;s all it takes.
+      </p>
+    </div>
+  );
+}
+
+export function Computer() {
+  return (
+    <div className="font-mono relative mt-16">
+      {/* Hero */}
+      <div className="max-w-screen-xl mx-auto pt-16 pb-12 md:py-28 flex flex-col lg:flex-row gap-12 justify-between items-center">
+        <div className="lg:max-w-[590px] space-y-8 w-full">
+          <div>
+            <span className="inline-block text-[10px] tracking-widest uppercase border border-border px-2 py-0.5 mb-6 text-muted-foreground">
+              Private Beta
+            </span>
+            <h1 className="text-3xl md:text-4xl lg:text-5xl leading-[1.1] tracking-tight font-sans">
+              The operating system for your business.
+            </h1>
+            <p className="text-base leading-normal mt-4 md:mt-8 text-muted-foreground">
+              Midday Computer puts your business on autopilot. Agents that run
+              on your schedule, learn over time, and take care of the work you
+              keep putting off.
+            </p>
+          </div>
+
+          <div className="lg:max-w-[480px]">
+            <CopyInstall />
+          </div>
+
+          <div className="flex items-center gap-4">
+            <Button
+              asChild
+              className="h-11 px-6 text-sm font-mono hover:!bg-[hsl(0,0%,85%)]"
+            >
+              <Link href="https://app.midday.ai">Get started</Link>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="hidden md:inline-flex h-11 px-6 text-sm font-mono hover:!bg-[hsl(0,0%,15%)] hover:!text-foreground"
+            >
+              <Link href="https://github.com/midday-ai/midday/tree/main/packages/cli">
+                View documentation
+              </Link>
+            </Button>
+          </div>
+        </div>
+
+        <Terminal />
+      </div>
+
+      <div className="space-y-16 max-w-screen-lg mx-auto">
+        {/* Features */}
+        <div className="mt-12">
+          <h3 className="font-sans text-2xl text-foreground">What you get</h3>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mt-4">
+            {features.map((feature) => (
+              <div
+                className="border border-border p-1 -mt-[1px] -ml-[1px]"
+                key={feature.title}
+              >
+                <div className="p-4">
+                  <div className="space-y-4">
+                    <h3 className="text-sm">{feature.title}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {feature.description}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <SectionDivider />
+
+        {/* Catalog agents */}
+        <div>
+          <h3 className="font-sans text-2xl text-foreground">
+            Pre-built agents
+          </h3>
+          <p className="text-sm mt-2 text-muted-foreground">
+            Enable in one click. Already tuned for real business workflows.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 mt-4">
+            {catalogAgents.map((agent) => (
+              <div
+                className="border border-border p-1 -mt-[1px] -ml-[1px]"
+                key={agent.name}
+              >
+                <div className="p-5">
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-sm font-sans">{agent.name}</h3>
+                      <span className="text-[10px] tracking-widest uppercase text-muted-foreground">
+                        {agent.schedule}
+                      </span>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {agent.description}
+                    </p>
+                    <ul className="space-y-1.5">
+                      {agent.details.map((detail) => (
+                        <li
+                          key={detail}
+                          className="text-sm text-muted-foreground"
+                        >
+                          ◇ {detail}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <SectionDivider />
+
+        {/* How it works */}
+        <div>
+          <h3 className="font-sans text-2xl text-foreground">How it works</h3>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 mt-4">
+            {howItWorks.map((item) => (
+              <div
+                className="border border-border p-1 -mt-[1px] -ml-[1px]"
+                key={item.step}
+              >
+                <div className="p-5">
+                  <div className="space-y-3">
+                    <span
+                      className="text-3xl font-sans"
+                      style={{ color: "hsl(0, 0%, 30%)" }}
+                    >
+                      {item.step}
+                    </span>
+                    <h3 className="text-sm">{item.title}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {item.description}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <SectionDivider />
+
+        {/* Capabilities */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 mt-4">
+          <div className="border border-border p-1 -mt-[1px] -ml-[1px]">
+            <div className="p-4 space-y-4">
+              <h2 className="text-sm">Dashboard</h2>
+              <ul className="space-y-2 text-muted-foreground">
+                <li className="text-sm">
+                  ◇ &quot;Enable the invoice chaser&quot;
+                </li>
+                <li className="text-sm">
+                  ◇ &quot;Create an agent that monitors expenses&quot;
+                </li>
+                <li className="text-sm">◇ Manage agents from chat</li>
+                <li className="text-sm">◇ View run history and results</li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="border border-border p-1 -mt-[1px] -ml-[1px]">
+            <div className="p-4 space-y-4">
+              <h2 className="text-sm">Chat</h2>
+              <ul className="space-y-2 text-muted-foreground">
+                <li className="text-sm">
+                  ◇ iMessage, WhatsApp, Slack, Telegram
+                </li>
+                <li className="text-sm">
+                  ◇ Get notified and approve on the go
+                </li>
+                <li className="text-sm">◇ Check agent results from any chat</li>
+                <li className="text-sm">◇ No app to install</li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="border border-border p-1 -mt-[1px] -ml-[1px]">
+            <div className="p-4 space-y-4">
+              <h2 className="text-sm">CLI</h2>
+              <ul className="space-y-2 text-muted-foreground">
+                <li className="text-sm">◇ Create, run, and manage agents</li>
+                <li className="text-sm">◇ Approve proposals from terminal</li>
+                <li className="text-sm">◇ Inspect memory and run history</li>
+                <li className="text-sm">◇ Sign in with your browser</li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="border border-border p-1 -mt-[1px] -ml-[1px]">
+            <div className="p-4 space-y-4">
+              <h2 className="text-sm">API</h2>
+              <ul className="space-y-2 text-muted-foreground">
+                <li className="text-sm">◇ Build your own integrations</li>
+                <li className="text-sm">◇ Trigger runs programmatically</li>
+                <li className="text-sm">◇ Manage proposals and approvals</li>
+                <li className="text-sm">◇ Full step trace access</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div className="hidden md:flex justify-center mt-12">
+          <Button
+            asChild
+            className="h-11 px-6 text-sm font-mono hover:!bg-[hsl(0,0%,85%)]"
+          >
+            <Link href="https://app.midday.ai">Get started</Link>
+          </Button>
+        </div>
+
+        <div className="hidden md:block">
+          <SectionDivider />
+        </div>
+
+        {/* Infrastructure diagram */}
+        <div className="hidden md:block text-center">
+          <h2 className="font-sans text-2xl sm:text-3xl text-foreground">
+            How it works
+          </h2>
+          <p className="text-base leading-normal mt-4 max-w-md mx-auto text-muted-foreground">
+            You describe what you need. Midday builds the agent, runs it on your
+            schedule, and delivers results.
+          </p>
+
+          <div className="hidden md:flex flex-col items-center justify-center mt-2">
+            <pre
+              className="p-4 text-sm leading-5 md:scale-[0.8] transform-gpu"
+              style={{
+                fontFamily: "monospace",
+                whiteSpace: "pre",
+                textAlign: "left",
+              }}
+            >
+              <InfraDiagram />
+            </pre>
+          </div>
+        </div>
+
+        <SectionDivider />
+
+        {/* Prompt showcase */}
+        <div className="text-center">
+          <h2 className="font-sans text-2xl sm:text-3xl text-foreground mb-8">
+            What would your agent do?
+          </h2>
+          <PromptShowcase />
+        </div>
+      </div>
+
+      {/* CTA */}
+      <div className="max-w-screen-lg mx-auto mt-16 mb-24">
+        <div className="bg-background border border-border p-8 lg:p-12 text-center relative before:absolute before:inset-0 before:bg-[repeating-linear-gradient(-60deg,hsla(var(--border),0.4),hsla(var(--border),0.4)_1px,transparent_1px,transparent_6px)] before:pointer-events-none">
+          <div className="relative z-10">
+            <h2 className="font-sans text-2xl sm:text-3xl text-foreground mb-4">
+              Get started
+            </h2>
+            <p className="font-sans text-base mb-6 max-w-lg mx-auto text-muted-foreground">
+              Midday Computer puts your business on autopilot. Describe what you
+              need and it takes care of the rest.
+            </p>
+            <div className="flex flex-wrap justify-center gap-4">
+              <Button
+                asChild
+                className="h-11 px-6 text-sm font-mono hover:!bg-[hsl(0,0%,85%)]"
+              >
+                <Link href="https://app.midday.ai">Get started</Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                className="h-11 px-6 text-sm font-mono border-primary bg-background hover:!bg-[hsl(0,0%,15%)] hover:!text-foreground"
+              >
+                <Link href="https://github.com/midday-ai/midday/tree/main/packages/cli">
+                  View documentation
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/components/computer.tsx
+++ b/apps/website/src/components/computer.tsx
@@ -496,9 +496,7 @@ function Terminal() {
           )}
 
           {past("result-2") && (
-            <>
-              <div className="mt-1">{scenario.result2Line}</div>
-            </>
+            <div className="mt-1">{scenario.result2Line}</div>
           )}
 
           {phase === "done" && (

--- a/apps/website/src/components/footer.tsx
+++ b/apps/website/src/components/footer.tsx
@@ -116,7 +116,8 @@ export function Footer() {
                 {[
                   { href: "/chat", label: "Chat", external: false },
                   { href: "/docs", label: "Documentation", external: false },
-                  { href: "/agents", label: "Agents", external: false },
+                  { href: "/agents", label: "CLI", external: false },
+                  { href: "/computer", label: "Computer", external: false },
                   {
                     href: "https://api.midday.ai",
                     label: "API",

--- a/apps/website/src/components/header.tsx
+++ b/apps/website/src/components/header.tsx
@@ -90,7 +90,14 @@ const FEATURE_ROUTES = [
 ];
 
 // App pages to prefetch on hover
-const APP_ROUTES = ["/integrations", "/download", "/docs", "/agents", "/computer", "/mcp"];
+const APP_ROUTES = [
+  "/integrations",
+  "/download",
+  "/docs",
+  "/agents",
+  "/computer",
+  "/mcp",
+];
 
 export function Header({
   transparent = false,

--- a/apps/website/src/components/header.tsx
+++ b/apps/website/src/components/header.tsx
@@ -90,7 +90,7 @@ const FEATURE_ROUTES = [
 ];
 
 // App pages to prefetch on hover
-const APP_ROUTES = ["/integrations", "/download", "/docs", "/agents", "/mcp"];
+const APP_ROUTES = ["/integrations", "/download", "/docs", "/agents", "/computer", "/mcp"];
 
 export function Header({
   transparent = false,
@@ -644,7 +644,7 @@ export function Header({
                                 },
                                 {
                                   href: "/agents",
-                                  title: "Agents",
+                                  title: "CLI",
                                   desc: "Agent-native CLI and MCP workflows.",
                                   external: false,
                                 },
@@ -696,6 +696,12 @@ export function Header({
                                   href: "/chat",
                                   title: "Chat",
                                   desc: "Run your business from any chat app.",
+                                  external: false,
+                                },
+                                {
+                                  href: "/computer",
+                                  title: "Computer",
+                                  desc: "Autonomous agents for your business.",
                                   external: false,
                                 },
                               ].map((item, index) => (
@@ -1062,7 +1068,18 @@ export function Header({
                           className="text-lg font-sans text-left text-muted-foreground hover:text-muted-foreground xl:active:text-muted-foreground focus:outline-none focus-visible:outline-none touch-manipulation transition-colors"
                           style={{ WebkitTapHighlightColor: "transparent" }}
                         >
-                          Agents
+                          CLI
+                        </Link>
+                        <Link
+                          href="/computer"
+                          onClick={() => {
+                            setIsMenuOpen(false);
+                            setIsMobileAppsOpen(false);
+                          }}
+                          className="text-lg font-sans text-left text-muted-foreground hover:text-muted-foreground xl:active:text-muted-foreground focus:outline-none focus-visible:outline-none touch-manipulation transition-colors"
+                          style={{ WebkitTapHighlightColor: "transparent" }}
+                        >
+                          Computer
                         </Link>
                         <Link
                           href="/mcp"

--- a/apps/website/src/components/startpage.tsx
+++ b/apps/website/src/components/startpage.tsx
@@ -269,10 +269,10 @@ export function StartPage() {
             <div className="flex flex-col items-center w-full text-center space-y-6 lg:space-y-8">
               <div className="space-y-5 lg:space-y-6 max-w-3xl 3xl:max-w-5xl mx-auto px-2 lg:px-0">
                 <Link
-                  href="/chat"
+                  href="/computer"
                   className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full border border-border text-xs font-sans text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors"
                 >
-                  Run your business from iMessage and more
+                  Introducing Midday Computer
                   <span aria-hidden="true">&rarr;</span>
                 </Link>
 


### PR DESCRIPTION
Introduces the /computer marketing page with terminal demos, feature grid, catalog agents, infrastructure diagram, and capabilities section. Adds the "Introducing Midday Computer" blog post. Updates header nav, homepage pill, footer, and sitemap to link to the new page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk marketing-site update: adds a new `/computer` page and blog content plus navigation/sitemap wiring, with no changes to backend or user data flows.
> 
> **Overview**
> Adds a new `/computer` marketing page with dedicated SEO metadata and a large client-side `Computer` component featuring interactive terminal-style demos, feature/capability sections, and CTAs.
> 
> Publishes a new Updates post (`midday-computer.mdx`) and tweaks the existing CLI post copy ("80+" → "100+"). Updates site navigation and discovery by linking to `/computer` from the header (desktop + mobile), footer, homepage hero pill, and including it in `sitemap.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47df69cb453228d111e72804ea6d0cbd143272dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->