### PR TITLE
Gate new sign-ups with waitlist notice on login page

### DIFF
--- a/apps/dashboard/src/actions/verify-otp-action.ts
+++ b/apps/dashboard/src/actions/verify-otp-action.ts
@@ -6,6 +6,8 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import { Cookies } from "@/utils/constants";
+import { getUrl } from "@/utils/environment";
+import { isBlockedNewUser } from "@/utils/new-user-gate";
 import { actionClient } from "./safe-action";
 
 export const verifyOtpAction = actionClient
@@ -32,6 +34,11 @@ export const verifyOtpAction = actionClient
 
     if (!session) {
       throw new Error("Failed to establish session after OTP verification");
+    }
+
+    if (isBlockedNewUser(session.user.created_at)) {
+      await supabase.auth.signOut();
+      redirect(`${getUrl()}/login?waitlist=1`);
     }
 
     const cookieStore = await cookies();

--- a/apps/dashboard/src/app/[locale]/(public)/login/page.tsx
+++ b/apps/dashboard/src/app/[locale]/(public)/login/page.tsx
@@ -1,3 +1,4 @@
+import { createClient } from "@midday/supabase/server";
 import { Icons } from "@midday/ui/icons";
 import type { Metadata } from "next";
 import { cookies, headers } from "next/headers";
@@ -8,6 +9,7 @@ import { LoginVideoBackground } from "@/components/login-video-background";
 import { OAuthSignIn } from "@/components/oauth-sign-in";
 import { OTPSignIn } from "@/components/otp-sign-in";
 import { Cookies } from "@/utils/constants";
+import { isBlockedNewUser } from "@/utils/new-user-gate";
 
 export const metadata: Metadata = {
   title: "Login | Midday",
@@ -17,6 +19,12 @@ export default async function Page() {
   const cookieStore = await cookies();
   const preferred = cookieStore.get(Cookies.PreferredSignInProvider);
   const { device } = userAgent({ headers: await headers() });
+
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+  const showQueueNotice = isBlockedNewUser(authUser?.created_at);
 
   let moreSignInOptions = null;
   let preferredSignInOption =
@@ -148,35 +156,50 @@ export default async function Page() {
       <div className="w-full lg:w-1/2 flex flex-col justify-center items-center p-8 lg:p-12 pb-2">
         <div className="w-full max-w-md flex flex-col h-full">
           <div className="space-y-8 flex-1 flex flex-col justify-center">
-            {/* Header */}
-            <div className="text-center space-y-2">
-              <h1 className="text-lg lg:text-xl mb-4 font-serif">
-                Welcome to Midday
-              </h1>
-              <p className="font-sans text-sm text-[#878787]">
-                Sign in or create an account
-              </p>
-            </div>
-
-            {/* Sign In Options */}
-            <div className="space-y-3 flex items-center justify-center w-full">
-              {preferredSignInOption}
-            </div>
-
-            {/* Divider */}
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-border" />
+            {showQueueNotice ? (
+              <div className="text-center space-y-2">
+                <h1 className="text-lg lg:text-xl mb-4 font-serif">
+                  You're on the waitlist
+                </h1>
+                <p className="font-sans text-sm text-[#878787]">
+                  Midday is not accepting new sign-ups right now. You've been
+                  added to our queue and we'll email you as soon as a spot opens
+                  up.
+                </p>
               </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="px-2 bg-background font-sans text-[#878787]">
-                  or
-                </span>
-              </div>
-            </div>
+            ) : (
+              <>
+                {/* Header */}
+                <div className="text-center space-y-2">
+                  <h1 className="text-lg lg:text-xl mb-4 font-serif">
+                    Welcome to Midday
+                  </h1>
+                  <p className="font-sans text-sm text-[#878787]">
+                    Sign in or create an account
+                  </p>
+                </div>
 
-            {/* More Options Accordion */}
-            <LoginAccordion>{moreSignInOptions}</LoginAccordion>
+                {/* Sign In Options */}
+                <div className="space-y-3 flex items-center justify-center w-full">
+                  {preferredSignInOption}
+                </div>
+
+                {/* Divider */}
+                <div className="relative">
+                  <div className="absolute inset-0 flex items-center">
+                    <div className="w-full border-t border-border" />
+                  </div>
+                  <div className="relative flex justify-center text-sm">
+                    <span className="px-2 bg-background font-sans text-[#878787]">
+                      or
+                    </span>
+                  </div>
+                </div>
+
+                {/* More Options Accordion */}
+                <LoginAccordion>{moreSignInOptions}</LoginAccordion>
+              </>
+            )}
           </div>
 
           {/* Terms and Privacy Policy - Bottom aligned */}

--- a/apps/dashboard/src/app/[locale]/(public)/login/page.tsx
+++ b/apps/dashboard/src/app/[locale]/(public)/login/page.tsx
@@ -15,7 +15,12 @@ export const metadata: Metadata = {
   title: "Login | Midday",
 };
 
-export default async function Page() {
+type Props = {
+  searchParams: Promise<{ waitlist?: string }>;
+};
+
+export default async function Page({ searchParams }: Props) {
+  const { waitlist: waitlistParam } = await searchParams;
   const cookieStore = await cookies();
   const preferred = cookieStore.get(Cookies.PreferredSignInProvider);
   const { device } = userAgent({ headers: await headers() });
@@ -24,7 +29,8 @@ export default async function Page() {
   const {
     data: { user: authUser },
   } = await supabase.auth.getUser();
-  const showQueueNotice = isBlockedNewUser(authUser?.created_at);
+  const showQueueNotice =
+    waitlistParam === "1" || isBlockedNewUser(authUser?.created_at);
 
   let moreSignInOptions = null;
   let preferredSignInOption =

--- a/apps/dashboard/src/app/api/auth/callback/route.ts
+++ b/apps/dashboard/src/app/api/auth/callback/route.ts
@@ -10,6 +10,7 @@ import { NextResponse } from "next/server";
 import { getTRPCClient } from "@/trpc/server";
 import { Cookies } from "@/utils/constants";
 import { getUrl } from "@/utils/environment";
+import { isBlockedNewUser } from "@/utils/new-user-gate";
 
 export async function GET(req: NextRequest) {
   const cookieStore = await cookies();
@@ -39,6 +40,11 @@ export async function GET(req: NextRequest) {
     } = await getSession();
 
     if (session) {
+      if (isBlockedNewUser(session.user.created_at)) {
+        await supabase.auth.signOut();
+        return NextResponse.redirect(`${origin}/login?waitlist=1`);
+      }
+
       // Set cookie to force primary database reads for subsequent client-side
       // requests after redirect. This prevents replication lag issues when the
       // user record hasn't replicated to read replicas yet.

--- a/apps/dashboard/src/utils/new-user-gate.ts
+++ b/apps/dashboard/src/utils/new-user-gate.ts
@@ -1,0 +1,6 @@
+export const NEW_USER_CUTOFF = "2026-04-20T00:00:00.000Z";
+
+export function isBlockedNewUser(createdAt: string | null | undefined) {
+  if (!createdAt) return false;
+  return new Date(createdAt) >= new Date(NEW_USER_CUTOFF);
+}


### PR DESCRIPTION
Users whose Supabase auth created_at is on/after NEW_USER_CUTOFF now see an inline waitlist message in place of the sign-in options.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new-user cutoff check into OAuth and OTP auth flows and changes login rendering based on auth state, which can affect sign-in/redirect behavior for legitimate users if the cutoff logic is wrong.
> 
> **Overview**
> Introduces a *new-user gate* based on Supabase `created_at`, with a shared `isBlockedNewUser` helper and `NEW_USER_CUTOFF` constant.
> 
> Blocked users are now signed out and redirected to `/login?waitlist=1` during both the OAuth callback and OTP verification, and the login page conditionally replaces sign-in options with an inline waitlist notice when `waitlist=1` is present or the current auth user falls after the cutoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5881328ab90c6996bb0f5014e0925497934de270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->