### PR TITLE
fix(dashboard): enforce waitlist in app layout

### DIFF
--- a/apps/dashboard/src/app/[locale]/(app)/layout.tsx
+++ b/apps/dashboard/src/app/[locale]/(app)/layout.tsx
@@ -1,0 +1,21 @@
+import { createClient } from "@midday/supabase/server";
+import { redirect } from "next/navigation";
+import { isBlockedNewUser } from "@/utils/new-user-gate";
+
+export default async function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+
+  if (authUser && isBlockedNewUser(authUser.created_at)) {
+    await supabase.auth.signOut();
+    redirect("/login?waitlist=1");
+  }
+
+  return children;
+}


### PR DESCRIPTION
Block waitlisted users from bypassing /login?waitlist=1 by signing them out and redirecting from the authenticated (app) layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication flow by signing out and redirecting users at the app layout level; mistakes could incorrectly block access or cause redirect loops. Scope is small and limited to the dashboard layout gate.
> 
> **Overview**
> Adds a waitlist enforcement check to the authenticated `(app)` layout: on every request it fetches the current Supabase user, and if the user is considered a *blocked new user* it signs them out and redirects to `\/login?waitlist=1`.
> 
> This closes a gap where waitlisted accounts could potentially access the app shell despite the existing waitlist checks elsewhere (e.g., during OTP verification/login).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44dd000119bf8e2eb274d0c798f391db443cc6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->