### PR TITLE
Add Midday Computer: API, compute runtime, CLI, database, and integrations

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,6 +28,7 @@ jobs:
       TURBO_SCM_BASE: ${{ github.event.before }}
     outputs:
       api: ${{ steps.affected.outputs.api }}
+      compute: ${{ steps.affected.outputs.compute }}
       dashboard: ${{ steps.affected.outputs.dashboard }}
       worker: ${{ steps.affected.outputs.worker }}
       website: ${{ steps.affected.outputs.website }}
@@ -45,6 +46,7 @@ jobs:
           AFFECTED=$(bunx turbo build --affected --dry-run=json 2>/dev/null | jq -r '.packages[]' 2>/dev/null || echo "")
           echo "Affected packages: $AFFECTED"
           echo "api=$(echo "$AFFECTED" | grep -q '@midday/api' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "compute=$(echo "$AFFECTED" | grep -q '@midday/compute' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "dashboard=$(echo "$AFFECTED" | grep -q '@midday/dashboard' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "worker=$(echo "$AFFECTED" | grep -q '@midday/worker' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "website=$(echo "$AFFECTED" | grep -q '@midday/website' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
@@ -232,6 +234,31 @@ jobs:
 
       - name: Deploy to Railway
         run: npx @railway/cli up --service worker
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Deploy Compute to Railway (waits for API when both change)
+  # ---------------------------------------------------------------------------
+  deploy-compute:
+    name: Deploy Compute
+    needs: [detect-changes, validate, deploy-api]
+    if: >-
+      always() &&
+      needs.validate.result == 'success' &&
+      needs.detect-changes.outputs.compute == 'true' &&
+      (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped')
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 20
+    concurrency: railway-compute-production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stamp git SHA for Docker build
+        run: echo "${{ github.sha }}" > .git-commit-sha
+
+      - name: Deploy to Railway
+        run: npx @railway/cli up --service compute
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,6 +28,7 @@ jobs:
       TURBO_SCM_BASE: origin/main
     outputs:
       api: ${{ steps.affected.outputs.api }}
+      compute: ${{ steps.affected.outputs.compute }}
       dashboard: ${{ steps.affected.outputs.dashboard }}
       worker: ${{ steps.affected.outputs.worker }}
       website: ${{ steps.affected.outputs.website }}
@@ -45,6 +46,7 @@ jobs:
           AFFECTED=$(bunx turbo build --affected --dry-run=json 2>/dev/null | jq -r '.packages[]' 2>/dev/null || echo "")
           echo "Affected packages: $AFFECTED"
           echo "api=$(echo "$AFFECTED" | grep -q '@midday/api' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "compute=$(echo "$AFFECTED" | grep -q '@midday/compute' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "dashboard=$(echo "$AFFECTED" | grep -q '@midday/dashboard' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "worker=$(echo "$AFFECTED" | grep -q '@midday/worker' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "website=$(echo "$AFFECTED" | grep -q '@midday/website' && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
@@ -232,6 +234,31 @@ jobs:
 
       - name: Deploy to Railway
         run: npx @railway/cli up --service worker --environment staging
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_STAGING }}
+
+  # ---------------------------------------------------------------------------
+  # Deploy Compute to Railway staging (waits for API when both change)
+  # ---------------------------------------------------------------------------
+  deploy-compute-staging:
+    name: Deploy Compute (staging)
+    needs: [detect-changes, validate, deploy-api-staging]
+    if: >-
+      always() &&
+      needs.validate.result == 'success' &&
+      needs.detect-changes.outputs.compute == 'true' &&
+      (needs.deploy-api-staging.result == 'success' || needs.deploy-api-staging.result == 'skipped')
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 20
+    concurrency: railway-compute-staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stamp git SHA for Docker build
+        run: echo "${{ github.sha }}" > .git-commit-sha
+
+      - name: Deploy to Railway
+        run: npx @railway/cli up --service compute --environment staging
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_STAGING }}
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -52,6 +52,7 @@
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@polar-sh/sdk": "^0.46.7",
     "@scalar/hono-api-reference": "^0.10.5",
+    "@secure-exec/typescript": "^0.2.1",
     "@sentry/bun": "catalog:",
     "@sindresorhus/slugify": "catalog:",
     "@trigger.dev/sdk": "catalog:",
@@ -61,6 +62,7 @@
     "hono": "catalog:",
     "hono-rate-limiter": "0.5.3",
     "jose": "catalog:",
+    "json-schema-to-typescript": "^15.0.4",
     "lru-cache": "^11.2.7",
     "nanoid": "catalog:",
     "parse-duration": "^2.1.5",
@@ -69,7 +71,8 @@
     "superjson": "^2.2.6",
     "toolpick": "0.4.0",
     "uuid": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/apps/api/src/chat/prompt.ts
+++ b/apps/api/src/chat/prompt.ts
@@ -20,7 +20,7 @@ export interface UserContext {
 }
 
 const MIDDAY_DOMAINS =
-  "transactions, invoices, customers, time tracking, reports, categories, tags, inbox, documents, bank accounts, team";
+  "transactions, invoices, customers, time tracking, reports, categories, tags, inbox, documents, bank accounts, team, computer agents";
 
 export function buildSystemPrompt(ctx: UserContext): string {
   const dateCtx = getDateContext(ctx.timezone);
@@ -71,6 +71,9 @@ When a question involves both external information and the user's finances, use 
 - "Can I afford X?" → search for the price, then check bank balances or runway.
 - "What's the VAT rate for my country?" → search for the rate, then check relevant transactions.
 - "How does my revenue compare to industry average?" → search for benchmarks, then pull revenue data.
+
+### Computer agents (automation)
+You can help users set up AI agents that run on autopilot. Use \`computer_catalog_list\` to show available pre-built agents. Use \`computer_agent_enable\` to install one. For custom workflows, use \`computer_agent_generate\` with the user's description, present the generated plan (name, schedule, tools used) to the user, and wait for explicit confirmation before calling \`computer_agent_confirm\` to deploy. Use \`computer_agents_list\` to see installed agents, \`computer_agent_run\` to trigger one, and \`computer_agent_runs\` to check results. Always explain what an agent will do before enabling or deploying it.
 
 ### Connected apps (external services)
 You have meta tools (COMPOSIO_SEARCH_TOOLS, COMPOSIO_MULTI_EXECUTE_TOOL) to interact with external services the user has connected (e.g. Gmail, Slack, Google Calendar, Notion, GitHub, Linear).

--- a/apps/api/src/chat/tools.ts
+++ b/apps/api/src/chat/tools.ts
@@ -56,6 +56,9 @@ export function ensureToolIndex(ctx: McpContext): Promise<ToolIndex<any>> {
         tracker_entries_list: ["tracker_projects_list"],
         tracker_projects_list: ["tracker_entries_list"],
         transactions_update: ["categories_list"],
+        computer_agent_enable: ["computer_catalog_list"],
+        computer_agent_generate: ["computer_agent_confirm"],
+        computer_agent_run: ["computer_agents_list", "computer_agent_runs"],
       },
     });
 

--- a/apps/api/src/mcp/schemas.ts
+++ b/apps/api/src/mcp/schemas.ts
@@ -501,6 +501,16 @@ export const mcpTeamMemberSchema = z.object({
 });
 
 // ============================================================
+// Shared pagination meta schema
+// ============================================================
+
+export const mcpListMetaSchema = z.object({
+  cursor: z.string().nullable(),
+  hasNextPage: z.boolean(),
+  hasPreviousPage: z.boolean(),
+});
+
+// ============================================================
 // Utility: safe parse with allowlist fallback
 // ============================================================
 

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -5,6 +5,7 @@ import { registerResources } from "./resources";
 import {
   registerBankAccountTools,
   registerCategoryTools,
+  registerComputerTools,
   registerCustomerTools,
   registerDocumentTools,
   registerInboxTools,
@@ -67,6 +68,7 @@ Tools are namespaced by domain — use the prefix to discover related tools:
 - invoice_recurring_* — Recurring invoice schedules
 - tags_* — Reusable labels for organizing records
 - team_* — Team metadata and member information
+- computer_* — AI agent automation (catalog, create, run, history)
 - search_global — Full-text search across all data types
 
 ## Key Patterns
@@ -127,6 +129,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
   registerInboxTools(server, ctx);
   registerTagTools(server, ctx);
   registerTeamTools(server, ctx);
+  registerComputerTools(server, ctx);
 
   registerMcpApps(server);
 

--- a/apps/api/src/mcp/tools/bank-accounts.ts
+++ b/apps/api/src/mcp/tools/bank-accounts.ts
@@ -35,7 +35,7 @@ export const registerBankAccountTools: RegisterTools = (server, ctx) => {
         "List all connected bank accounts for the team. Returns account name, type, balance, currency, and connection info (institution name and logo). Filter by enabled/manual to narrow results.",
       inputSchema: getBankAccountsSchema.shape,
       outputSchema: {
-        data: z.array(z.record(z.string(), z.any())),
+        data: z.array(mcpBankAccountSchema),
       },
       annotations: READ_ONLY_ANNOTATIONS,
     },
@@ -63,7 +63,7 @@ export const registerBankAccountTools: RegisterTools = (server, ctx) => {
         "Get current balances for all bank accounts. Returns each account's balance, currency, and name. Use this for a quick cash position overview.",
       inputSchema: {},
       outputSchema: {
-        data: z.array(z.record(z.string(), z.any())),
+        data: z.array(mcpBankAccountBalanceSchema),
       },
       annotations: READ_ONLY_ANNOTATIONS,
     },
@@ -86,7 +86,7 @@ export const registerBankAccountTools: RegisterTools = (server, ctx) => {
         "List all unique currencies across connected bank accounts. Useful for multi-currency reporting.",
       inputSchema: {},
       outputSchema: {
-        data: z.array(z.record(z.string(), z.any())),
+        data: z.array(mcpBankAccountCurrencySchema),
       },
       annotations: READ_ONLY_ANNOTATIONS,
     },
@@ -109,7 +109,7 @@ export const registerBankAccountTools: RegisterTools = (server, ctx) => {
         "Get banking details for a specific account including IBAN, account number, routing number, BIC, and sort code. Only available for accounts that have this information on file.",
       inputSchema: getBankAccountDetailsSchema.shape,
       outputSchema: {
-        data: z.record(z.string(), z.any()).nullable(),
+        data: mcpBankAccountDetailsSchema.nullable(),
       },
       annotations: READ_ONLY_ANNOTATIONS,
     },

--- a/apps/api/src/mcp/tools/categories.ts
+++ b/apps/api/src/mcp/tools/categories.ts
@@ -48,7 +48,7 @@ export const registerCategoryTools: RegisterTools = (server, ctx) => {
             ),
         },
         outputSchema: {
-          data: z.array(z.record(z.string(), z.any())),
+          data: z.array(mcpCategoryDetailSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -77,7 +77,7 @@ export const registerCategoryTools: RegisterTools = (server, ctx) => {
           id: getCategoryByIdSchema.shape.id,
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpCategoryDetailSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -117,6 +117,9 @@ export const registerCategoryTools: RegisterTools = (server, ctx) => {
           taxReportingCode:
             createTransactionCategorySchema.shape.taxReportingCode,
           parentId: createTransactionCategorySchema.shape.parentId,
+        },
+        outputSchema: {
+          data: mcpCategoryDetailSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -181,6 +184,9 @@ export const registerCategoryTools: RegisterTools = (server, ctx) => {
             updateTransactionCategorySchema.shape.taxReportingCode,
           parentId: updateTransactionCategorySchema.shape.parentId,
         },
+        outputSchema: {
+          data: mcpCategoryDetailSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -237,6 +243,10 @@ export const registerCategoryTools: RegisterTools = (server, ctx) => {
           "Delete a custom transaction category by ID. System default categories cannot be deleted. Returns the deleted category.",
         inputSchema: {
           id: deleteTransactionCategorySchema.shape.id,
+        },
+        outputSchema: {
+          success: z.boolean(),
+          deleted: mcpCategoryDetailSchema,
         },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },

--- a/apps/api/src/mcp/tools/computer.ts
+++ b/apps/api/src/mcp/tools/computer.ts
@@ -1,0 +1,310 @@
+import { enqueueRun } from "@midday/job-client";
+import {
+  createComputerAgent,
+  createComputerRun,
+  getComputerAgentBySlug,
+  getComputerAgentForRun,
+  getComputerAgents,
+  getComputerRuns,
+} from "@midday/db/queries";
+import { z } from "zod";
+import { CATALOG_AGENTS } from "../../rest/routers/computer/catalog";
+import { generateAgentFromDescription } from "../../rest/routers/computer/orchestrator";
+import {
+  hasScope,
+  READ_ONLY_ANNOTATIONS,
+  WRITE_ANNOTATIONS,
+  type RegisterTools,
+} from "../types";
+import { withErrorHandling } from "../utils";
+
+export const registerComputerTools: RegisterTools = (server, ctx) => {
+  const { db, teamId, userId } = ctx;
+
+  const hasReadScope = hasScope(ctx, "teams.read");
+  const hasWriteScope = hasScope(ctx, "teams.write");
+
+  if (!hasReadScope) {
+    return;
+  }
+
+  server.registerTool(
+    "computer_catalog_list",
+    {
+      title: "List Agent Catalog",
+      description:
+        "List available pre-built AI agents that can be enabled to automate financial workflows (e.g. invoice chasing, expense monitoring, financial briefings). Returns name, description, and schedule for each.",
+      inputSchema: {},
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    withErrorHandling(async () => {
+      const catalog = CATALOG_AGENTS.map(
+        ({ code, ...rest }) => rest,
+      );
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(catalog) }],
+        structuredContent: { data: catalog },
+      };
+    }, "Failed to list agent catalog"),
+  );
+
+  server.registerTool(
+    "computer_agents_list",
+    {
+      title: "List Team Agents",
+      description:
+        "List all AI agents enabled for the current team, including their ID, name, schedule, and enabled status. Use this to find an agent before running it or checking its history.",
+      inputSchema: {},
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    withErrorHandling(async () => {
+      const agents = await getComputerAgents(db, { teamId });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(agents) }],
+        structuredContent: { data: agents },
+      };
+    }, "Failed to list agents"),
+  );
+
+  if (!hasWriteScope) {
+    return;
+  }
+
+  server.registerTool(
+    "computer_agent_enable",
+    {
+      title: "Enable Catalog Agent",
+      description:
+        "Install and enable a pre-built agent from the catalog. Pass the templateId from computer_catalog_list. The agent starts running on its defined schedule immediately.",
+      inputSchema: {
+        templateId: z
+          .string()
+          .describe("The templateId of the catalog agent to enable"),
+      },
+      annotations: WRITE_ANNOTATIONS,
+    },
+    withErrorHandling(async ({ templateId }) => {
+      const template = CATALOG_AGENTS.find(
+        (a) => a.templateId === templateId,
+      );
+
+      if (!template) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Template "${templateId}" not found. Use computer_catalog_list to see available agents.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const existing = await getComputerAgentBySlug(db, {
+        teamId,
+        slug: template.slug,
+      });
+
+      if (existing) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Agent "${template.name}" is already enabled (id: ${existing.id}).`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const agent = await createComputerAgent(db, {
+        teamId,
+        name: template.name,
+        slug: template.slug,
+        description: template.description,
+        source: "catalog",
+        code: template.code,
+        templateId: template.templateId,
+        scheduleCron: template.scheduleCron,
+        enabled: true,
+        createdBy: userId,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(agent) }],
+        structuredContent: { data: agent },
+      };
+    }, "Failed to enable agent"),
+  );
+
+  server.registerTool(
+    "computer_agent_generate",
+    {
+      title: "Generate Custom Agent",
+      description:
+        "Generate a custom AI agent from a natural language description. Returns a plan with the agent's name, schedule, code, and tools it will use. The user must review and confirm before deployment via computer_agent_confirm.",
+      inputSchema: {
+        description: z
+          .string()
+          .min(10)
+          .describe(
+            "Natural language description of what the agent should do, e.g. 'Every Monday, check for overdue invoices and send me a summary'",
+          ),
+      },
+      annotations: WRITE_ANNOTATIONS,
+    },
+    withErrorHandling(async ({ description }) => {
+      const result = await generateAgentFromDescription(description);
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+        structuredContent: { data: result },
+      };
+    }, "Failed to generate agent"),
+  );
+
+  server.registerTool(
+    "computer_agent_confirm",
+    {
+      title: "Deploy Generated Agent",
+      description:
+        "Deploy a previously generated agent after the user has reviewed and approved the plan. Pass the exact name, slug, code, and description returned by computer_agent_generate.",
+      inputSchema: {
+        name: z.string().describe("Agent display name"),
+        slug: z.string().describe("URL-safe unique slug"),
+        description: z.string().describe("What the agent does"),
+        code: z.string().describe("Compiled JavaScript code from generation"),
+        scheduleCron: z
+          .string()
+          .optional()
+          .describe("Cron expression for scheduled runs"),
+      },
+      annotations: WRITE_ANNOTATIONS,
+    },
+    withErrorHandling(async ({ name, slug, description, code, scheduleCron }) => {
+      const existing = await getComputerAgentBySlug(db, { teamId, slug });
+
+      if (existing) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `An agent with slug "${slug}" already exists.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const agent = await createComputerAgent(db, {
+        teamId,
+        name,
+        slug,
+        description,
+        source: "generated",
+        code,
+        scheduleCron: scheduleCron ?? null,
+        enabled: true,
+        createdBy: userId,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(agent) }],
+        structuredContent: { data: agent },
+      };
+    }, "Failed to deploy agent"),
+  );
+
+  server.registerTool(
+    "computer_agent_run",
+    {
+      title: "Run Agent Now",
+      description:
+        "Trigger an immediate manual run of an agent. Returns the run ID which can be used to check status via computer_agent_runs.",
+      inputSchema: {
+        agentId: z.string().uuid().describe("The agent ID to run"),
+      },
+      annotations: WRITE_ANNOTATIONS,
+    },
+    withErrorHandling(async ({ agentId }) => {
+      const agent = await getComputerAgentForRun(db, { id: agentId, teamId });
+
+      if (!agent) {
+        return {
+          content: [{ type: "text" as const, text: "Agent not found." }],
+          isError: true,
+        };
+      }
+
+      if (!agent.enabled) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Agent is disabled. Enable it before triggering a run.",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const runId = crypto.randomUUID();
+
+      await createComputerRun(db, {
+        id: runId,
+        agentId,
+        teamId,
+      });
+
+      await enqueueRun({
+        agentId,
+        teamId,
+        runId,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ runId, status: "pending" }),
+          },
+        ],
+        structuredContent: { data: { runId, status: "pending" } },
+      };
+    }, "Failed to run agent"),
+  );
+
+  server.registerTool(
+    "computer_agent_runs",
+    {
+      title: "List Agent Runs",
+      description:
+        "List recent runs for a specific agent, including status, summary, errors, and timing. Use this to check what an agent found or whether a run completed successfully.",
+      inputSchema: {
+        agentId: z.string().uuid().describe("The agent ID"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .default(10)
+          .describe("Number of runs to return (default 10)"),
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    withErrorHandling(async ({ agentId, limit }) => {
+      const runs = await getComputerRuns(db, {
+        agentId,
+        teamId,
+        limit: limit ?? 10,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(runs) }],
+        structuredContent: { data: runs },
+      };
+    }, "Failed to list agent runs"),
+  );
+};

--- a/apps/api/src/mcp/tools/customers.ts
+++ b/apps/api/src/mcp/tools/customers.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import {
   mcpCustomerDetailSchema,
   mcpCustomerListItemSchema,
+  mcpListMetaSchema,
   sanitize,
   sanitizeArray,
 } from "../schemas";
@@ -70,12 +71,8 @@ export const registerCustomerTools: RegisterTools = (server, ctx) => {
             .describe("Sort direction"),
         },
         outputSchema: {
-          meta: z.looseObject({
-            cursor: z.string().nullable().optional(),
-            hasNextPage: z.boolean(),
-            hasPreviousPage: z.boolean(),
-          }),
-          data: z.array(z.record(z.string(), z.any())),
+          meta: mcpListMetaSchema,
+          data: z.array(mcpCustomerListItemSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -120,7 +117,7 @@ export const registerCustomerTools: RegisterTools = (server, ctx) => {
           id: getCustomerByIdSchema.shape.id,
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpCustomerDetailSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -168,6 +165,9 @@ export const registerCustomerTools: RegisterTools = (server, ctx) => {
           vatNumber: upsertCustomerSchema.shape.vatNumber,
           note: upsertCustomerSchema.shape.note,
           tags: upsertCustomerSchema.shape.tags,
+        },
+        outputSchema: {
+          data: mcpCustomerDetailSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -241,6 +241,9 @@ export const registerCustomerTools: RegisterTools = (server, ctx) => {
           note: upsertCustomerSchema.shape.note,
           tags: upsertCustomerSchema.shape.tags,
         },
+        outputSchema: {
+          data: mcpCustomerDetailSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -309,6 +312,10 @@ export const registerCustomerTools: RegisterTools = (server, ctx) => {
           "Permanently delete a customer by ID. Will fail if the customer has associated invoices or projects — remove those first.",
         inputSchema: {
           id: deleteCustomerSchema.shape.id,
+        },
+        outputSchema: {
+          success: z.boolean(),
+          deleted: z.record(z.string(), z.any()),
         },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },

--- a/apps/api/src/mcp/tools/documents.ts
+++ b/apps/api/src/mcp/tools/documents.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import {
   mcpDocumentSchema,
   mcpDocumentTagSchema,
+  mcpListMetaSchema,
   sanitize,
   sanitizeArray,
 } from "../schemas";
@@ -53,12 +54,8 @@ export const registerDocumentTools: RegisterTools = (server, ctx) => {
           "List documents and files stored in the vault. Supports free-text search and filtering by document tag IDs (from document_tags_list, not tags_list). Returns paginated results (default 25) with document name, type, size, and creation date.",
         inputSchema: documentsListFields,
         outputSchema: {
-          meta: z.looseObject({
-            cursor: z.string().nullable().optional(),
-            hasNextPage: z.boolean(),
-            hasPreviousPage: z.boolean(),
-          }),
-          data: z.array(z.record(z.string(), z.any())),
+          meta: mcpListMetaSchema,
+          data: z.array(mcpDocumentSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -102,6 +99,9 @@ export const registerDocumentTools: RegisterTools = (server, ctx) => {
             .optional()
             .default(false)
             .describe("Include the file content as a downloadable resource"),
+        },
+        outputSchema: {
+          data: mcpDocumentSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -161,7 +161,7 @@ export const registerDocumentTools: RegisterTools = (server, ctx) => {
           "List all document tags for the team. These tags are separate from transaction tags and are used to organize documents in the vault.",
         inputSchema: {},
         outputSchema: {
-          data: z.array(z.record(z.string(), z.any())),
+          data: z.array(mcpDocumentTagSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -186,6 +186,10 @@ export const registerDocumentTools: RegisterTools = (server, ctx) => {
           "Permanently delete a document from the vault. Removes the file and all metadata. This action cannot be undone.",
         inputSchema: {
           id: z.string().uuid().describe("Document ID to delete"),
+        },
+        outputSchema: {
+          success: z.boolean(),
+          deletedId: z.string(),
         },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
@@ -234,6 +238,9 @@ export const registerDocumentTools: RegisterTools = (server, ctx) => {
           "Create a new document tag for organizing files in the vault. Tag names are auto-slugified.",
         inputSchema: {
           name: z.string().min(1).describe("Tag name"),
+        },
+        outputSchema: {
+          data: mcpDocumentTagSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -285,6 +292,10 @@ export const registerDocumentTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           id: z.string().uuid().describe("Document tag ID to delete"),
         },
+        outputSchema: {
+          success: z.boolean(),
+          deletedId: z.string(),
+        },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -334,6 +345,11 @@ export const registerDocumentTools: RegisterTools = (server, ctx) => {
           documentId: z.string().uuid().describe("Document ID"),
           tagId: z.string().uuid().describe("Document tag ID to assign"),
         },
+        outputSchema: {
+          success: z.boolean(),
+          documentId: z.string(),
+          tagId: z.string(),
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async ({ documentId, tagId }) => {
@@ -378,6 +394,11 @@ export const registerDocumentTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           documentId: z.string().uuid().describe("Document ID"),
           tagId: z.string().uuid().describe("Document tag ID to remove"),
+        },
+        outputSchema: {
+          success: z.boolean(),
+          documentId: z.string(),
+          tagId: z.string(),
         },
         annotations: WRITE_ANNOTATIONS,
       },

--- a/apps/api/src/mcp/tools/inbox.ts
+++ b/apps/api/src/mcp/tools/inbox.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import {
   mcpInboxDetailSchema,
   mcpInboxItemSchema,
+  mcpListMetaSchema,
   sanitize,
   sanitizeArray,
 } from "../schemas";
@@ -60,12 +61,8 @@ export const registerInboxTools: RegisterTools = (server, ctx) => {
           "List inbox items (uploaded receipts, invoices, and documents pending processing). Filter by status (pending, done, suggested_match, no_match, other). Returns paginated results (default 25) with file name, status, and matched transaction.",
         inputSchema: getInboxSchema.shape,
         outputSchema: {
-          meta: z.looseObject({
-            cursor: z.string().nullable().optional(),
-            hasNextPage: z.boolean(),
-            hasPreviousPage: z.boolean(),
-          }),
-          data: z.array(z.record(z.string(), z.any())),
+          meta: mcpListMetaSchema,
+          data: z.array(mcpInboxItemSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -111,6 +108,9 @@ export const registerInboxTools: RegisterTools = (server, ctx) => {
             .optional()
             .default(false)
             .describe("Include the file content as a downloadable resource"),
+        },
+        outputSchema: {
+          data: mcpInboxDetailSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -183,6 +183,9 @@ export const registerInboxTools: RegisterTools = (server, ctx) => {
           currency: updateInboxSchema.shape.currency,
           amount: updateInboxSchema.shape.amount,
         },
+        outputSchema: {
+          data: mcpInboxDetailSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -237,6 +240,10 @@ export const registerInboxTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           id: deleteInboxSchema.shape.id,
         },
+        outputSchema: {
+          success: z.boolean(),
+          deletedId: z.string(),
+        },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -285,6 +292,10 @@ export const registerInboxTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           id: matchTransactionSchema.shape.id,
           transactionId: matchTransactionSchema.shape.transactionId,
+        },
+        outputSchema: {
+          message: z.string(),
+          item: mcpInboxDetailSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -351,6 +362,10 @@ export const registerInboxTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           id: unmatchTransactionSchema.shape.id,
         },
+        outputSchema: {
+          success: z.boolean(),
+          unmatched: z.string(),
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -390,6 +405,10 @@ export const registerInboxTools: RegisterTools = (server, ctx) => {
         description:
           "Confirm an AI-suggested match between an inbox item and a transaction. This links them together as if manually matched.",
         inputSchema: confirmMatchSchema.shape,
+        outputSchema: {
+          message: z.string(),
+          item: mcpInboxDetailSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -449,6 +468,10 @@ export const registerInboxTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           suggestionId: declineMatchSchema.shape.suggestionId,
           inboxId: declineMatchSchema.shape.inboxId,
+        },
+        outputSchema: {
+          success: z.boolean(),
+          message: z.string(),
         },
         annotations: WRITE_ANNOTATIONS,
       },

--- a/apps/api/src/mcp/tools/index.ts
+++ b/apps/api/src/mcp/tools/index.ts
@@ -1,5 +1,6 @@
 export { registerBankAccountTools } from "./bank-accounts";
 export { registerCategoryTools } from "./categories";
+export { registerComputerTools } from "./computer";
 export { registerCustomerTools } from "./customers";
 export { registerDocumentTools } from "./documents";
 export { registerInboxTools } from "./inbox";

--- a/apps/api/src/mcp/tools/invoice-products.ts
+++ b/apps/api/src/mcp/tools/invoice-products.ts
@@ -57,7 +57,7 @@ export const registerInvoiceProductTools: RegisterTools = (server, ctx) => {
           currency: z.string().optional().describe("Filter by currency code"),
         },
         outputSchema: {
-          data: z.array(z.record(z.string(), z.any())),
+          data: z.array(mcpInvoiceProductSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -88,7 +88,7 @@ export const registerInvoiceProductTools: RegisterTools = (server, ctx) => {
           id: getInvoiceProductSchema.shape.id,
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpInvoiceProductSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -129,6 +129,9 @@ export const registerInvoiceProductTools: RegisterTools = (server, ctx) => {
           unit: createInvoiceProductSchema.shape.unit,
           taxRate: createInvoiceProductSchema.shape.taxRate,
           isActive: createInvoiceProductSchema.shape.isActive,
+        },
+        outputSchema: {
+          data: mcpInvoiceProductSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -184,6 +187,9 @@ export const registerInvoiceProductTools: RegisterTools = (server, ctx) => {
           unit: updateInvoiceProductSchema.shape.unit,
           taxRate: updateInvoiceProductSchema.shape.taxRate,
           isActive: updateInvoiceProductSchema.shape.isActive,
+        },
+        outputSchema: {
+          data: mcpInvoiceProductSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -244,6 +250,10 @@ export const registerInvoiceProductTools: RegisterTools = (server, ctx) => {
           "Delete an invoice product by ID. This does not affect existing invoices that used this product.",
         inputSchema: {
           id: deleteInvoiceProductSchema.shape.id,
+        },
+        outputSchema: {
+          success: z.boolean(),
+          deletedId: z.string(),
         },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },

--- a/apps/api/src/mcp/tools/invoice-recurring.ts
+++ b/apps/api/src/mcp/tools/invoice-recurring.ts
@@ -8,7 +8,11 @@ import {
   resumeInvoiceRecurring,
 } from "@midday/db/queries";
 import { z } from "zod";
-import { sanitize, sanitizeArray } from "../schemas";
+import {
+  mcpListMetaSchema,
+  sanitize,
+  sanitizeArray,
+} from "../schemas";
 import {
   DESTRUCTIVE_ANNOTATIONS,
   hasScope,
@@ -50,6 +54,21 @@ const mcpRecurringInvoiceSchema = z.object({
     .optional(),
 });
 
+const mcpUpcomingInvoicePreviewSchema = z.object({
+  invoices: z.array(
+    z.object({
+      date: z.string(),
+      amount: z.number(),
+    }),
+  ),
+  summary: z.object({
+    hasEndDate: z.boolean(),
+    totalCount: z.number().nullable(),
+    totalAmount: z.number().nullable(),
+    currency: z.string(),
+  }),
+});
+
 export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
   const { db, teamId } = ctx;
 
@@ -86,11 +105,8 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
             .describe("Filter by customer ID"),
         },
         outputSchema: {
-          meta: z.looseObject({
-            cursor: z.string().nullable().optional(),
-            hasNextPage: z.boolean(),
-          }),
-          data: z.array(z.record(z.string(), z.any())),
+          meta: mcpListMetaSchema,
+          data: z.array(mcpRecurringInvoiceSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -131,7 +147,7 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
           id: z.string().uuid().describe("Recurring invoice schedule ID"),
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpRecurringInvoiceSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -172,7 +188,7 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
             .describe("Number of upcoming invoices to preview (default 6)"),
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpUpcomingInvoicePreviewSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -195,9 +211,11 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
           };
         }
 
+        const clean = sanitize(mcpUpcomingInvoicePreviewSchema, result);
+
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(result) }],
-          structuredContent: { data: result },
+          content: [{ type: "text" as const, text: JSON.stringify(clean) }],
+          structuredContent: { data: clean },
         };
       }, "Failed to get upcoming invoices"),
     );
@@ -278,6 +296,9 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
             .optional()
             .describe("Days after issue date for the due date (default 30)"),
         },
+        outputSchema: {
+          data: mcpRecurringInvoiceSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -342,6 +363,9 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
             .uuid()
             .describe("Recurring invoice schedule ID to pause"),
         },
+        outputSchema: {
+          data: mcpRecurringInvoiceSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -368,14 +392,11 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
                 type: "text",
                 text: JSON.stringify({
                   message: "Recurring invoice paused",
-                  schedule: clean,
+                  data: clean,
                 }),
               },
             ],
-            structuredContent: {
-              message: "Recurring invoice paused",
-              schedule: clean,
-            },
+            structuredContent: { data: clean },
           };
         } catch (error) {
           return {
@@ -406,6 +427,9 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
             .uuid()
             .describe("Recurring invoice schedule ID to resume"),
         },
+        outputSchema: {
+          data: mcpRecurringInvoiceSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -432,14 +456,11 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
                 type: "text",
                 text: JSON.stringify({
                   message: "Recurring invoice resumed",
-                  schedule: clean,
+                  data: clean,
                 }),
               },
             ],
-            structuredContent: {
-              message: "Recurring invoice resumed",
-              schedule: clean,
-            },
+            structuredContent: { data: clean },
           };
         } catch (error) {
           return {
@@ -469,6 +490,10 @@ export const registerInvoiceRecurringTools: RegisterTools = (server, ctx) => {
             .string()
             .uuid()
             .describe("Recurring invoice schedule ID to delete"),
+        },
+        outputSchema: {
+          success: z.boolean(),
+          deletedId: z.string(),
         },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },

--- a/apps/api/src/mcp/tools/invoice-templates.ts
+++ b/apps/api/src/mcp/tools/invoice-templates.ts
@@ -37,6 +37,9 @@ export const registerInvoiceTemplateTools: RegisterTools = (server, ctx) => {
         description:
           "List all invoice templates for the team. Returns template names, labels, and settings. Use this to see available templates before updating one.",
         inputSchema: {},
+        outputSchema: {
+          data: z.array(mcpInvoiceTemplateSchema),
+        },
         annotations: READ_ONLY_ANNOTATIONS,
       },
       withErrorHandling(async () => {
@@ -53,7 +56,7 @@ export const registerInvoiceTemplateTools: RegisterTools = (server, ctx) => {
 
         return {
           content: [{ type: "text" as const, text }],
-          structuredContent,
+          structuredContent: { data: structuredContent.data },
         };
       }, "Failed to list invoice templates"),
     );
@@ -72,6 +75,10 @@ export const registerInvoiceTemplateTools: RegisterTools = (server, ctx) => {
             .describe(
               "Template ID. If omitted, returns the default (or first) template.",
             ),
+        },
+        outputSchema: {
+          data: mcpInvoiceTemplateSchema,
+          previewUrl: z.string().nullable(),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -96,13 +103,17 @@ export const registerInvoiceTemplateTools: RegisterTools = (server, ctx) => {
 
         const clean = sanitize(mcpInvoiceTemplateSchema, template);
 
+        const previewUrl = `${DASHBOARD_URL}/invoices`;
         const response = {
-          ...clean,
-          previewUrl: `${DASHBOARD_URL}/invoices`,
+          data: clean,
+          previewUrl,
         };
 
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(response) }],
+          content: [
+            { type: "text" as const, text: JSON.stringify(response) },
+          ],
+          structuredContent: response,
         };
       }, "Failed to get invoice template"),
     );
@@ -310,6 +321,11 @@ export const registerInvoiceTemplateTools: RegisterTools = (server, ctx) => {
               "Default footer note for new invoices (plain text, line breaks preserved). e.g. thank you message, terms.",
             ),
         },
+        outputSchema: {
+          message: z.string(),
+          template: mcpInvoiceTemplateSchema,
+          previewUrl: z.string().nullable(),
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -400,6 +416,7 @@ export const registerInvoiceTemplateTools: RegisterTools = (server, ctx) => {
             content: [
               { type: "text" as const, text: JSON.stringify(response) },
             ],
+            structuredContent: response,
           };
         } catch (error) {
           return {

--- a/apps/api/src/mcp/tools/invoices.ts
+++ b/apps/api/src/mcp/tools/invoices.ts
@@ -40,6 +40,7 @@ import { z } from "zod";
 import {
   mcpInvoiceDetailSchema,
   mcpInvoiceListItemSchema,
+  mcpListMetaSchema,
   sanitize,
   sanitizeArray,
 } from "../schemas";
@@ -132,12 +133,8 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
             .describe("Sort direction"),
         },
         outputSchema: {
-          meta: z.looseObject({
-            cursor: z.string().nullable().optional(),
-            hasNextPage: z.boolean(),
-            hasPreviousPage: z.boolean(),
-          }),
-          data: z.array(z.record(z.string(), z.any())),
+          meta: mcpListMetaSchema,
+          data: z.array(mcpInvoiceListItemSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -296,7 +293,7 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
           query: z.string().describe("Invoice number to search for"),
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()).nullable(),
+          data: mcpInvoiceListItemSchema.nullable(),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -417,6 +414,9 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
             .optional()
             .describe("Internal note visible only to your team"),
         },
+        outputSchema: {
+          data: mcpInvoiceDetailSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -494,6 +494,9 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
             .describe(
               "Payment date in ISO 8601 format (defaults to current time)",
             ),
+        },
+        outputSchema: {
+          data: mcpInvoiceDetailSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -576,6 +579,10 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           id: deleteInvoiceSchema.shape.id,
         },
+        outputSchema: {
+          success: z.boolean(),
+          deletedId: z.string(),
+        },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -645,6 +652,9 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           id: duplicateInvoiceSchema.shape.id,
         },
+        outputSchema: {
+          data: mcpInvoiceDetailSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -705,6 +715,9 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
           "Cancel an invoice. Cannot cancel an invoice that is already paid. After cancellation the invoice can be deleted if needed.",
         inputSchema: {
           id: z.string().uuid().describe("The ID of the invoice to cancel"),
+        },
+        outputSchema: {
+          data: mcpInvoiceDetailSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -788,6 +801,12 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
             .string()
             .uuid()
             .describe("ID of the invoice to send a reminder for"),
+        },
+        outputSchema: {
+          message: z.string(),
+          invoiceId: z.string(),
+          reminderSentAt: z.string(),
+          previewUrl: z.string().nullable(),
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -1563,6 +1582,13 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
               "Override recipient email address (defaults to customer's email on file)",
             ),
         },
+        outputSchema: {
+          message: z.string(),
+          invoiceId: z.string(),
+          sentTo: z.string(),
+          previewUrl: z.string().nullable(),
+          data: mcpInvoiceDetailSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async ({ id, sentTo }) => {
@@ -1617,15 +1643,34 @@ export const registerInvoiceTools: RegisterTools = (server, ctx) => {
             "invoices",
           );
 
-          const previewUrl = existing.token
-            ? `${DASHBOARD_URL}/i/${existing.token}`
+          const fresh = await getInvoiceById(db, { id, teamId });
+
+          if (!fresh) {
+            return {
+              content: [{ type: "text", text: "Invoice not found after send" }],
+              isError: true,
+            };
+          }
+
+          const pdfUrl = fresh.token
+            ? `${apiUrl}/files/download/invoice?token=${encodeURIComponent(fresh.token)}`
             : null;
+          const previewUrl = fresh.token
+            ? `${DASHBOARD_URL}/i/${fresh.token}`
+            : null;
+
+          const data = sanitize(mcpInvoiceDetailSchema, {
+            ...fresh,
+            pdfUrl,
+            previewUrl,
+          });
 
           const response = {
             message: `Invoice ${existing.invoiceNumber} is being sent to ${recipientEmail}`,
             invoiceId: id,
             sentTo: recipientEmail,
             previewUrl,
+            data,
           };
 
           return {

--- a/apps/api/src/mcp/tools/search.ts
+++ b/apps/api/src/mcp/tools/search.ts
@@ -20,7 +20,7 @@ export const registerSearchTools: RegisterTools = (server, ctx) => {
         "Full-text search across all data types: transactions, invoices, customers, documents, inbox items, and more. Results are ranked by relevance. This is the fastest way to find something when you don't know which domain it belongs to. Returns up to 30 results by default (configurable via limit, max 1000).",
       inputSchema: globalSearchSchema.shape,
       outputSchema: {
-        data: z.array(z.record(z.string(), z.any())),
+        data: z.array(mcpSearchResultSchema),
       },
       annotations: READ_ONLY_ANNOTATIONS,
     },

--- a/apps/api/src/mcp/tools/tags.ts
+++ b/apps/api/src/mcp/tools/tags.ts
@@ -40,7 +40,7 @@ export const registerTagTools: RegisterTools = (server, ctx) => {
           "List all transaction/project tags. Returns tag ID and name. Use these tag IDs for the tags filter in transactions_list and tracker_projects_list. For document tags, use document_tags_list instead.",
         inputSchema: {},
         outputSchema: {
-          data: z.array(z.record(z.string(), z.any())),
+          data: z.array(mcpTagResponseSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -66,7 +66,7 @@ export const registerTagTools: RegisterTools = (server, ctx) => {
           id: z.string().uuid().describe("Tag ID"),
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpTagResponseSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -98,6 +98,9 @@ export const registerTagTools: RegisterTools = (server, ctx) => {
         description:
           "Create a new transaction/project tag. Tags can be used to label and filter transactions in transactions_list and projects in tracker_projects_list. Use tags_list first to check if the tag already exists.",
         inputSchema: createTagSchema.shape,
+        outputSchema: {
+          data: mcpTagResponseSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -141,6 +144,9 @@ export const registerTagTools: RegisterTools = (server, ctx) => {
         description:
           "Rename an existing transaction/project tag by ID. The updated name will apply to all transactions and projects that use this tag.",
         inputSchema: updateTagSchema.shape,
+        outputSchema: {
+          data: mcpTagResponseSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -181,6 +187,9 @@ export const registerTagTools: RegisterTools = (server, ctx) => {
         description:
           "Delete a transaction/project tag by ID. Removes the tag from all transactions and projects it was applied to. This action cannot be undone.",
         inputSchema: deleteTagSchema.shape,
+        outputSchema: {
+          data: mcpTagResponseSchema,
+        },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
       withErrorHandling(async (params) => {

--- a/apps/api/src/mcp/tools/team.ts
+++ b/apps/api/src/mcp/tools/team.ts
@@ -24,7 +24,7 @@ export const registerTeamTools: RegisterTools = (server, ctx) => {
         "Get current team details including name, base currency, country code, plan, and fiscal year settings. Call this first when you need to know the team's default currency for formatting.",
       inputSchema: {},
       outputSchema: {
-        data: z.record(z.string(), z.any()),
+        data: mcpTeamSchema,
       },
       annotations: READ_ONLY_ANNOTATIONS,
     },
@@ -55,7 +55,7 @@ export const registerTeamTools: RegisterTools = (server, ctx) => {
         "List all members of the current team with their user ID, name, email, avatar, and role. Use the user ID from the response as assignedId when assigning transactions or creating tracker entries.",
       inputSchema: {},
       outputSchema: {
-        data: z.array(z.record(z.string(), z.any())),
+        data: z.array(mcpTeamMemberSchema),
       },
       annotations: READ_ONLY_ANNOTATIONS,
     },

--- a/apps/api/src/mcp/tools/tracker.ts
+++ b/apps/api/src/mcp/tools/tracker.ts
@@ -25,6 +25,7 @@ import {
 } from "@midday/db/queries";
 import { z } from "zod";
 import {
+  mcpListMetaSchema,
   mcpTrackerEntrySchema,
   mcpTrackerProjectSchema,
   sanitize,
@@ -95,12 +96,8 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
             .describe("Sort direction"),
         },
         outputSchema: {
-          meta: z.looseObject({
-            cursor: z.string().nullable().optional(),
-            hasNextPage: z.boolean(),
-            hasPreviousPage: z.boolean(),
-          }),
-          data: z.array(z.record(z.string(), z.any())),
+          meta: mcpListMetaSchema,
+          data: z.array(mcpTrackerProjectSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -150,7 +147,7 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
           id: getTrackerProjectByIdSchema.shape.id,
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpTrackerProjectSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -190,6 +187,9 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
           currency: upsertTrackerProjectSchema.shape.currency,
           customerId: upsertTrackerProjectSchema.shape.customerId,
           tags: upsertTrackerProjectSchema.shape.tags,
+        },
+        outputSchema: {
+          data: mcpTrackerProjectSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -247,6 +247,9 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
           currency: upsertTrackerProjectSchema.shape.currency,
           customerId: upsertTrackerProjectSchema.shape.customerId,
           tags: upsertTrackerProjectSchema.shape.tags,
+        },
+        outputSchema: {
+          data: mcpTrackerProjectSchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -314,6 +317,10 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
           "Permanently delete a tracker project and all its associated time entries. This action cannot be undone.",
         inputSchema: {
           id: deleteTrackerProjectSchema.shape.id,
+        },
+        outputSchema: {
+          success: z.boolean(),
+          deletedId: z.string(),
         },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
@@ -463,7 +470,7 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
             .describe("User ID to check timer for (optional)"),
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpTrackerEntrySchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -500,6 +507,9 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
           duration: upsertTrackerEntriesSchema.shape.duration,
           description: upsertTrackerEntriesSchema.shape.description,
           assignedId: upsertTrackerEntriesSchema.shape.assignedId,
+        },
+        outputSchema: {
+          data: z.array(mcpTrackerEntrySchema),
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -557,6 +567,9 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
           duration: upsertTrackerEntriesSchema.shape.duration.optional(),
           description: upsertTrackerEntriesSchema.shape.description,
           assignedId: upsertTrackerEntriesSchema.shape.assignedId,
+        },
+        outputSchema: {
+          data: z.array(mcpTrackerEntrySchema),
         },
         annotations: WRITE_ANNOTATIONS,
       },
@@ -638,6 +651,10 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
         inputSchema: {
           id: deleteTrackerEntrySchema.shape.id,
         },
+        outputSchema: {
+          success: z.boolean(),
+          deletedId: z.string(),
+        },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -696,6 +713,9 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
             .optional()
             .describe("Start time (ISO 8601). Defaults to now."),
         },
+        outputSchema: {
+          data: mcpTrackerEntrySchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -743,6 +763,9 @@ export const registerTrackerTools: RegisterTools = (server, ctx) => {
           stop: lenientDateTimeSchema
             .optional()
             .describe("Stop time (ISO 8601). Defaults to now."),
+        },
+        outputSchema: {
+          data: mcpTrackerEntrySchema,
         },
         annotations: WRITE_ANNOTATIONS,
       },

--- a/apps/api/src/mcp/tools/transactions.ts
+++ b/apps/api/src/mcp/tools/transactions.ts
@@ -27,6 +27,7 @@ import {
 } from "@midday/job-client";
 import { z } from "zod";
 import {
+  mcpListMetaSchema,
   mcpTransactionDetailSchema,
   mcpTransactionSchema,
   sanitize,
@@ -108,12 +109,8 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
             .describe("Maximum absolute amount to include"),
         },
         outputSchema: {
-          meta: z.looseObject({
-            cursor: z.string().nullable().optional(),
-            hasNextPage: z.boolean(),
-            hasPreviousPage: z.boolean(),
-          }),
-          data: z.array(z.record(z.string(), z.any())),
+          meta: mcpListMetaSchema,
+          data: z.array(mcpTransactionSchema),
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -183,7 +180,7 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
           id: getTransactionByIdSchema.shape.id,
         },
         outputSchema: {
-          data: z.record(z.string(), z.any()),
+          data: mcpTransactionDetailSchema,
         },
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -215,6 +212,9 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         description:
           "Create a manual transaction (not from bank sync). Requires bank account ID, amount, currency, date, and name. Use for manual entries and adjustments.",
         inputSchema: createTransactionSchema.shape,
+        outputSchema: {
+          data: mcpTransactionSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -260,6 +260,9 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         inputSchema: z.object({
           transactions: z.array(createTransactionSchema).min(1).max(100),
         }).shape,
+        outputSchema: {
+          data: z.array(mcpTransactionSchema),
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async ({ transactions: items }) => {
@@ -299,6 +302,9 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         description:
           "Update a single transaction by ID: category, status, note, assignment, amount, tax fields, etc. Use the transaction status field for workflow states (pending, posted, excluded, archived, exported, completed).",
         inputSchema: updateTransactionSchema.shape,
+        outputSchema: {
+          data: mcpTransactionSchema,
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -351,6 +357,9 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         description:
           "Apply the same updates to multiple transactions by ID (e.g. bulk categorize, set tag, assignee, status).",
         inputSchema: updateTransactionsSchema.shape,
+        outputSchema: {
+          data: z.array(mcpTransactionSchema),
+        },
         annotations: WRITE_ANNOTATIONS,
       },
       async (params) => {
@@ -391,6 +400,9 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         description:
           "Delete a single transaction. Only manually created transactions can be deleted; bank-imported rows must be excluded via status instead.",
         inputSchema: deleteTransactionSchema.shape,
+        outputSchema: {
+          data: mcpTransactionSchema,
+        },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
       async ({ id }) => {
@@ -447,6 +459,9 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
               "Transaction IDs to delete (1–1000 UUIDs, must not be empty)",
             ),
         },
+        outputSchema: {
+          data: z.array(mcpTransactionSchema),
+        },
         annotations: DESTRUCTIVE_ANNOTATIONS,
       },
       async ({ ids }) => {
@@ -482,6 +497,15 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         title: "Export Transactions (File)",
         description:
           "Export transactions as a ZIP file containing CSV and/or XLSX spreadsheets plus receipt attachments. Optionally emails the file to your accountant. Provide either transactionIds directly OR use filter parameters (start, end, categories, statuses, accounts, q, type) to select transactions by criteria. For up to 500 transactions the export completes synchronously and returns a download URL; larger exports return a jobId for polling with export_job_status.",
+        outputSchema: {
+          status: z.enum(["completed", "started"]).optional(),
+          message: z.string().optional(),
+          fileName: z.string().nullable().optional(),
+          totalItems: z.number().optional(),
+          downloadUrl: z.string().nullable().optional(),
+          jobId: z.string().optional(),
+          transactionCount: z.number().optional(),
+        },
         inputSchema: {
           transactionIds: z
             .array(z.string().uuid())
@@ -760,6 +784,13 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         title: "Export to Accounting Software",
         description:
           "Push transactions (with receipt attachments) to a connected accounting provider (Xero, QuickBooks, or Fortnox). Use accounting_connections first to check which providers are connected. Returns a job ID — poll with export_job_status to track progress.",
+        outputSchema: {
+          message: z.string(),
+          jobId: z.string(),
+          provider: z.string(),
+          tenantName: z.string(),
+          transactionCount: z.number(),
+        },
         inputSchema: {
           transactionIds: z
             .array(z.string().uuid())
@@ -839,6 +870,10 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         title: "Export Job Status",
         description:
           "Poll the status of an export job (file export or accounting sync). Use the jobId returned by transactions_export or transactions_export_to_accounting. Status progresses: waiting → active → completed/failed.",
+        outputSchema: {
+          status: z.string(),
+          result: z.record(z.string(), z.any()).nullable().optional(),
+        },
         inputSchema: {
           jobId: z
             .string()
@@ -899,6 +934,14 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         title: "List Accounting Connections",
         description:
           "List connected accounting providers (Xero, QuickBooks, Fortnox) for the team. Use this before transactions_export_to_accounting to check which providers are available.",
+        outputSchema: {
+          connections: z.array(
+            z.object({
+              providerId: z.string(),
+              tenantName: z.string(),
+            }),
+          ),
+        },
         inputSchema: {},
         annotations: READ_ONLY_ANNOTATIONS,
       },
@@ -962,6 +1005,9 @@ export const registerTransactionTools: RegisterTools = (server, ctx) => {
         title: "Accounting Sync Status",
         description:
           "Check the sync status of transactions with connected accounting software. Filter by specific transaction IDs or by provider (xero, quickbooks, fortnox). Returns sync records showing which transactions have been exported and their status.",
+        outputSchema: {
+          data: z.array(z.record(z.string(), z.any())),
+        },
         inputSchema: {
           transactionIds: z
             .array(z.string().uuid())

--- a/apps/api/src/rest/routers/computer.ts
+++ b/apps/api/src/rest/routers/computer.ts
@@ -1,0 +1,358 @@
+import type { Context } from "@api/rest/types";
+import { enqueueReplay, enqueueRun } from "@midday/job-client";
+import {
+  approveComputerRun,
+  createComputerAgent,
+  createComputerRun,
+  deleteComputerAgent,
+  getComputerAgentBySlug,
+  getComputerAgentForRun,
+  getComputerAgentMemoryEntries,
+  getComputerAgents,
+  getComputerRunProposals,
+  getComputerRunWithSteps,
+  getComputerRuns,
+  rejectComputerRun,
+  updateComputerAgent,
+} from "@midday/db/queries";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { generateAgentFromDescription } from "./computer/orchestrator";
+import { CATALOG_AGENTS } from "./computer/catalog";
+
+const app = new OpenAPIHono<Context>();
+
+app.get("/catalog", async (c) => {
+  return c.json({
+    data: CATALOG_AGENTS.map(({ code, ...rest }) => rest),
+  });
+});
+
+app.get("/agents", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+
+  const agents = await getComputerAgents(db, { teamId });
+
+  return c.json({ data: agents });
+});
+
+app.post("/agents", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const session = c.get("session");
+  const body = await c.req.json();
+
+  const { templateId } = body as { templateId?: string };
+
+  if (!templateId) {
+    return c.json({ error: "templateId is required" }, 400);
+  }
+
+  const template = CATALOG_AGENTS.find((a) => a.templateId === templateId);
+  if (!template) {
+    return c.json({ error: "Template not found" }, 404);
+  }
+
+  const existing = await getComputerAgentBySlug(db, {
+    teamId,
+    slug: template.slug,
+  });
+
+  if (existing) {
+    return c.json({ error: "Agent already enabled", id: existing.id }, 409);
+  }
+
+  const agent = await createComputerAgent(db, {
+    teamId,
+    name: template.name,
+    slug: template.slug,
+    description: template.description,
+    source: "catalog",
+    code: template.code,
+    templateId: template.templateId,
+    scheduleCron: template.scheduleCron,
+    enabled: true,
+    createdBy: session.user.id,
+  });
+
+  return c.json({ data: agent }, 201);
+});
+
+app.post("/generate", async (c) => {
+  const body = await c.req.json();
+  const { description } = body as { description?: string };
+
+  if (!description || description.trim().length < 10) {
+    return c.json(
+      { error: "Description must be at least 10 characters" },
+      400,
+    );
+  }
+
+  try {
+    const result = await generateAgentFromDescription(description);
+    return c.json({ data: result });
+  } catch (error) {
+    return c.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to generate agent",
+      },
+      500,
+    );
+  }
+});
+
+app.post("/agents/confirm", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const session = c.get("session");
+  const body = await c.req.json();
+
+  const { name, slug, description, code, scheduleCron } = body as {
+    name: string;
+    slug: string;
+    description: string;
+    code: string;
+    scheduleCron?: string;
+  };
+
+  if (!name || !slug || !code) {
+    return c.json({ error: "name, slug, and code are required" }, 400);
+  }
+
+  const existing = await getComputerAgentBySlug(db, { teamId, slug });
+
+  if (existing) {
+    return c.json({ error: "An agent with this slug already exists" }, 409);
+  }
+
+  const agent = await createComputerAgent(db, {
+    teamId,
+    name,
+    slug,
+    description,
+    source: "generated",
+    code,
+    scheduleCron: scheduleCron ?? null,
+    enabled: true,
+    createdBy: session.user.id,
+  });
+
+  return c.json({ data: agent }, 201);
+});
+
+app.put("/agents/:id", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id } = c.req.param();
+  const body = await c.req.json();
+
+  const { enabled, scheduleCron, config } = body as {
+    enabled?: boolean;
+    scheduleCron?: string;
+    config?: Record<string, unknown>;
+  };
+
+  const updated = await updateComputerAgent(db, {
+    id,
+    teamId,
+    enabled,
+    scheduleCron,
+    config,
+  });
+
+  if (!updated) {
+    return c.json({ error: "Agent not found" }, 404);
+  }
+
+  return c.json({ data: updated });
+});
+
+app.delete("/agents/:id", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id } = c.req.param();
+
+  const deleted = await deleteComputerAgent(db, { id, teamId });
+
+  if (!deleted) {
+    return c.json({ error: "Agent not found" }, 404);
+  }
+
+  return c.json({ success: true });
+});
+
+app.post("/agents/:id/run", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id } = c.req.param();
+
+  const agent = await getComputerAgentForRun(db, { id, teamId });
+
+  if (!agent) {
+    return c.json({ error: "Agent not found" }, 404);
+  }
+
+  if (!agent.enabled) {
+    return c.json({ error: "Agent is disabled. Enable it before triggering a run." }, 400);
+  }
+
+  const runId = crypto.randomUUID();
+
+  await createComputerRun(db, {
+    id: runId,
+    agentId: agent.id,
+    teamId,
+  });
+
+  await enqueueRun({
+    agentId: agent.id,
+    teamId,
+    runId,
+  });
+
+  return c.json({ data: { runId } }, 202);
+});
+
+app.get("/agents/:id/runs", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id } = c.req.param();
+  const limit = Number(c.req.query("limit") || "20");
+
+  const runs = await getComputerRuns(db, { agentId: id, teamId, limit });
+
+  return c.json({ data: runs });
+});
+
+app.get("/agents/:id/runs/:runId", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id, runId } = c.req.param();
+
+  const run = await getComputerRunWithSteps(db, {
+    runId,
+    agentId: id,
+    teamId,
+  });
+
+  if (!run) {
+    return c.json({ error: "Run not found" }, 404);
+  }
+
+  return c.json({ data: run });
+});
+
+app.get("/agents/:id/runs/:runId/proposals", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id, runId } = c.req.param();
+
+  const run = await getComputerRunProposals(db, {
+    runId,
+    agentId: id,
+    teamId,
+  });
+
+  if (!run) {
+    return c.json({ error: "No pending proposals found for this run" }, 404);
+  }
+
+  return c.json({
+    data: {
+      runId: run.id,
+      status: run.status,
+      actions: run.proposedActions ?? [],
+    },
+  });
+});
+
+app.post("/agents/:id/runs/:runId/approve", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id, runId } = c.req.param();
+  const body = await c.req.json().catch(() => ({}));
+  const { actions: approvedIndices } = body as { actions?: number[] };
+
+  const proposal = await getComputerRunProposals(db, {
+    runId,
+    agentId: id,
+    teamId,
+  });
+
+  if (!proposal) {
+    return c.json({ error: "No pending proposals found for this run" }, 404);
+  }
+
+  const updated = await approveComputerRun(db, {
+    runId,
+    approvedIndices: approvedIndices ?? undefined,
+  });
+
+  if (!updated) {
+    return c.json({ error: "Failed to approve run" }, 500);
+  }
+
+  const approvedActions = updated.proposedActions as Array<{
+    tool: string;
+    args: Record<string, unknown>;
+    description?: string;
+  }>;
+
+  await enqueueReplay({
+    runId,
+    agentId: id,
+    teamId,
+    actions: approvedActions,
+  });
+
+  return c.json({
+    data: {
+      runId,
+      status: "approved",
+      actionsQueued: approvedActions.length,
+    },
+  });
+});
+
+app.post("/agents/:id/runs/:runId/reject", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id, runId } = c.req.param();
+
+  const proposal = await getComputerRunProposals(db, {
+    runId,
+    agentId: id,
+    teamId,
+  });
+
+  if (!proposal) {
+    return c.json({ error: "No pending proposals found for this run" }, 404);
+  }
+
+  const result = await rejectComputerRun(db, { runId });
+
+  if (!result) {
+    return c.json({ error: "Failed to reject run" }, 500);
+  }
+
+  return c.json({ data: { runId, status: "rejected" } });
+});
+
+app.get("/agents/:id/memory", async (c) => {
+  const db = c.get("db");
+  const teamId = c.get("teamId");
+  const { id } = c.req.param();
+
+  const memory = await getComputerAgentMemoryEntries(db, {
+    agentId: id,
+    teamId,
+  });
+
+  return c.json({ data: memory });
+});
+
+export const computerRouter = app;

--- a/apps/api/src/rest/routers/computer/catalog.ts
+++ b/apps/api/src/rest/routers/computer/catalog.ts
@@ -1,0 +1,602 @@
+export interface CatalogAgent {
+  templateId: string;
+  name: string;
+  slug: string;
+  description: string;
+  scheduleCron: string;
+  code: string;
+}
+
+export const CATALOG_AGENTS: CatalogAgent[] = [
+  {
+    templateId: "month-end-close",
+    name: "Month-End Close",
+    slug: "month-end-close",
+    description:
+      "Runs a close-the-books checklist near month end: flags uncategorized transactions, unmatched inbox items, unsent draft invoices, and compares this month's P&L to last month with anomaly detection.",
+    scheduleCron: "0 8 28-31 * *",
+    code: `const { callTool, parseMcp, generateText, readMemory, writeMemory, notify } = SecureExec.bindings;
+
+const now = new Date();
+const year = now.getFullYear();
+const month = now.getMonth();
+const monthStart = new Date(year, month, 1).toISOString().split("T")[0];
+const monthEnd = new Date(year, month + 1, 0).toISOString().split("T")[0];
+
+const issues = [];
+const errors = [];
+
+// 1. Uncategorized transactions this month
+let uncategorizedCount = 0;
+try {
+  const txnResult = await callTool("transactions_list", {
+    categories: ["uncategorized"],
+    start: monthStart,
+    end: monthEnd,
+    pageSize: 100,
+  });
+  const { data: txns } = parseMcp(txnResult);
+  uncategorizedCount = txns.length;
+  if (uncategorizedCount > 0) {
+    const totalAmount = txns.reduce((s, t) => s + Math.abs(Number(t.amount || 0)), 0);
+    issues.push(uncategorizedCount + " uncategorized transactions (" + totalAmount.toFixed(2) + " total)");
+  }
+} catch (e) {
+  errors.push("Failed to fetch uncategorized transactions: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 2. Pending inbox items
+let pendingInboxCount = 0;
+try {
+  const inboxResult = await callTool("inbox_list", {
+    status: "pending",
+    pageSize: 100,
+  });
+  const { data: items } = parseMcp(inboxResult);
+  pendingInboxCount = items.length;
+  if (pendingInboxCount > 0) {
+    issues.push(pendingInboxCount + " inbox items still pending (unmatched receipts/documents)");
+  }
+} catch (e) {
+  errors.push("Failed to fetch inbox items: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 3. Draft invoices not yet sent
+let draftInvoiceCount = 0;
+try {
+  const invResult = await callTool("invoices_list", {
+    statuses: ["draft"],
+    pageSize: 100,
+  });
+  const { data: invoices } = parseMcp(invResult);
+  draftInvoiceCount = invoices.length;
+  if (draftInvoiceCount > 0) {
+    const totalDraft = invoices.reduce((s, i) => s + Math.abs(Number(i.amount || 0)), 0);
+    issues.push(draftInvoiceCount + " draft invoices not sent (" + totalDraft.toFixed(2) + " total)");
+  }
+} catch (e) {
+  errors.push("Failed to fetch draft invoices: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 4. This month's P&L
+let currentPnl = null;
+try {
+  const pnlResult = await callTool("reports_profit", {
+    from: monthStart,
+    to: monthEnd,
+  });
+  currentPnl = parseMcp(pnlResult);
+} catch (e) {
+  errors.push("Failed to fetch P&L: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 5. Spending breakdown (bare array, no .data wrapper)
+let spending = [];
+try {
+  const spendResult = await callTool("reports_spending", {
+    from: monthStart,
+    to: monthEnd,
+  });
+  const spendData = parseMcp(spendResult);
+  spending = spendData?.data ?? spendData ?? [];
+} catch (e) {
+  errors.push("Failed to fetch spending: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 6. Load previous month summary from memory
+const prevMemories = await readMemory({ key: "month_close_summary" });
+let prevSummary = null;
+try {
+  if (prevMemories.length > 0) prevSummary = JSON.parse(prevMemories[0].content);
+} catch (e) {}
+
+if (errors.length > 0) {
+  issues.push("\\u26a0 " + errors.length + " data source(s) failed to load: " + errors.join("; "));
+}
+
+// 7. AI analysis
+const dataForAi = {
+  month: monthStart + " to " + monthEnd,
+  issues,
+  errors,
+  currentPnl: currentPnl?.summary ?? null,
+  spending: spending.slice(0, 10),
+  previousMonth: prevSummary,
+};
+
+const analysis = await generateText(
+  "You are reviewing month-end financials for a business. Analyze this data and produce a concise close checklist.\\n\\n" +
+  JSON.stringify(dataForAi, null, 2) +
+  "\\n\\nProvide:\\n" +
+  "1. A numbered checklist of open items that need attention before closing\\n" +
+  "2. If previous month data exists, flag any category where spending changed by more than 25%\\n" +
+  "3. A one-line overall health assessment\\n\\n" +
+  "Keep it direct and actionable. No preamble.",
+  { system: "You are a CFO assistant. Be specific, cite numbers, and keep it under 300 words." }
+);
+
+// 8. Save this month's summary for next month's comparison
+const thisMonthData = {
+  month: monthStart,
+  pnl: currentPnl?.summary ?? null,
+  spending: spending.slice(0, 10),
+  uncategorized: uncategorizedCount,
+  pendingInbox: pendingInboxCount,
+  draftInvoices: draftInvoiceCount,
+  closedAt: now.toISOString(),
+};
+
+await writeMemory(
+  "month_close_summary",
+  JSON.stringify(thisMonthData),
+  "snapshot",
+  { month: monthStart }
+);
+
+// 9. Notify team
+const hasIssues = issues.length > 0;
+await notify(
+  (hasIssues ? "Month-end checklist (" + issues.length + " open items):\\n\\n" : "Month-end review — all clear:\\n\\n") +
+  analysis
+);
+
+module.exports = {
+  summary: hasIssues ? issues.length + " items need attention" : "Books are clean",
+  uncategorized: uncategorizedCount,
+  pendingInbox: pendingInboxCount,
+  draftInvoices: draftInvoiceCount,
+  errors,
+  analysis,
+};`,
+  },
+  {
+    templateId: "invoice-chaser",
+    name: "Invoice Chaser",
+    slug: "invoice-chaser",
+    description:
+      "Intelligent weekly collections assistant: finds overdue and aging unpaid invoices, prioritizes by amount and age, tracks escalation history in memory, and proposes sending reminders for your approval.",
+    scheduleCron: "0 9 * * 2",
+    code: `const { callTool, parseMcp, generateText, readMemory, writeMemory, propose, notify } = SecureExec.bindings;
+
+// 1. Fetch overdue and unpaid invoices
+let overdue = [];
+let unpaid = [];
+const errors = [];
+
+try {
+  const overdueResult = await callTool("invoices_list", { statuses: ["overdue"], pageSize: 100 });
+  overdue = parseMcp(overdueResult)?.data ?? [];
+} catch (e) {
+  errors.push("Failed to fetch overdue invoices: " + (e instanceof Error ? e.message : String(e)));
+}
+
+try {
+  const unpaidResult = await callTool("invoices_list", { statuses: ["unpaid"], pageSize: 100 });
+  unpaid = parseMcp(unpaidResult)?.data ?? [];
+} catch (e) {
+  errors.push("Failed to fetch unpaid invoices: " + (e instanceof Error ? e.message : String(e)));
+}
+
+if (errors.length > 0 && overdue.length === 0 && unpaid.length === 0) {
+  await notify("Invoice Chaser encountered errors and could not fetch invoice data:\\n" + errors.join("\\n"), "urgent");
+  module.exports = { summary: "Failed to fetch invoices", errors };
+  return;
+}
+
+// Deduplicate: remove overdue invoices from unpaid set
+const overdueIds = new Set(overdue.map(inv => inv.id));
+unpaid = unpaid.filter(inv => !overdueIds.has(inv.id));
+const allOutstanding = [...overdue, ...unpaid];
+
+if (allOutstanding.length === 0) {
+  await notify("No overdue or unpaid invoices this week. All clear!");
+  module.exports = { summary: "No outstanding invoices", count: 0 };
+  return;
+}
+
+// 2. Get customer context for unique customers
+const customerIds = [...new Set(allOutstanding.map(inv => inv.customer?.id).filter(Boolean))];
+const customerInfo = {};
+for (const cid of customerIds.slice(0, 10)) {
+  try {
+    const cResult = await callTool("customers_get", { id: cid });
+    const customer = parseMcp(cResult)?.data;
+    if (customer) customerInfo[cid] = { name: customer.name, email: customer.email };
+  } catch (e) {
+    // Non-critical: customer enrichment failure doesn't block the workflow
+  }
+}
+
+// 3. Load escalation history from memory
+const memEntries = await readMemory({ key: "chaser_history" });
+let history = {};
+try {
+  if (memEntries.length > 0) history = JSON.parse(memEntries[0].content);
+} catch (e) {}
+
+// 4. Build invoice summary for AI prioritization
+const invoiceSummary = allOutstanding.map(inv => ({
+  id: inv.id,
+  number: inv.invoiceNumber,
+  customer: inv.customer?.id ? (customerInfo[inv.customer.id]?.name ?? inv.customerName ?? "Unknown") : (inv.customerName ?? "Unknown"),
+  amount: inv.amount,
+  currency: inv.currency,
+  status: inv.status,
+  dueDate: inv.dueDate,
+  daysPastDue: inv.dueDate ? Math.floor((Date.now() - new Date(inv.dueDate).getTime()) / 86400000) : 0,
+  previousReminders: history[inv.id]?.count ?? 0,
+}));
+
+// 5. AI prioritization
+const prioritized = await generateText(
+  "You are a collections specialist. Prioritize these outstanding invoices for follow-up.\\n\\n" +
+  JSON.stringify(invoiceSummary, null, 2) +
+  "\\n\\nRank them by urgency (oldest and largest first, repeat offenders higher). " +
+  "For each, suggest whether to send a reminder or escalate. " +
+  "Return a numbered list with invoice number, customer, amount, days overdue, and recommended action. " +
+  "Keep it concise — max 5 words per recommendation.",
+  { system: "You are a collections assistant. Be direct, prioritize by business impact." }
+);
+
+// 6. Propose sending reminders for overdue invoices
+const remindActions = overdue
+  .filter(inv => inv.dueDate)
+  .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())
+  .slice(0, 10)
+  .map(inv => {
+    const custName = inv.customer?.id ? (customerInfo[inv.customer.id]?.name ?? inv.customerName ?? "Unknown") : (inv.customerName ?? "Unknown");
+    const daysPastDue = Math.floor((Date.now() - new Date(inv.dueDate).getTime()) / 86400000);
+    return {
+      tool: "invoices_remind",
+      args: { id: inv.id },
+      description: "Send reminder for #" + (inv.invoiceNumber ?? inv.id.slice(0, 8)) +
+        " (" + custName +
+        ", " + (inv.currency ?? "") + " " + Math.abs(Number(inv.amount || 0)).toFixed(2) +
+        ", " + daysPastDue + " days overdue)",
+    };
+  });
+
+if (remindActions.length > 0) {
+  const updatedHistory = { ...history };
+  for (const inv of overdue) {
+    updatedHistory[inv.id] = {
+      count: (history[inv.id]?.count ?? 0) + 1,
+      lastFlagged: new Date().toISOString(),
+    };
+  }
+  await writeMemory("chaser_history", JSON.stringify(updatedHistory), "tracker");
+
+  await notify(
+    "Invoice Chaser found " + allOutstanding.length + " outstanding invoices (" +
+    overdue.length + " overdue).\\n\\n" + prioritized +
+    "\\n\\nReview proposed reminders with: midday computer proposals"
+  );
+
+  await propose(remindActions);
+} else {
+  await notify(
+    "Invoice Chaser: " + allOutstanding.length + " unpaid invoices, none overdue yet.\\n\\n" + prioritized
+  );
+}
+
+const totalOutstanding = allOutstanding.reduce((s, i) => s + Math.abs(Number(i.amount || 0)), 0);
+module.exports = {
+  summary: overdue.length + " overdue, " + unpaid.length + " unpaid (" + totalOutstanding.toFixed(2) + " total)",
+  overdueCount: overdue.length,
+  unpaidCount: unpaid.length,
+  totalOutstanding,
+  analysis: prioritized,
+};`,
+  },
+  {
+    templateId: "weekly-financial-briefing",
+    name: "Weekly Financial Briefing",
+    slug: "weekly-financial-briefing",
+    description:
+      "Monday morning executive summary: cash position, revenue vs expenses, week-over-week trends, outstanding invoices, and spending breakdown — with running trend analysis from memory.",
+    scheduleCron: "0 8 * * 1",
+    code: `const { callTool, parseMcp, generateText, readMemory, writeMemory, notify } = SecureExec.bindings;
+
+const now = new Date();
+const weekEnd = now.toISOString().split("T")[0];
+const weekStart = new Date(now.getTime() - 7 * 86400000).toISOString().split("T")[0];
+
+const errors = [];
+
+// 1. Team currency
+let currency = "USD";
+try {
+  const teamResult = await callTool("team_get", {});
+  const team = parseMcp(teamResult)?.data;
+  if (team?.baseCurrency) currency = team.baseCurrency;
+} catch (e) {
+  errors.push("Failed to fetch team info: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 2. Cash position
+let balances = [];
+try {
+  const balResult = await callTool("bank_accounts_balances", {});
+  balances = parseMcp(balResult)?.data ?? [];
+} catch (e) {
+  errors.push("Failed to fetch bank balances: " + (e instanceof Error ? e.message : String(e)));
+}
+const totalCash = balances.reduce((s, b) => s + Number(b.balance || 0), 0);
+
+// 3. This week's P&L
+let thisWeekPnl = null;
+try {
+  const pnlResult = await callTool("reports_profit", { from: weekStart, to: weekEnd, currency });
+  thisWeekPnl = parseMcp(pnlResult);
+} catch (e) {
+  errors.push("Failed to fetch P&L: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 4. Revenue
+let thisWeekRevenue = null;
+try {
+  const revResult = await callTool("reports_revenue", { from: weekStart, to: weekEnd, currency });
+  thisWeekRevenue = parseMcp(revResult);
+} catch (e) {
+  errors.push("Failed to fetch revenue: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 5. Spending by category
+let spending = [];
+try {
+  const spendResult = await callTool("reports_spending", { from: weekStart, to: weekEnd, currency });
+  const spendData = parseMcp(spendResult);
+  spending = spendData?.data ?? spendData ?? [];
+} catch (e) {
+  errors.push("Failed to fetch spending: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 6. Cash flow
+let cashFlow = null;
+try {
+  const cfResult = await callTool("reports_cash_flow", { from: weekStart, to: weekEnd, currency });
+  cashFlow = parseMcp(cfResult);
+} catch (e) {
+  errors.push("Failed to fetch cash flow: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 7. Invoice summary
+let invoiceSummary = null;
+try {
+  const invResult = await callTool("invoices_summary", {});
+  invoiceSummary = parseMcp(invResult);
+} catch (e) {
+  errors.push("Failed to fetch invoice summary: " + (e instanceof Error ? e.message : String(e)));
+}
+
+// 8. Load previous week's snapshot
+const prevMemories = await readMemory({ key: "weekly_briefing" });
+let prevSnapshot = null;
+try {
+  if (prevMemories.length > 0) prevSnapshot = JSON.parse(prevMemories[0].content);
+} catch (e) {}
+
+// 9. Load trend history (rolling 8 weeks)
+const trendMemories = await readMemory({ key: "weekly_trends" });
+let trends = [];
+try {
+  if (trendMemories.length > 0) trends = JSON.parse(trendMemories[0].content);
+} catch (e) {}
+
+// 10. AI briefing
+const briefingData = {
+  period: weekStart + " to " + weekEnd,
+  currency,
+  cashPosition: { totalCash, accounts: balances.length },
+  profitLoss: thisWeekPnl?.summary ?? null,
+  revenue: thisWeekRevenue?.summary ?? null,
+  cashFlow: cashFlow?.summary ?? null,
+  topSpending: spending.slice(0, 8),
+  invoices: invoiceSummary,
+  previousWeek: prevSnapshot,
+  trendHistory: trends.slice(-4),
+  dataErrors: errors.length > 0 ? errors : undefined,
+};
+
+const briefing = await generateText(
+  "Create a weekly financial briefing from this data.\\n\\n" +
+  JSON.stringify(briefingData, null, 2) +
+  "\\n\\nStructure:\\n" +
+  "1. **Cash Position** — total cash and change from last week\\n" +
+  "2. **Revenue & Profit** — this week vs last week with % change\\n" +
+  "3. **Top Spending** — largest categories and any notable changes\\n" +
+  "4. **Invoices** — outstanding, overdue amounts, collection status\\n" +
+  "5. **Trends** — if history exists, note multi-week patterns (growing/declining revenue, spending creep, etc.)\\n" +
+  "6. **Key Actions** — 2-3 specific things to address this week\\n\\n" +
+  "Keep it under 400 words. Use exact numbers. No generic advice.",
+  { system: "You are a CFO producing a Monday morning briefing for the business owner. Be specific and concise." }
+);
+
+// 11. Save this week's snapshot
+const thisWeekSnapshot = {
+  week: weekStart,
+  totalCash,
+  profit: thisWeekPnl?.summary?.profit ?? null,
+  revenue: thisWeekRevenue?.summary?.current ?? null,
+  topSpending: spending.slice(0, 5).map(s => ({ category: s.name, amount: s.amount })),
+  createdAt: now.toISOString(),
+};
+
+await writeMemory("weekly_briefing", JSON.stringify(thisWeekSnapshot), "snapshot", { week: weekStart });
+
+// Save rolling trend (keep last 12 weeks)
+const updatedTrends = [...trends, thisWeekSnapshot].slice(-12);
+await writeMemory("weekly_trends", JSON.stringify(updatedTrends), "trends");
+
+// 12. Notify
+const errorNote = errors.length > 0 ? "\\n\\n\\u26a0 " + errors.length + " data source(s) unavailable — briefing may be incomplete." : "";
+await notify("Weekly Financial Briefing — " + weekStart + "\\n\\n" + briefing + errorNote);
+
+module.exports = {
+  summary: "Briefing delivered for " + weekStart,
+  totalCash,
+  errors,
+  briefing,
+};`,
+  },
+  {
+    templateId: "expense-anomaly-detector",
+    name: "Expense Anomaly Detector",
+    slug: "expense-anomaly-detector",
+    description:
+      "Daily scan for unusual expenses: flags transactions that are abnormally large for their category, new unknown vendors, spending spikes, and potential duplicates. Only notifies when something looks wrong.",
+    scheduleCron: "0 10 * * *",
+    code: `const { callTool, parseMcp, generateText, readMemory, writeMemory, notify } = SecureExec.bindings;
+
+const now = new Date();
+const today = now.toISOString().split("T")[0];
+const yesterday = new Date(now.getTime() - 24 * 3600000).toISOString().split("T")[0];
+const threeMonthsAgo = new Date(now.getTime() - 90 * 86400000).toISOString().split("T")[0];
+
+// 1. Get recent expenses (last 24h)
+let recentExpenses = [];
+try {
+  const txnResult = await callTool("transactions_list", {
+    start: yesterday,
+    end: today,
+    type: "expense",
+    pageSize: 100,
+  });
+  recentExpenses = parseMcp(txnResult)?.data ?? [];
+} catch (e) {
+  await notify("Expense Anomaly Detector failed to fetch recent expenses: " + (e instanceof Error ? e.message : String(e)), "urgent");
+  module.exports = { summary: "Failed to fetch expenses", error: e instanceof Error ? e.message : String(e) };
+  return;
+}
+
+if (recentExpenses.length === 0) {
+  module.exports = { summary: "No new expenses to analyze", anomalies: 0 };
+  return;
+}
+
+// 2. Get 90-day spending baseline by category
+let spendingBaseline = [];
+try {
+  const baseResult = await callTool("reports_spending", {
+    from: threeMonthsAgo,
+    to: today,
+  });
+  const baseData = parseMcp(baseResult);
+  spendingBaseline = baseData?.data ?? baseData ?? [];
+} catch (e) {
+  // Non-critical: anomaly detection will run without baselines
+}
+
+// 3. Load previously flagged IDs and baselines from memory
+const flagMemories = await readMemory({ key: "anomaly_flagged_ids" });
+let flaggedIdList = [];
+try {
+  if (flagMemories.length > 0) flaggedIdList = JSON.parse(flagMemories[0].content);
+} catch (e) {}
+const flaggedIds = new Set(flaggedIdList);
+
+const baselineMemories = await readMemory({ key: "anomaly_baselines" });
+let storedBaselines = {};
+try {
+  if (baselineMemories.length > 0) storedBaselines = JSON.parse(baselineMemories[0].content);
+} catch (e) {}
+
+// 4. Build baseline map (daily average per category over 90 days)
+const baselineMap = {};
+for (const cat of spendingBaseline) {
+  const catName = cat.name || "unknown";
+  const dailyAvg = Math.abs(Number(cat.amount || 0)) / 90;
+  baselineMap[catName] = {
+    dailyAvg,
+    totalAmount: Math.abs(Number(cat.amount || 0)),
+    name: catName,
+  };
+}
+
+// 5. Filter to only new (unflagged) expenses
+const newExpenses = recentExpenses.filter(tx => !flaggedIds.has(tx.id));
+
+if (newExpenses.length === 0) {
+  module.exports = { summary: "No new unflagged expenses", anomalies: 0 };
+  return;
+}
+
+// 6. AI anomaly detection
+const analysisData = {
+  newExpenses: newExpenses.map(tx => ({
+    id: tx.id,
+    name: tx.name,
+    amount: Math.abs(Number(tx.amount || 0)),
+    currency: tx.currency,
+    category: tx.category?.name ?? tx.category?.slug ?? "uncategorized",
+    date: tx.date,
+  })),
+  categoryBaselines: baselineMap,
+  previousBaselines: storedBaselines,
+};
+
+const analysis = await generateText(
+  "Analyze these recent expenses against the 90-day category baselines.\\n\\n" +
+  JSON.stringify(analysisData, null, 2) +
+  "\\n\\nFlag as anomalies:\\n" +
+  "- Transactions >3x the daily category average\\n" +
+  "- Categories with no baseline (new/unknown spending)\\n" +
+  "- Potential duplicate charges (same amount + similar name within 24h)\\n" +
+  "- Any single transaction over 2000 in the base currency\\n\\n" +
+  "For each anomaly, state: transaction name, amount, why it's flagged, and severity (high/medium/low).\\n" +
+  "If nothing looks unusual, start your response with 'ALL_CLEAR:' followed by a brief summary.\\n" +
+  "Be conservative — only flag genuinely unusual items.",
+  { system: "You are a financial controller reviewing daily expenses. Flag only real anomalies, not normal business costs." }
+);
+
+// 7. Update flagged IDs (add all reviewed, keep last 500)
+const allFlaggedIds = [...flaggedIds, ...newExpenses.map(tx => tx.id)].slice(-500);
+await writeMemory("anomaly_flagged_ids", JSON.stringify(allFlaggedIds), "tracker");
+
+// Update baselines snapshot
+await writeMemory("anomaly_baselines", JSON.stringify(baselineMap), "snapshot", { date: today });
+
+// 8. Only notify if anomalies found
+const hasAnomalies = !analysis.startsWith("ALL_CLEAR:");
+
+if (hasAnomalies) {
+  const expenseTotal = newExpenses.reduce((s, t) => s + Math.abs(Number(t.amount || 0)), 0);
+  const isUrgent = newExpenses.some(t => Math.abs(Number(t.amount || 0)) > 5000);
+
+  await notify(
+    "Expense Alert — " + newExpenses.length + " new expenses reviewed (" + expenseTotal.toFixed(2) + " total)\\n\\n" +
+    analysis,
+    isUrgent ? "urgent" : "normal"
+  );
+}
+
+module.exports = {
+  summary: hasAnomalies
+    ? "Anomalies detected in " + newExpenses.length + " expenses"
+    : "All clear — " + newExpenses.length + " expenses reviewed",
+  expensesReviewed: newExpenses.length,
+  anomaliesDetected: hasAnomalies,
+  analysis: hasAnomalies ? analysis : null,
+};`,
+  },
+];

--- a/apps/api/src/rest/routers/computer/orchestrator.ts
+++ b/apps/api/src/rest/routers/computer/orchestrator.ts
@@ -1,0 +1,242 @@
+import type { MCPClient } from "@ai-sdk/mcp";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { openai } from "@ai-sdk/openai";
+import { createMcpServer } from "@api/mcp/server";
+import type { McpContext } from "@api/mcp/types";
+import { SCOPES } from "@api/utils/scopes";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createTypeScriptTools } from "@secure-exec/typescript";
+import { generateObject } from "ai";
+import { createNodeDriver, createNodeRuntimeDriverFactory } from "secure-exec";
+import { z } from "zod";
+
+import { generateTypeStubs } from "./stubs";
+
+const agentOutputSchema = z.object({
+  name: z.string().describe("Human-readable agent name"),
+  slug: z
+    .string()
+    .regex(/^[a-z0-9-]+$/)
+    .describe("URL-safe slug for the agent"),
+  description: z
+    .string()
+    .describe("One-line description of what the agent does"),
+  scheduleCron: z
+    .string()
+    .nullable()
+    .describe("Cron expression for scheduling, or null for manual-only"),
+  plan: z
+    .array(z.string())
+    .describe("Human-readable step-by-step plan of what the agent will do"),
+  toolsUsed: z
+    .array(z.string())
+    .describe("List of MCP tool names the agent will call"),
+  code: z
+    .string()
+    .describe(
+      "TypeScript async function body. Uses parseMcp() for type-safe tool results.",
+    ),
+});
+
+export type GeneratedAgent = z.infer<typeof agentOutputSchema> & {
+  compiledCode: string;
+};
+
+function buildSystemPrompt(typeStubs: string): string {
+  return `You are the Midday Computer agent generator. You create TypeScript code that runs inside a secure V8 sandbox with access to Midday's business tools.
+
+## Type Definitions
+
+The following types are available in the sandbox environment. Use them for type-safe tool calls:
+
+\`\`\`typescript
+${typeStubs}
+\`\`\`
+
+## Code Pattern
+
+Generate a TypeScript async function body (NOT an arrow function wrapper). The code executes directly inside the sandbox:
+
+\`\`\`typescript
+const { callTool, parseMcp, generateText, readMemory, writeMemory, notify, getTrigger, callConnector, propose } = SecureExec.bindings;
+
+// Use parseMcp() to unwrap tool results with full type safety:
+const result = await callTool("transactions_list", { start: "2024-01-01", end: "2024-12-31" });
+const { meta, data } = parseMcp(result);
+// data is Transaction[] with correct field names (camelCase)
+
+// Use generateText for analysis and decision-making:
+const analysis = await generateText("Analyze these transactions: " + JSON.stringify(data));
+
+// Always assign the result to module.exports
+module.exports = { summary: "What was done", itemsProcessed: data.length };
+\`\`\`
+
+## Rules
+
+1. Always destructure bindings at the top
+2. ALWAYS use parseMcp() to unwrap tool call results -- never access .content[0].text manually
+3. All field names are camelCase (e.g. invoiceNumber, baseCurrency, customerId)
+4. Handle empty results gracefully (don't error on no data)
+5. Use generateText for analysis and decision-making, not just formatting
+6. Use notify to proactively tell the team about important findings
+7. Use readMemory/writeMemory to remember patterns across runs
+8. Always assign the result to module.exports
+9. Keep code concise and focused
+10. Use try/catch around individual tool calls that might fail
+11. Use callConnector for external services (Slack, Gmail, Sheets) -- only when the workflow needs external integrations
+12. Use propose() for destructive write operations (sending invoices, bulk updates, deleting records) so the user can review first
+13. Wrap JSON.parse of memory content in try/catch`;
+}
+
+async function createBootstrapMcpClient(): Promise<{
+  client: MCPClient;
+  cleanup: () => Promise<void>;
+}> {
+  const ctx: McpContext = {
+    db: null as any,
+    teamId: "stub",
+    userId: "stub",
+    userEmail: null,
+    scopes: [...SCOPES],
+    apiUrl: process.env.MIDDAY_API_URL || "https://api.midday.ai",
+    timezone: null,
+    locale: null,
+    countryCode: null,
+    dateFormat: null,
+    timeFormat: null,
+  };
+
+  const server = createMcpServer(ctx);
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+
+  const client = await createMCPClient({
+    transport: clientTransport,
+    name: "midday-codegen-bootstrap",
+  });
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+const MAX_REPAIR_ATTEMPTS = 2;
+
+async function typecheckAndCompile(
+  typeStubs: string,
+  tsCode: string,
+): Promise<{ success: true; js: string } | { success: false; diagnostics: string }> {
+  const systemDriver = createNodeDriver({
+    permissions: {
+      fs: () => ({ allow: false }),
+      network: () => ({ allow: false }),
+    },
+  });
+
+  const runtimeDriverFactory = createNodeRuntimeDriverFactory();
+
+  const tsTools = createTypeScriptTools({
+    systemDriver,
+    runtimeDriverFactory,
+    memoryLimit: 128,
+    cpuTimeLimitMs: 15_000,
+  });
+
+  const fullSource = `${typeStubs}\n\n// --- Agent Code ---\n${tsCode}`;
+
+  const checkResult = await tsTools.typecheckSource({
+    sourceText: fullSource,
+    filePath: "agent.ts",
+    compilerOptions: {
+      target: "ES2022",
+      module: "commonjs",
+      strict: false,
+      noEmit: true,
+      skipLibCheck: true,
+      allowJs: true,
+    },
+  });
+
+  if (!checkResult.success) {
+    const errors = checkResult.diagnostics
+      .filter((d) => d.category === "error")
+      .map((d) => `Line ${d.line ?? "?"}: ${d.message}`)
+      .join("\n");
+    return { success: false, diagnostics: errors };
+  }
+
+  const compileResult = await tsTools.compileSource({
+    sourceText: tsCode,
+    filePath: "agent.ts",
+    compilerOptions: {
+      target: "ES2022",
+      module: "commonjs",
+      strict: false,
+      skipLibCheck: true,
+      removeComments: true,
+    },
+  });
+
+  if (!compileResult.outputText) {
+    return { success: false, diagnostics: "Compilation produced no output" };
+  }
+
+  return { success: true, js: compileResult.outputText };
+}
+
+export async function generateAgentFromDescription(
+  description: string,
+): Promise<GeneratedAgent> {
+  const { client: mcpClient, cleanup } = await createBootstrapMcpClient();
+
+  try {
+    const typeStubs = await generateTypeStubs(mcpClient);
+    const systemPrompt = buildSystemPrompt(typeStubs);
+
+    let tsCode: string;
+    const { object } = await generateObject({
+      model: openai("gpt-4.1"),
+      schema: agentOutputSchema,
+      system: systemPrompt,
+      prompt: `Create a Midday Computer agent for the following request:\n\n"${description}"\n\nGenerate the agent configuration and TypeScript code.`,
+    });
+
+    tsCode = object.code;
+    const agentMeta = object;
+
+    let compiled = await typecheckAndCompile(typeStubs, tsCode);
+    let attempts = 0;
+
+    while (!compiled.success && attempts < MAX_REPAIR_ATTEMPTS) {
+      attempts++;
+      const { object: repaired } = await generateObject({
+        model: openai("gpt-4.1"),
+        schema: z.object({ code: z.string() }),
+        system: systemPrompt,
+        prompt: `The following TypeScript agent code has type errors. Fix them and return only the corrected code.\n\n## Original Code\n\`\`\`typescript\n${tsCode}\n\`\`\`\n\n## Type Errors\n${compiled.diagnostics}\n\nFix the errors and return the corrected code.`,
+      });
+      tsCode = repaired.code;
+      compiled = await typecheckAndCompile(typeStubs, tsCode);
+    }
+
+    if (!compiled.success) {
+      throw new Error(
+        `Agent code failed type-checking after ${MAX_REPAIR_ATTEMPTS} repair attempts:\n${compiled.diagnostics}`,
+      );
+    }
+
+    return {
+      ...agentMeta,
+      code: compiled.js,
+      compiledCode: compiled.js,
+    };
+  } finally {
+    await cleanup();
+  }
+}

--- a/apps/api/src/rest/routers/computer/stubs.ts
+++ b/apps/api/src/rest/routers/computer/stubs.ts
@@ -1,0 +1,101 @@
+import type { MCPClient } from "@ai-sdk/mcp";
+import { compile } from "json-schema-to-typescript";
+
+type ToolDef = Awaited<
+  ReturnType<MCPClient["listTools"]>
+>["tools"][number];
+
+const BINDING_STUBS = `
+declare const SecureExec: {
+  bindings: {
+    callTool: typeof callTool;
+    parseMcp: (result: unknown) => any;
+    generateText: (prompt: string, opts?: { model?: string; system?: string }) => Promise<string>;
+    readMemory: (opts?: { key?: string; type?: string }) => Promise<Array<{ key: string; content: string; type: string | null; metadata: unknown }>>;
+    writeMemory: (key: string, content: string, type?: string, metadata?: Record<string, unknown>) => Promise<void>;
+    notify: (message: string, priority?: "low" | "normal" | "urgent") => Promise<void>;
+    getTrigger: () => { type: "manual" | "schedule"; manual: boolean };
+    callConnector: (toolName: string, args: Record<string, unknown>) => Promise<unknown>;
+    propose: (actions: Array<{ tool: string; args: Record<string, unknown>; description?: string }>) => Promise<never>;
+  };
+};
+
+declare const module: { exports: unknown };
+`;
+
+async function jsonSchemaToInterface(
+  name: string,
+  schema: Record<string, unknown>,
+): Promise<string> {
+  try {
+    const ts = await compile(schema, name, {
+      bannerComment: "",
+      additionalProperties: false,
+      unknownAny: false,
+    });
+    return ts;
+  } catch {
+    return `interface ${name} { [key: string]: any; }\n`;
+  }
+}
+
+function sanitizeToolName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+async function generateToolOverload(tool: ToolDef): Promise<{
+  interfaces: string;
+  overload: string;
+}> {
+  const safeName = sanitizeToolName(tool.name);
+  const interfaces: string[] = [];
+
+  let inputType = "Record<string, unknown>";
+  if (tool.inputSchema?.properties && Object.keys(tool.inputSchema.properties).length > 0) {
+    const typeName = `${safeName}_Input`;
+    const iface = await jsonSchemaToInterface(typeName, tool.inputSchema as Record<string, unknown>);
+    interfaces.push(iface);
+    inputType = typeName;
+  }
+
+  let outputType = "unknown";
+  if (tool.outputSchema) {
+    const typeName = `${safeName}_Output`;
+    const iface = await jsonSchemaToInterface(typeName, tool.outputSchema as Record<string, unknown>);
+    interfaces.push(iface);
+    outputType = typeName;
+  }
+
+  const overload = `declare function callTool(name: "${tool.name}", args: ${inputType}): Promise<{ structuredContent?: ${outputType}; content?: Array<{ text?: string }>; isError?: boolean }>;`;
+
+  return {
+    interfaces: interfaces.join("\n"),
+    overload,
+  };
+}
+
+export async function generateTypeStubs(
+  mcpClient: MCPClient,
+): Promise<string> {
+  const { tools } = await mcpClient.listTools();
+
+  const results = await Promise.all(tools.map(generateToolOverload));
+
+  const allInterfaces = results
+    .map((r) => r.interfaces)
+    .filter(Boolean)
+    .join("\n");
+
+  const allOverloads = results.map((r) => r.overload).join("\n");
+
+  const fallbackOverload =
+    "declare function callTool(name: string, args: Record<string, unknown>): Promise<{ structuredContent?: unknown; content?: Array<{ text?: string }>; isError?: boolean }>;";
+
+  return [
+    "// Auto-generated type stubs from MCP tool definitions",
+    allInterfaces,
+    allOverloads,
+    fallbackOverload,
+    BINDING_STUBS,
+  ].join("\n\n");
+}

--- a/apps/api/src/rest/routers/index.ts
+++ b/apps/api/src/rest/routers/index.ts
@@ -3,6 +3,7 @@ import { protectedMiddleware } from "../middleware";
 import { appsRouter } from "./apps";
 import { bankAccountsRouter } from "./bank-accounts";
 import { chatRouter } from "./chat";
+import { computerRouter } from "./computer";
 import { connectorsCatalogRouter } from "./connectors-catalog";
 import { customersRouter } from "./customers";
 import { desktopRouter } from "./desktop";
@@ -58,5 +59,6 @@ routers.route("/reports", reportsRouter);
 routers.route("/tracker-projects", trackerProjectsRouter);
 routers.route("/tracker-entries", trackerEntriesRouter);
 routers.route("/chat", chatRouter);
+routers.route("/computer", computerRouter);
 
 export { routers };

--- a/apps/compute/.env-template
+++ b/apps/compute/.env-template
@@ -1,0 +1,22 @@
+# Database — worker-client uses one of these (pooler preferred)
+DATABASE_PRIMARY_POOLER_URL=
+DATABASE_PRIMARY_URL=
+
+# Redis — shared BullMQ queue (same instance as the main worker)
+REDIS_QUEUE_URL=redis://localhost:6379
+
+# OpenAI — used for agent LLM calls (generateText binding)
+OPENAI_API_KEY=
+
+# Composio — external integrations (Gmail, Slack, etc.)
+COMPOSIO_API_KEY=
+
+# Sentry — error reporting (optional in development)
+SENTRY_DSN=
+
+# Midday API — used for in-process MCP server context
+MIDDAY_API_URL=https://api.midday.ai
+
+# Server
+PORT=8081
+NODE_ENV=development

--- a/apps/compute/Dockerfile
+++ b/apps/compute/Dockerfile
@@ -1,0 +1,48 @@
+FROM oven/bun:1.3.10 AS base
+
+FROM base AS turbo-cli
+RUN bun add -g turbo
+
+FROM turbo-cli AS builder
+WORKDIR /app
+COPY . .
+RUN turbo prune @midday/compute --docker --out-dir=out/compute
+
+FROM base AS installer
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/out/compute/json/ .
+COPY bunfig.toml .
+
+RUN rm -f bun.lock
+RUN bun install
+
+COPY --from=builder /app/out/compute/full/ .
+
+FROM oven/bun:1.3.10 AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=8081
+
+COPY --from=installer /app/node_modules ./node_modules
+COPY --from=installer /app/apps/compute ./apps/compute
+COPY --from=installer /app/apps/api ./apps/api
+COPY --from=installer /app/packages ./packages
+COPY --from=installer /app/package.json ./package.json
+
+COPY --from=builder /app/.git-commit-sha /tmp/git-sha.txt
+COPY --from=builder /app/scripts/docker-entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+WORKDIR /app/apps/compute
+
+EXPOSE 8081
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["bun", "src/index.ts"]

--- a/apps/compute/package.json
+++ b/apps/compute/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@midday/compute",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "bun run --hot src/index.ts",
+    "start": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write ."
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "catalog:",
+    "@composio/core": "^0.6.7",
+    "@composio/vercel": "^0.6.7",
+    "@midday/cache": "workspace:*",
+    "@midday/connectors": "workspace:*",
+    "@midday/job-client": "workspace:*",
+    "@midday/db": "workspace:*",
+    "@midday/logger": "workspace:*",
+    "@midday/notifications": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.28.0",
+    "@sentry/bun": "catalog:",
+    "ai": "catalog:",
+    "bullmq": "catalog:",
+    "croner": "^9.1.0",
+    "lru-cache": "^11.2.7",
+    "hono": "catalog:",
+    "secure-exec": "^0.2.0",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/apps/compute/railway.json
+++ b/apps/compute/railway.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/compute/Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 60,
+    "restartPolicyType": "ON_FAILURE",
+    "deploymentOverlapSeconds": 30,
+    "drainingSeconds": 15,
+    "region": "europe-west4-drams3a",
+    "numReplicas": 1
+  },
+  "environments": {
+    "staging": {
+      "deploy": {
+        "numReplicas": 1
+      }
+    }
+  }
+}

--- a/apps/compute/src/config.ts
+++ b/apps/compute/src/config.ts
@@ -1,0 +1,49 @@
+import { getConnectionOptions } from "@midday/job-client";
+import { createLoggerWithContext } from "@midday/logger";
+
+const logger = createLoggerWithContext("compute:config");
+
+const isProduction =
+  process.env.NODE_ENV === "production" ||
+  process.env.RAILWAY_ENVIRONMENT === "production";
+
+export function getRedisConnection() {
+  const baseOptions = getConnectionOptions();
+
+  return {
+    ...baseOptions,
+    connectTimeout: isProduction ? 15000 : 5000,
+    retryStrategy: (times: number) => {
+      const delay = Math.min(1000 * 2 ** times, 20000);
+      if (times > 5) {
+        logger.info(
+          `[Redis/Compute] Reconnecting in ${delay}ms (attempt ${times})`,
+        );
+      }
+      return delay;
+    },
+    reconnectOnError: (err: Error) => {
+      if (err.message.includes("READONLY")) {
+        logger.info(
+          "[Redis/Compute] READONLY error detected, reconnecting",
+        );
+        return true;
+      }
+      if (
+        err.message.includes("timed out") ||
+        err.message.includes("ETIMEDOUT")
+      ) {
+        logger.info("[Redis/Compute] Timeout error detected, reconnecting");
+        return true;
+      }
+      return false;
+    },
+  };
+}
+
+export const AGENT_LIMITS = {
+  maxToolCalls: 50,
+  maxLlmCalls: 10,
+  memoryLimitMb: 64,
+  cpuTimeLimitMs: 30_000,
+} as const;

--- a/apps/compute/src/index.ts
+++ b/apps/compute/src/index.ts
@@ -1,0 +1,140 @@
+import "./instrument";
+
+import { closeWorkerDb, getWorkerDb } from "@midday/db/worker-client";
+import { COMPUTE_QUEUE_NAME } from "@midday/job-client";
+import { createLoggerWithContext } from "@midday/logger";
+import * as Sentry from "@sentry/bun";
+import { Worker } from "bullmq";
+import { Hono } from "hono";
+import { getRedisConnection } from "./config";
+import { startScheduler, stopScheduler } from "./scheduler";
+import { processJob, processReplay } from "./worker";
+
+const logger = createLoggerWithContext("compute");
+
+const db = getWorkerDb();
+
+const worker = new Worker(
+  COMPUTE_QUEUE_NAME,
+  async (job) => {
+    if (job.name === "replay-proposals") {
+      await processReplay(job, db);
+    } else {
+      await processJob(job, db);
+    }
+  },
+  {
+    connection: getRedisConnection(),
+    concurrency: 5,
+  },
+);
+
+worker.on("error", (err) => {
+  logger.error("Worker error", { error: err.message });
+  Sentry.captureException(err, {
+    tags: { errorType: "worker_error" },
+  });
+});
+
+worker.on("failed", (job, err) => {
+  logger.error("Job failed", {
+    jobId: job?.id,
+    jobName: job?.name,
+    error: err.message,
+  });
+  Sentry.captureException(err, {
+    tags: { jobName: job?.name ?? "unknown", errorType: "job_failed" },
+    extra: { jobId: job?.id, attemptsMade: job?.attemptsMade },
+  });
+});
+
+worker.on("completed", (job) => {
+  logger.info("Job completed", { jobId: job.id, jobName: job.name });
+});
+
+startScheduler(db).catch((error) => {
+  logger.error("Failed to start scheduler", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exit(1);
+});
+
+const app = new Hono();
+
+app.get("/", (c) => c.json({ status: "ok" }));
+app.get("/health", (c) => c.json({ status: "ok" }));
+
+const port = Number.parseInt(process.env.PORT || "8081", 10);
+
+Bun.serve({
+  port,
+  hostname: "0.0.0.0",
+  fetch: app.fetch,
+});
+
+logger.info(`Compute service running on port ${port}`);
+
+let shuttingDown = false;
+
+const shutdown = async (signal: string) => {
+  if (shuttingDown) {
+    logger.warn(`Received ${signal} again during shutdown, ignoring`);
+    return;
+  }
+  shuttingDown = true;
+  logger.info(`Received ${signal}, starting graceful shutdown...`);
+
+  const SHUTDOWN_TIMEOUT = 30_000;
+
+  const shutdownPromise = (async () => {
+    try {
+      stopScheduler();
+
+      logger.info("Stopping worker...");
+      await worker.close();
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
+      logger.info("Closing database...");
+      await closeWorkerDb();
+
+      logger.info("Flushing Sentry events...");
+      await Sentry.close(2000);
+
+      logger.info("Graceful shutdown complete");
+    } catch (error) {
+      logger.error("Error during shutdown", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  })();
+
+  const timeoutPromise = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      logger.warn("Shutdown timeout reached, forcing exit");
+      resolve();
+    }, SHUTDOWN_TIMEOUT);
+  });
+
+  await Promise.race([shutdownPromise, timeoutPromise]);
+  process.exit(0);
+};
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+process.on("uncaughtException", (err) => {
+  logger.error("Uncaught exception", { error: err.message, stack: err.stack });
+  Sentry.captureException(err, {
+    tags: { errorType: "uncaught_exception" },
+  });
+});
+
+process.on("unhandledRejection", (reason) => {
+  logger.error("Unhandled rejection", {
+    reason: reason instanceof Error ? reason.message : String(reason),
+  });
+  Sentry.captureException(
+    reason instanceof Error ? reason : new Error(String(reason)),
+    { tags: { errorType: "unhandled_rejection" } },
+  );
+});

--- a/apps/compute/src/instrument.ts
+++ b/apps/compute/src/instrument.ts
@@ -1,0 +1,31 @@
+import * as Sentry from "@sentry/bun";
+
+if (process.env.NODE_ENV === "production" && process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+
+    release: process.env.GIT_COMMIT_SHA || process.env.RAILWAY_GIT_COMMIT_SHA,
+
+    environment:
+      process.env.RAILWAY_ENVIRONMENT_NAME ||
+      process.env.NODE_ENV ||
+      "production",
+
+    integrations: [Sentry.consoleLoggingIntegration({ levels: ["error"] })],
+
+    sendDefaultPii: true,
+    enableLogs: true,
+
+    tracesSampleRate: 0.1,
+
+    beforeSendTransaction(event) {
+      const url = event.request?.url || event.transaction || "";
+
+      if (url.includes("/health")) {
+        return null;
+      }
+
+      return event;
+    },
+  });
+}

--- a/apps/compute/src/runtime.ts
+++ b/apps/compute/src/runtime.ts
@@ -1,0 +1,523 @@
+import { openai } from "@ai-sdk/openai";
+import { getComposioTools } from "@api/composio/client";
+import { createMcpServer } from "@api/mcp/server";
+import type { McpContext } from "@api/mcp/types";
+import { SCOPES } from "@api/utils/scopes";
+import type { Database } from "@midday/db/client";
+import {
+  getAgentMemory,
+  updateComputerRun,
+  upsertAgentMemory,
+} from "@midday/db/queries";
+import { createLoggerWithContext } from "@midday/logger";
+import { Notifications } from "@midday/notifications";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { generateText } from "ai";
+import {
+  type BindingTree,
+  createNodeDriver,
+  NodeExecutionDriver,
+} from "secure-exec";
+import { AGENT_LIMITS } from "./config";
+
+const logger = createLoggerWithContext("compute:runtime");
+
+export interface ProposedAction {
+  tool: string;
+  args: Record<string, unknown>;
+  description?: string;
+}
+
+export class ProposalSubmittedError extends Error {
+  public readonly actionCount: number;
+  constructor(actionCount: number) {
+    super(`Agent submitted ${actionCount} proposed action(s) for approval`);
+    this.name = "ProposalSubmittedError";
+    this.actionCount = actionCount;
+  }
+}
+
+interface StepRecord {
+  type: string;
+  name: string;
+  input: unknown;
+  output: unknown;
+  durationMs: number;
+}
+
+function createStepLogger(steps: StepRecord[]) {
+  return {
+    log(type: string, name: string, input: unknown) {
+      const start = Date.now();
+      return {
+        done(output: unknown) {
+          steps.push({
+            type,
+            name,
+            input,
+            output,
+            durationMs: Date.now() - start,
+          });
+        },
+      };
+    },
+  };
+}
+
+interface ExecuteAgentOptions {
+  db: Database;
+  teamId: string;
+  userId: string;
+  agentId: string;
+  agentName: string;
+  agentSlug: string;
+  runId: string;
+  code: string;
+  timezone?: string | null;
+  triggerContext?: Record<string, unknown>;
+}
+
+export interface ExecuteAgentResult {
+  success: boolean;
+  proposalSubmitted?: boolean;
+  result?: unknown;
+  error?: string;
+  steps: StepRecord[];
+  toolCallCount: number;
+  llmCallCount: number;
+}
+
+async function createInProcessMcp(
+  db: Database,
+  teamId: string,
+  userId: string,
+  timezone?: string | null,
+) {
+  const mcpContext: McpContext = {
+    db,
+    teamId,
+    userId,
+    userEmail: null,
+    scopes: [...SCOPES],
+    apiUrl: process.env.MIDDAY_API_URL || "https://api.midday.ai",
+    timezone: timezone ?? null,
+    locale: null,
+    countryCode: null,
+    dateFormat: null,
+    timeFormat: null,
+  };
+
+  const server = createMcpServer(mcpContext);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const client = new Client({ name: "midday-compute", version: "1.0.0" });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, server };
+}
+
+export async function executeAgent(
+  options: ExecuteAgentOptions,
+): Promise<ExecuteAgentResult> {
+  const {
+    db,
+    teamId,
+    userId,
+    agentId,
+    agentName,
+    agentSlug,
+    runId,
+    code,
+    timezone,
+    triggerContext,
+  } = options;
+  const notifications = new Notifications(db);
+  const steps: StepRecord[] = [];
+  const stepLogger = createStepLogger(steps);
+  let toolCallCount = 0;
+  let llmCallCount = 0;
+
+  const { client: mcpClient, server: mcpServer } = await createInProcessMcp(
+    db,
+    teamId,
+    userId,
+    timezone,
+  );
+
+  let driver: NodeExecutionDriver | null = null;
+
+  try {
+    const bindings: BindingTree = {
+      parseMcp: (result: unknown) => {
+        const r = result as {
+          structuredContent?: unknown;
+          content?: Array<{ text?: string }>;
+          isError?: boolean;
+        };
+        if (r?.isError) {
+          const errText = r?.content?.[0]?.text ?? "Tool call failed";
+          throw new Error(errText);
+        }
+        if (r?.structuredContent !== undefined) return r.structuredContent;
+        const text = r?.content?.[0]?.text;
+        if (!text) return null;
+        try {
+          return JSON.parse(text);
+        } catch {
+          return text;
+        }
+      },
+
+      callTool: async (name: unknown, args: unknown) => {
+        if (toolCallCount >= AGENT_LIMITS.maxToolCalls) {
+          throw new Error(
+            `Tool call limit exceeded (max ${AGENT_LIMITS.maxToolCalls})`,
+          );
+        }
+        toolCallCount++;
+        const toolName = name as string;
+        const toolArgs = args as Record<string, unknown>;
+        const step = stepLogger.log("tool_call", toolName, toolArgs);
+        try {
+          const result = await mcpClient.callTool({
+            name: toolName,
+            arguments: toolArgs,
+          });
+          step.done(result);
+          return result;
+        } catch (error) {
+          const msg =
+            error instanceof Error ? error.message : "Tool call failed";
+          step.done({ error: msg });
+          throw error;
+        }
+      },
+
+      generateText: async (prompt: unknown, opts: unknown) => {
+        if (llmCallCount >= AGENT_LIMITS.maxLlmCalls) {
+          throw new Error(
+            `LLM call limit exceeded (max ${AGENT_LIMITS.maxLlmCalls})`,
+          );
+        }
+        llmCallCount++;
+        const promptStr = prompt as string;
+        const options = opts as { model?: string; system?: string } | undefined;
+        const step = stepLogger.log("ai_generation", "generateText", {
+          promptLength: promptStr.length,
+          model: options?.model,
+        });
+        try {
+          const { text } = await generateText({
+            model: openai(options?.model ?? "gpt-4.1-mini"),
+            system: options?.system,
+            prompt: promptStr,
+          });
+          step.done({ textLength: text.length });
+          return text;
+        } catch (error) {
+          const msg =
+            error instanceof Error ? error.message : "LLM call failed";
+          step.done({ error: msg });
+          throw error;
+        }
+      },
+
+      readMemory: async (opts: unknown) => {
+        const memOpts = opts as { key?: string; type?: string } | undefined;
+        const step = stepLogger.log("memory_read", "readMemory", memOpts);
+        try {
+          const result = await getAgentMemory(db, {
+            agentId,
+            teamId,
+            key: memOpts?.key,
+            type: memOpts?.type,
+          });
+          step.done({ count: result.length });
+          return result;
+        } catch (error) {
+          const msg =
+            error instanceof Error ? error.message : "Memory read failed";
+          step.done({ error: msg });
+          throw error;
+        }
+      },
+
+      writeMemory: async (
+        key: unknown,
+        content: unknown,
+        type: unknown,
+        metadata: unknown,
+      ) => {
+        const keyStr = key as string;
+        const contentStr = content as string;
+        const typeStr = type as string | undefined;
+        const metadataObj = metadata as Record<string, unknown> | undefined;
+        const step = stepLogger.log("memory_write", "writeMemory", {
+          key: keyStr,
+          type: typeStr,
+        });
+        try {
+          await upsertAgentMemory(db, {
+            agentId,
+            teamId,
+            key: keyStr,
+            content: contentStr,
+            type: typeStr ?? null,
+            metadata: metadataObj ?? null,
+          });
+          step.done({ upserted: true });
+          return { success: true };
+        } catch (error) {
+          const msg =
+            error instanceof Error ? error.message : "Memory write failed";
+          step.done({ error: msg });
+          throw error;
+        }
+      },
+
+      getTrigger: () => {
+        const step = stepLogger.log("context", "getTrigger", {});
+        step.done(triggerContext ?? {});
+        return triggerContext ?? {};
+      },
+
+      notify: async (message: unknown, priority: unknown) => {
+        const messageStr = message as string;
+        const priorityStr = (priority as string) ?? "normal";
+        const step = stepLogger.log("notification", "notify", {
+          priority: priorityStr,
+          messageLength: messageStr.length,
+        });
+        try {
+          await updateComputerRun(db, { id: runId, summary: messageStr });
+          await notifications.create(
+            "agent_alert",
+            teamId,
+            { agentName, agentSlug, runId, message: messageStr, priority: priorityStr as "low" | "normal" | "urgent" },
+            { sendEmail: priorityStr === "urgent" },
+          );
+          step.done({ delivered: true });
+          return { success: true };
+        } catch (error) {
+          const msg =
+            error instanceof Error ? error.message : "Notification failed";
+          step.done({ error: msg });
+          throw error;
+        }
+      },
+
+      propose: async (actions: unknown) => {
+        const actionList = actions as ProposedAction[];
+        const step = stepLogger.log("proposal", "propose", {
+          actionCount: actionList.length,
+        });
+        await updateComputerRun(db, {
+          id: runId,
+          proposedActions: actionList,
+          status: "waiting_approval",
+        });
+
+        await notifications.create(
+          "agent_alert",
+          teamId,
+          {
+            agentName,
+            agentSlug,
+            runId,
+            message: `${agentName} has ${actionList.length} proposed action(s) waiting for your approval.`,
+            priority: "normal" as const,
+          },
+        );
+
+        step.done({ submitted: true, actionCount: actionList.length });
+        throw new ProposalSubmittedError(actionList.length);
+      },
+
+      callConnector: async (toolName: unknown, args: unknown) => {
+        if (toolCallCount >= AGENT_LIMITS.maxToolCalls) {
+          throw new Error(
+            `Tool call limit exceeded (max ${AGENT_LIMITS.maxToolCalls})`,
+          );
+        }
+        toolCallCount++;
+        const name = toolName as string;
+        const toolArgs = args as Record<string, unknown>;
+        const step = stepLogger.log("connector_call", name, toolArgs);
+        try {
+          const composioTools = await getComposioTools(userId);
+          const tool = composioTools[name] as
+            | { execute?: (args: Record<string, unknown>) => Promise<unknown> }
+            | undefined;
+          if (!tool?.execute) {
+            throw new Error(`Connector tool not found: ${name}. Ensure the user has connected the service.`);
+          }
+          const result = await tool.execute(toolArgs);
+          step.done(result);
+          return result;
+        } catch (error) {
+          const msg =
+            error instanceof Error ? error.message : "Connector call failed";
+          step.done({ error: msg });
+          throw error;
+        }
+      },
+    };
+
+    const systemDriver = createNodeDriver({
+      permissions: {
+        fs: () => ({ allow: false }),
+        network: () => ({ allow: false }),
+      },
+    });
+
+    driver = new NodeExecutionDriver({
+      system: systemDriver,
+      runtime: systemDriver.runtime,
+      memoryLimit: AGENT_LIMITS.memoryLimitMb,
+      cpuTimeLimitMs: AGENT_LIMITS.cpuTimeLimitMs,
+      bindings,
+    });
+
+    const result = await driver.run(code);
+
+    return {
+      success: true,
+      result: result?.exports ?? result,
+      steps,
+      toolCallCount,
+      llmCallCount,
+    };
+  } catch (error) {
+    if (error instanceof ProposalSubmittedError) {
+      logger.info("Agent submitted proposals for approval", {
+        agentId,
+        runId,
+        actionCount: error.actionCount,
+      });
+      return {
+        success: true,
+        proposalSubmitted: true,
+        steps,
+        toolCallCount,
+        llmCallCount,
+      };
+    }
+
+    const errorMsg =
+      error instanceof Error ? error.message : "Agent execution failed";
+    logger.error("Agent execution failed", {
+      agentId,
+      runId,
+      error: errorMsg,
+    });
+    return {
+      success: false,
+      error: errorMsg,
+      steps,
+      toolCallCount,
+      llmCallCount,
+    };
+  } finally {
+    try {
+      driver?.dispose();
+    } catch {
+      // ignore cleanup errors
+    }
+    try {
+      await mcpServer.close();
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Replay: execute approved proposed actions
+// ---------------------------------------------------------------------------
+
+interface ReplayOptions {
+  db: Database;
+  teamId: string;
+  userId: string;
+  runId: string;
+  actions: ProposedAction[];
+}
+
+export async function executeProposedActions(
+  options: ReplayOptions,
+): Promise<ExecuteAgentResult> {
+  const { db, teamId, userId, runId, actions } = options;
+  const steps: StepRecord[] = [];
+  const stepLogger = createStepLogger(steps);
+  let toolCallCount = 0;
+
+  const { client: mcpClient, server: mcpServer } = await createInProcessMcp(
+    db,
+    teamId,
+    userId,
+  );
+
+  try {
+    for (const action of actions) {
+      toolCallCount++;
+      const step = stepLogger.log("tool_call", action.tool, action.args);
+      try {
+        const result = await mcpClient.callTool({
+          name: action.tool,
+          arguments: action.args,
+        });
+        step.done(result);
+      } catch (error) {
+        const msg =
+          error instanceof Error ? error.message : "Tool call failed";
+        step.done({ error: msg });
+        throw error;
+      }
+    }
+
+    await updateComputerRun(db, {
+      id: runId,
+      status: "completed",
+      toolCallCount,
+      completedAt: new Date(),
+    });
+
+    return {
+      success: true,
+      steps,
+      toolCallCount,
+      llmCallCount: 0,
+    };
+  } catch (error) {
+    const errorMsg =
+      error instanceof Error ? error.message : "Replay execution failed";
+    logger.error("Replay execution failed", { runId, error: errorMsg });
+
+    await updateComputerRun(db, {
+      id: runId,
+      status: "failed",
+      error: errorMsg,
+      toolCallCount,
+      completedAt: new Date(),
+    });
+
+    return {
+      success: false,
+      error: errorMsg,
+      steps,
+      toolCallCount,
+      llmCallCount: 0,
+    };
+  } finally {
+    try {
+      await mcpServer.close();
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}

--- a/apps/compute/src/scheduler.ts
+++ b/apps/compute/src/scheduler.ts
@@ -1,0 +1,119 @@
+import { enqueueRun } from "@midday/job-client";
+import type { Database } from "@midday/db/client";
+import {
+  acquireSchedulerLock,
+  createComputerRun,
+  failStaleRunningRuns,
+  getEnabledScheduledAgents,
+} from "@midday/db/queries";
+import { createLoggerWithContext } from "@midday/logger";
+import { Cron } from "croner";
+
+const logger = createLoggerWithContext("compute:scheduler");
+
+let activeCrons: Cron[] = [];
+let hasLock = false;
+
+export async function startScheduler(db: Database) {
+  const refreshInterval = 60_000;
+
+  async function refreshSchedules() {
+    try {
+      if (!hasLock) {
+        hasLock = await acquireSchedulerLock(db);
+        if (!hasLock) {
+          logger.info("Another instance holds the scheduler lock, skipping");
+          return;
+        }
+        logger.info("Acquired scheduler lock");
+      }
+
+      const staleCount = await failStaleRunningRuns(db, { staleMinutes: 60 });
+      if (staleCount > 0) {
+        logger.warn("Failed stale running runs", { count: staleCount });
+      }
+
+      const agents = await getEnabledScheduledAgents(db);
+
+      for (const cron of activeCrons) {
+        cron.stop();
+      }
+      activeCrons = [];
+
+      for (const agent of agents) {
+        if (!agent.scheduleCron) continue;
+
+        try {
+          const cron = new Cron(agent.scheduleCron, { timezone: agent.timezone ?? "UTC" }, async () => {
+            try {
+              const runId = crypto.randomUUID();
+
+              await createComputerRun(db, {
+                id: runId,
+                agentId: agent.id,
+                teamId: agent.teamId,
+              });
+
+              await enqueueRun({
+                agentId: agent.id,
+                teamId: agent.teamId,
+                runId,
+                triggerType: "schedule",
+              });
+
+              logger.info("Scheduled run enqueued", {
+                agentId: agent.id,
+                slug: agent.slug,
+                runId,
+              });
+            } catch (error) {
+              logger.error("Failed to enqueue scheduled run", {
+                agentId: agent.id,
+                error:
+                  error instanceof Error ? error.message : String(error),
+              });
+            }
+          });
+
+          activeCrons.push(cron);
+          logger.info("Cron registered", {
+            agentId: agent.id,
+            slug: agent.slug,
+            cron: agent.scheduleCron,
+          });
+        } catch (error) {
+          logger.error("Invalid cron expression", {
+            agentId: agent.id,
+            cron: agent.scheduleCron,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      logger.info("Schedules refreshed", {
+        total: agents.length,
+        active: activeCrons.length,
+      });
+    } catch (error) {
+      logger.error("Failed to refresh schedules", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  await refreshSchedules();
+  setInterval(refreshSchedules, refreshInterval);
+
+  logger.info("Scheduler started", {
+    refreshInterval: `${refreshInterval}ms`,
+  });
+}
+
+export function stopScheduler() {
+  for (const cron of activeCrons) {
+    cron.stop();
+  }
+  activeCrons = [];
+  hasLock = false;
+  logger.info("Scheduler stopped");
+}

--- a/apps/compute/src/worker.ts
+++ b/apps/compute/src/worker.ts
@@ -1,0 +1,247 @@
+import type { Database } from "@midday/db/client";
+import {
+  claimComputerRun,
+  getComputerAgentById,
+  getUserTimezone,
+  insertComputerRunSteps,
+  updateComputerRun,
+} from "@midday/db/queries";
+import { createLoggerWithContext } from "@midday/logger";
+import type { Job } from "bullmq";
+import {
+  type ProposedAction,
+  executeAgent,
+  executeProposedActions,
+} from "./runtime";
+
+const logger = createLoggerWithContext("compute:worker");
+
+interface ExecuteAgentJobData {
+  agentId: string;
+  teamId: string;
+  runId: string;
+  triggerType?: "manual" | "schedule";
+  payload?: Record<string, unknown>;
+}
+
+interface ReplayProposalsJobData {
+  runId: string;
+  agentId: string;
+  teamId: string;
+  actions: ProposedAction[];
+}
+
+function safeStringify(value: unknown): string | null {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+type StepType =
+  | "tool_call"
+  | "ai_generation"
+  | "memory_read"
+  | "memory_write"
+  | "notification"
+  | "proposal"
+  | "connector_call"
+  | "context";
+
+export async function processJob(job: Job, db: Database) {
+  const data = job.data as ExecuteAgentJobData;
+  const { agentId, teamId, runId, triggerType, payload } = data;
+
+  logger.info("Processing compute job", { agentId, runId, teamId });
+
+  try {
+    const agent = await getComputerAgentById(db, { id: agentId });
+
+    if (!agent) {
+      logger.error("Agent not found", { agentId, runId });
+      await updateComputerRun(db, {
+        id: runId,
+        status: "failed",
+        error: "agent_not_found",
+        completedAt: new Date(),
+      });
+      return;
+    }
+
+    const claimed = await claimComputerRun(db, { runId, agentId });
+
+    if (!claimed) {
+      logger.info("Skipping run -- agent already has an active run or run was already claimed", {
+        agentId,
+        runId,
+      });
+      await updateComputerRun(db, {
+        id: runId,
+        status: "failed",
+        error: "skipped_concurrent",
+        completedAt: new Date(),
+      });
+      return;
+    }
+
+    const userTimezone = agent.createdBy
+      ? await getUserTimezone(db, { userId: agent.createdBy })
+      : null;
+
+    const result = await executeAgent({
+      db,
+      teamId,
+      userId: agent.createdBy ?? "",
+      agentId,
+      agentName: agent.name,
+      agentSlug: agent.slug,
+      runId,
+      code: agent.code,
+      timezone: userTimezone,
+      triggerContext: {
+        type: triggerType ?? "manual",
+        manual: triggerType !== "schedule",
+        ...(payload ?? {}),
+      },
+    });
+
+    if (result.steps.length > 0) {
+      await insertComputerRunSteps(db, {
+        runId,
+        steps: result.steps.map((step) => ({
+          type: step.type as StepType,
+          name: step.name,
+          input: step.input,
+          output: step.output,
+          durationMs: step.durationMs,
+        })),
+      });
+    }
+
+    if (result.proposalSubmitted) {
+      logger.info("Agent submitted proposals, awaiting approval", {
+        agentId,
+        runId,
+        steps: result.steps.length,
+      });
+    } else {
+      await updateComputerRun(db, {
+        id: runId,
+        status: result.success ? "completed" : "failed",
+        summary: result.success
+          ? typeof result.result === "string"
+            ? result.result
+            : safeStringify(result.result)
+          : null,
+        error: result.error ?? null,
+        toolCallCount: result.toolCallCount,
+        llmCallCount: result.llmCallCount,
+        completedAt: new Date(),
+      });
+    }
+
+    logger.info("Compute job completed", {
+      agentId,
+      runId,
+      success: result.success,
+      proposalSubmitted: result.proposalSubmitted ?? false,
+      toolCalls: result.toolCallCount,
+      llmCalls: result.llmCallCount,
+      steps: result.steps.length,
+    });
+  } catch (error) {
+    const errorMsg =
+      error instanceof Error ? error.message : "Unexpected worker error";
+    logger.error("processJob failed with unhandled error", {
+      agentId,
+      runId,
+      error: errorMsg,
+    });
+    try {
+      await updateComputerRun(db, {
+        id: runId,
+        status: "failed",
+        error: errorMsg,
+        completedAt: new Date(),
+      });
+    } catch (dbError) {
+      logger.error("Failed to update run status after error", {
+        runId,
+        error: dbError instanceof Error ? dbError.message : "unknown",
+      });
+    }
+  }
+}
+
+export async function processReplay(job: Job, db: Database) {
+  const data = job.data as ReplayProposalsJobData;
+  const { runId, agentId, teamId, actions } = data;
+
+  logger.info("Processing replay job", { runId, agentId, actionCount: actions.length });
+
+  try {
+    const agent = await getComputerAgentById(db, { id: agentId });
+    if (!agent) {
+      logger.error("Agent not found for replay", { agentId, runId });
+      await updateComputerRun(db, {
+        id: runId,
+        status: "failed",
+        error: "agent_not_found",
+        completedAt: new Date(),
+      });
+      return;
+    }
+
+    await updateComputerRun(db, { id: runId, status: "running" });
+
+    const result = await executeProposedActions({
+      db,
+      teamId,
+      userId: agent.createdBy ?? "",
+      runId,
+      actions,
+    });
+
+    if (result.steps.length > 0) {
+      await insertComputerRunSteps(db, {
+        runId,
+        steps: result.steps.map((step) => ({
+          type: step.type as StepType,
+          name: step.name,
+          input: step.input,
+          output: step.output,
+          durationMs: step.durationMs,
+        })),
+      });
+    }
+
+    logger.info("Replay job completed", {
+      runId,
+      agentId,
+      success: result.success,
+      toolCalls: result.toolCallCount,
+    });
+  } catch (error) {
+    const errorMsg =
+      error instanceof Error ? error.message : "Unexpected replay error";
+    logger.error("processReplay failed with unhandled error", {
+      agentId,
+      runId,
+      error: errorMsg,
+    });
+    try {
+      await updateComputerRun(db, {
+        id: runId,
+        status: "failed",
+        error: errorMsg,
+        completedAt: new Date(),
+      });
+    } catch (dbError) {
+      logger.error("Failed to update run status after replay error", {
+        runId,
+        error: dbError instanceof Error ? dbError.message : "unknown",
+      });
+    }
+  }
+}

--- a/apps/compute/tsconfig.json
+++ b/apps/compute/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "allowJs": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "paths": {
+      "@compute/*": ["./src/*"],
+      "@api/*": ["../../apps/api/src/*"]
+    },
+    "types": ["bun"]
+  },
+  "exclude": ["node_modules"],
+  "include": ["src", "../../types"]
+}

--- a/apps/dashboard/src/components/chat/chat-utils.ts
+++ b/apps/dashboard/src/components/chat/chat-utils.ts
@@ -129,6 +129,15 @@ export const TOOL_LABELS: Record<string, string> = {
   documents_delete: "Deleting document",
   documents_tag: "Tagging document",
 
+  // Computer agents
+  computer_catalog_list: "Browsing agent catalog",
+  computer_agents_list: "Listing your agents",
+  computer_agent_enable: "Setting up agent",
+  computer_agent_generate: "Generating custom agent",
+  computer_agent_confirm: "Deploying agent",
+  computer_agent_run: "Running agent",
+  computer_agent_runs: "Fetching run history",
+
   // Search & Team
   search_global: "Searching",
   team_members: "Fetching team members",

--- a/apps/dashboard/src/components/chat/tool-call-group.tsx
+++ b/apps/dashboard/src/components/chat/tool-call-group.tsx
@@ -34,6 +34,7 @@ const TOOL_ICON_MAP: Record<string, (s: number) => ReactNode> = {
   search: (s) => <Icons.Search size={s} />,
   web_search: (s) => <Icons.Globle size={s} />,
   team: (s) => <Icons.Face size={s} />,
+  computer: (s) => <Icons.Bolt size={s} />,
   COMPOSIO: (s) => <Icons.AddLink size={s} className="-rotate-45" />,
 };
 

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@polar-sh/sdk": "^0.46.7",
         "@scalar/hono-api-reference": "^0.10.5",
+        "@secure-exec/typescript": "^0.2.1",
         "@sentry/bun": "catalog:",
         "@sindresorhus/slugify": "catalog:",
         "@trigger.dev/sdk": "catalog:",
@@ -63,6 +64,7 @@
         "hono": "catalog:",
         "hono-rate-limiter": "0.5.3",
         "jose": "catalog:",
+        "json-schema-to-typescript": "^15.0.4",
         "lru-cache": "^11.2.7",
         "nanoid": "catalog:",
         "parse-duration": "^2.1.5",
@@ -72,11 +74,39 @@
         "toolpick": "0.4.0",
         "uuid": "catalog:",
         "zod": "catalog:",
+        "zod-to-json-schema": "^3.25.2",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "evalite": "^0.19.0",
         "vitest": "^4.1.1",
+      },
+    },
+    "apps/compute": {
+      "name": "@midday/compute",
+      "version": "0.0.1",
+      "dependencies": {
+        "@ai-sdk/openai": "catalog:",
+        "@composio/core": "^0.6.7",
+        "@composio/vercel": "^0.6.7",
+        "@midday/cache": "workspace:*",
+        "@midday/connectors": "workspace:*",
+        "@midday/db": "workspace:*",
+        "@midday/job-client": "workspace:*",
+        "@midday/logger": "workspace:*",
+        "@midday/notifications": "workspace:*",
+        "@modelcontextprotocol/sdk": "^1.28.0",
+        "@sentry/bun": "catalog:",
+        "ai": "catalog:",
+        "bullmq": "catalog:",
+        "croner": "^9.1.0",
+        "hono": "catalog:",
+        "lru-cache": "^11.2.7",
+        "secure-exec": "^0.2.0",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
       },
     },
     "apps/dashboard": {
@@ -908,6 +938,8 @@
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.27.3", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw=="],
 
+    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
+
     "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.8.2", "", {}, "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA=="],
 
     "@apm-js-collab/tracing-hooks": ["@apm-js-collab/tracing-hooks@0.3.1", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.8.0", "debug": "^4.4.1", "module-details-from-path": "^1.0.4" } }, "sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw=="],
@@ -977,6 +1009,18 @@
     "@browserbasehq/stagehand": ["@browserbasehq/stagehand@1.14.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.27.3", "@browserbasehq/sdk": "^2.0.0", "ws": "^8.18.0", "zod-to-json-schema": "^3.23.5" }, "peerDependencies": { "@playwright/test": "^1.42.1", "deepmerge": "^4.3.1", "dotenv": "^16.4.5", "openai": "^4.62.1", "zod": "^3.23.8" } }, "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ=="],
 
     "@bugsnag/cuid": ["@bugsnag/cuid@3.2.1", "", {}, "sha512-zpvN8xQ5rdRWakMd/BcVkdn2F8HKlDSbM3l7duueK590WmI1T0ObTLc1V/1e55r14WNjPd5AJTYX4yPEAFVi+Q=="],
+
+    "@cbor-extract/cbor-extract-darwin-arm64": ["@cbor-extract/cbor-extract-darwin-arm64@2.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA=="],
+
+    "@cbor-extract/cbor-extract-darwin-x64": ["@cbor-extract/cbor-extract-darwin-x64@2.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q=="],
+
+    "@cbor-extract/cbor-extract-linux-arm": ["@cbor-extract/cbor-extract-linux-arm@2.2.2", "", { "os": "linux", "cpu": "arm" }, "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ=="],
+
+    "@cbor-extract/cbor-extract-linux-arm64": ["@cbor-extract/cbor-extract-linux-arm64@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg=="],
+
+    "@cbor-extract/cbor-extract-linux-x64": ["@cbor-extract/cbor-extract-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA=="],
+
+    "@cbor-extract/cbor-extract-win32-x64": ["@cbor-extract/cbor-extract-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA=="],
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
@@ -1246,6 +1290,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
+
     "@jsonhero/path": ["@jsonhero/path@1.0.21", "", {}, "sha512-gVUDj/92acpVoJwsVJ/RuWOaHyG4oFzn898WNGQItLCTQ+hOaVlEaImhwE1WqOTf+l3dGOUkbSiVKlb3q1hd1Q=="],
 
     "@langchain/classic": ["@langchain/classic@1.0.3", "", { "dependencies": { "@langchain/openai": "1.1.1", "@langchain/textsplitters": "1.0.0", "handlebars": "^4.7.8", "js-yaml": "^4.1.0", "jsonpointer": "^5.0.1", "openapi-types": "^12.1.3", "p-retry": "4", "uuid": "^10.0.0", "yaml": "^2.2.1", "zod": "^3.25.76 || ^4" }, "optionalDependencies": { "langsmith": "^0.3.64" }, "peerDependencies": { "@langchain/core": "^1.0.0", "cheerio": "*", "peggy": "^3.0.2", "typeorm": "*" }, "optionalPeers": ["cheerio", "peggy", "typeorm"] }, "sha512-XyoaiJSi4y7SzrZMCb3DdDfC+M3gqIQpVH2cOCh9xQf4244jNrncpLXF/MwOJYWxzTsjfcCAHIbFJ0kSH5nqmg=="],
@@ -1291,6 +1337,8 @@
     "@midday/cache": ["@midday/cache@workspace:packages/cache"],
 
     "@midday/categories": ["@midday/categories@workspace:packages/categories"],
+
+    "@midday/compute": ["@midday/compute@workspace:apps/compute"],
 
     "@midday/connectors": ["@midday/connectors@workspace:packages/connectors"],
 
@@ -1856,6 +1904,22 @@
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
+    "@secure-exec/core": ["@secure-exec/core@0.2.1", "", { "dependencies": { "better-sqlite3": "^12.8.0" } }, "sha512-HsnUv6gClpMA1BBRmX86j30TKTZtgJC/fO1tVavr7IpM2zNKbHU8LgSlBd7mv2SNy02ImTmU/GnQ3aYB4NSbEg=="],
+
+    "@secure-exec/nodejs": ["@secure-exec/nodejs@0.2.1", "", { "dependencies": { "@secure-exec/core": "0.2.1", "@secure-exec/v8": "0.2.1", "cbor-x": "^1.6.4", "cjs-module-lexer": "^2.1.0", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.1", "node-stdlib-browser": "^1.3.1", "web-streams-polyfill": "^4.2.0" } }, "sha512-UJMJqVFxexlHJV0Q9nWURvrz6GElj8673DDOOFln6FHR6JS+9SaSU3eISrN158DuNC3SFi4rgjb/scKnK4YOYQ=="],
+
+    "@secure-exec/typescript": ["@secure-exec/typescript@0.2.1", "", { "dependencies": { "@secure-exec/core": "0.2.1", "secure-exec": "0.2.1", "typescript": "^5.9.3" } }, "sha512-ilp7Zs3gm4VlM1dMNL9D/tLdu6EESEneng8EloNeG8kRAG7PFJDvwULjXAjuC7Ock6IUNF5lm1QzbZjtLPtF0w=="],
+
+    "@secure-exec/v8": ["@secure-exec/v8@0.2.1", "", { "dependencies": { "cbor-x": "^1.6.4" }, "optionalDependencies": { "@secure-exec/v8-darwin-arm64": "0.2.1", "@secure-exec/v8-darwin-x64": "0.2.1", "@secure-exec/v8-linux-arm64-gnu": "0.2.1", "@secure-exec/v8-linux-x64-gnu": "0.2.1" } }, "sha512-ye/seCqzvyMGnvyP+AO7RkVMR/lE3x9m0D2PfmiAXA457R78ZmOFmZ6v+JlJG2vv3LM30KsSXTUhwpG+Teh0hw=="],
+
+    "@secure-exec/v8-darwin-arm64": ["@secure-exec/v8-darwin-arm64@0.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gEWhMHzUpLwzuBNAD0lVkZXE8wFlWMLp4IOZ+56FYwOW/C+m07cYxuW4TjHyPqZ+vPm3IkoaMqqH5yT9VhjX/Q=="],
+
+    "@secure-exec/v8-darwin-x64": ["@secure-exec/v8-darwin-x64@0.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-H2Z5K+Cq+fn/kxjGvhJzepnNFWG6qNdyhZybVWGr5bAAZoSz/Qkad4WnXcurWU+880tKDtnf19LHBXrg7zewNQ=="],
+
+    "@secure-exec/v8-linux-arm64-gnu": ["@secure-exec/v8-linux-arm64-gnu@0.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-14subGhVV/gW35mYYm7Gv1Keeex7PxIgQfoKji/JH7wYyDuarP6kgaES0nJw+JXVkxEVud52c+kbcIjIggqCEw=="],
+
+    "@secure-exec/v8-linux-x64-gnu": ["@secure-exec/v8-linux-x64-gnu@0.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Az4s+vUf+78vWtsC7rTn/jQc6WKJafAdt2YpEjB4Gnu+sX+FFTIst1hRV4gJonbRyJdy6SW+OQ6DZatmwczorQ=="],
+
     "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
     "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.38.0", "", { "dependencies": { "@sentry/core": "10.38.0" } }, "sha512-UOJtYmdcxHCcV0NPfXFff/a95iXl/E0EhuQ1y0uE0BuZDMupWSF5t2BgC4HaE5Aw3RTjDF3XkSHWoIF6ohy7eA=="],
@@ -2154,7 +2218,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -2266,6 +2330,8 @@
 
     "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
 
+    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
+
     "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
@@ -2278,7 +2344,7 @@
 
     "@types/mysql": ["@types/mysql@2.15.27", "", { "dependencies": { "@types/node": "*" } }, "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA=="],
 
-    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
@@ -2444,6 +2510,10 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
+    "asn1.js": ["asn1.js@4.10.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw=="],
+
+    "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
@@ -2463,6 +2533,8 @@
     "attr-accept": ["attr-accept@2.2.5", "", {}, "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ=="],
 
     "autoprefixer": ["autoprefixer@10.4.27", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-lite": "^1.0.30001774", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA=="],
+
+    "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "avvio": ["avvio@9.2.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ=="],
 
@@ -2504,13 +2576,29 @@
 
     "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
+    "bn.js": ["bn.js@5.2.3", "", {}, "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
+
     "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
+
+    "browser-resolve": ["browser-resolve@2.0.0", "", { "dependencies": { "resolve": "^1.17.0" } }, "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ=="],
+
+    "browserify-aes": ["browserify-aes@1.2.0", "", { "dependencies": { "buffer-xor": "^1.0.3", "cipher-base": "^1.0.0", "create-hash": "^1.1.0", "evp_bytestokey": "^1.0.3", "inherits": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA=="],
+
+    "browserify-cipher": ["browserify-cipher@1.0.1", "", { "dependencies": { "browserify-aes": "^1.0.4", "browserify-des": "^1.0.0", "evp_bytestokey": "^1.0.0" } }, "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w=="],
+
+    "browserify-des": ["browserify-des@1.0.2", "", { "dependencies": { "cipher-base": "^1.0.1", "des.js": "^1.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A=="],
+
+    "browserify-rsa": ["browserify-rsa@4.1.1", "", { "dependencies": { "bn.js": "^5.2.1", "randombytes": "^2.1.0", "safe-buffer": "^5.2.1" } }, "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ=="],
+
+    "browserify-sign": ["browserify-sign@4.2.5", "", { "dependencies": { "bn.js": "^5.2.2", "browserify-rsa": "^4.1.1", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "elliptic": "^6.6.1", "inherits": "^2.0.4", "parse-asn1": "^5.1.9", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1" } }, "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw=="],
 
     "browserify-zlib": ["browserify-zlib@0.2.0", "", { "dependencies": { "pako": "~1.0.5" } }, "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA=="],
 
@@ -2524,9 +2612,13 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "buffer-xor": ["buffer-xor@1.0.3", "", {}, "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="],
+
+    "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
+
     "bullmq": ["bullmq@5.71.1", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.10.1", "msgpackr": "1.11.5", "node-abort-controller": "3.1.1", "semver": "7.7.4", "tslib": "2.8.1", "uuid": "11.1.0" } }, "sha512-kOBfdcsHmO6wwmIjpersoVdYQ7jkjTgky4Yop0loc7QwSdgxliSzD69U9ijZuRrkyCJwz5p5eqxeGeQkJ0YGZQ=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -2553,6 +2645,10 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001769", "", {}, "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg=="],
 
     "canvas": ["canvas@3.2.1", "", { "dependencies": { "node-addon-api": "^7.0.0", "prebuild-install": "^7.1.3" } }, "sha512-ej1sPFR5+0YWtaVp6S1N1FVz69TQCqmrkGeRvQxZeAB1nAIcjNTHVwrZtYtWFFBmQsF40/uDLehsW5KuYC99mg=="],
+
+    "cbor-extract": ["cbor-extract@2.2.2", "", { "dependencies": { "node-gyp-build-optional-packages": "5.1.1" }, "optionalDependencies": { "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2", "@cbor-extract/cbor-extract-darwin-x64": "2.2.2", "@cbor-extract/cbor-extract-linux-arm": "2.2.2", "@cbor-extract/cbor-extract-linux-arm64": "2.2.2", "@cbor-extract/cbor-extract-linux-x64": "2.2.2", "@cbor-extract/cbor-extract-win32-x64": "2.2.2" }, "bin": { "download-cbor-prebuilds": "bin/download-prebuilds.js" } }, "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng=="],
+
+    "cbor-x": ["cbor-x@1.6.4", "", { "optionalDependencies": { "cbor-extract": "^2.2.2" } }, "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -2586,9 +2682,11 @@
 
     "chrono-node": ["chrono-node@2.9.0", "", {}, "sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ=="],
 
+    "cipher-base": ["cipher-base@1.0.7", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.2" } }, "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA=="],
+
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
-    "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -2646,7 +2744,11 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "console-browserify": ["console-browserify@1.2.0", "", {}, "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="],
+
     "console-table-printer": ["console-table-printer@2.15.0", "", { "dependencies": { "simple-wcswidth": "^1.1.2" } }, "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw=="],
+
+    "constants-browserify": ["constants-browserify@1.0.0", "", {}, "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ=="],
 
     "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
@@ -2674,13 +2776,25 @@
 
     "crc32-stream": ["crc32-stream@6.0.0", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^4.0.0" } }, "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g=="],
 
+    "create-ecdh": ["create-ecdh@4.0.4", "", { "dependencies": { "bn.js": "^4.1.0", "elliptic": "^6.5.3" } }, "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A=="],
+
+    "create-hash": ["create-hash@1.2.0", "", { "dependencies": { "cipher-base": "^1.0.1", "inherits": "^2.0.1", "md5.js": "^1.3.4", "ripemd160": "^2.0.1", "sha.js": "^2.4.0" } }, "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg=="],
+
+    "create-hmac": ["create-hmac@1.1.7", "", { "dependencies": { "cipher-base": "^1.0.3", "create-hash": "^1.1.0", "inherits": "^2.0.1", "ripemd160": "^2.0.0", "safe-buffer": "^5.0.1", "sha.js": "^2.4.8" } }, "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg=="],
+
+    "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
+
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
 
+    "croner": ["croner@9.1.0", "", {}, "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g=="],
+
     "cronstrue": ["cronstrue@2.61.0", "", { "bin": { "cronstrue": "bin/cli.js" } }, "sha512-ootN5bvXbIQI9rW94+QsXN5eROtXWwew6NkdGxIRpS/UFWRggL0G5Al7a9GTBFEsuvVhJ2K3CntIIVt7L2ILhA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crypto-browserify": ["crypto-browserify@3.12.1", "", { "dependencies": { "browserify-cipher": "^1.0.1", "browserify-sign": "^4.2.3", "create-ecdh": "^4.0.4", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "diffie-hellman": "^5.0.3", "hash-base": "~3.0.4", "inherits": "^2.0.4", "pbkdf2": "^3.1.2", "public-encrypt": "^4.0.3", "randombytes": "^2.1.0", "randomfill": "^1.0.4" } }, "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ=="],
 
     "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
 
@@ -2806,6 +2920,8 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
@@ -2817,6 +2933,8 @@
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "des.js": ["des.js@1.1.0", "", { "dependencies": { "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg=="],
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
@@ -2830,6 +2948,8 @@
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
+    "diffie-hellman": ["diffie-hellman@5.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "miller-rabin": "^4.0.0", "randombytes": "^2.0.0" } }, "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg=="],
+
     "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
 
     "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
@@ -2837,6 +2957,8 @@
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domain-browser": ["domain-browser@4.22.0", "", {}, "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw=="],
 
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
@@ -2869,6 +2991,8 @@
     "effect": ["effect@3.19.16", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-7+XC3vGrbAhCHd8LTFHvnZjRpZKZ8YHRZqJTkpNoxcJ2mCyNs2SwI+6VkV/ij8Y3YW7wfBN4EbU06/F5+m/wkQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.286", "", {}, "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A=="],
+
+    "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
 
     "embla-carousel": ["embla-carousel@8.6.0", "", {}, "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA=="],
 
@@ -2968,6 +3092,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
+    "evp_bytestokey": ["evp_bytestokey@1.0.3", "", { "dependencies": { "md5.js": "^1.3.4", "safe-buffer": "^5.1.1" } }, "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA=="],
+
     "evt": ["evt@2.5.9", "", { "dependencies": { "minimal-polyfills": "^2.2.3", "run-exclusive": "^2.2.19", "tsafe": "^1.8.5" } }, "sha512-GpjX476FSlttEGWHT8BdVMoI8wGXQGbEOtKcP4E+kggg+yJzXBZN2n4x7TS/zPBJ1DZqWI+rguZZApjjzQ0HpA=="],
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
@@ -3048,6 +3174,8 @@
 
     "fontkit": ["fontkit@2.0.4", "", { "dependencies": { "@swc/helpers": "^0.5.12", "brotli": "^1.3.2", "clone": "^2.1.2", "dfa": "^1.2.0", "fast-deep-equal": "^3.1.3", "restructure": "^3.0.0", "tiny-inflate": "^1.0.3", "unicode-properties": "^1.4.0", "unicode-trie": "^2.0.0" } }, "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g=="],
 
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
@@ -3081,6 +3209,8 @@
     "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "geist": ["geist@1.7.0", "", { "peerDependencies": { "next": ">=13.2.0" } }, "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ=="],
+
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -3144,6 +3274,10 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
+    "hash-base": ["hash-base@3.0.5", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1" } }, "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg=="],
+
+    "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
@@ -3172,6 +3306,8 @@
 
     "hls.js": ["hls.js@1.6.15", "", {}, "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA=="],
 
+    "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
+
     "hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 
     "hono-rate-limiter": ["hono-rate-limiter@0.5.3", "", { "peerDependencies": { "hono": "^4.10.8", "unstorage": "^1.17.3" }, "optionalPeers": ["unstorage"] }, "sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A=="],
@@ -3189,6 +3325,8 @@
     "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "https-browserify": ["https-browserify@1.0.0", "", {}, "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="],
 
     "https-proxy-agent": ["https-proxy-agent@8.0.0", "", { "dependencies": { "agent-base": "8.0.0", "debug": "^4.3.4" } }, "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ=="],
 
@@ -3246,9 +3384,13 @@
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
+    "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
+
     "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
@@ -3262,6 +3404,8 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
@@ -3271,6 +3415,8 @@
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
+    "is-nan": ["is-nan@1.3.2", "", { "dependencies": { "call-bind": "^1.0.0", "define-properties": "^1.1.3" } }, "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w=="],
 
     "is-network-error": ["is-network-error@1.3.0", "", {}, "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw=="],
 
@@ -3282,7 +3428,11 @@
 
     "is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
 
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
@@ -3297,6 +3447,8 @@
     "isbot": ["isbot@5.1.34", "", {}, "sha512-aCMIBSKd/XPRYdiCQTLC8QHH4YT8B3JUADu+7COgYIZPvkeoMcUHMRjZLM9/7V8fCj+l7FSREc1lOPNjzogo/A=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "isomorphic-timers-promises": ["isomorphic-timers-promises@1.0.1", "", {}, "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ=="],
 
     "isstream": ["isstream@0.1.2", "", {}, "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="],
 
@@ -3331,6 +3483,8 @@
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
+
+    "json-schema-to-typescript": ["json-schema-to-typescript@15.0.4", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "^11.5.5", "@types/json-schema": "^7.0.15", "@types/lodash": "^4.17.7", "is-glob": "^4.0.3", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "minimist": "^1.2.8", "prettier": "^3.2.5", "tinyglobby": "^0.2.9" }, "bin": { "json2ts": "dist/src/cli.js" } }, "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -3526,6 +3680,8 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "md5.js": ["md5.js@1.3.5", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
@@ -3646,6 +3802,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "miller-rabin": ["miller-rabin@4.0.1", "", { "dependencies": { "bn.js": "^4.0.0", "brorand": "^1.0.1" }, "bin": { "miller-rabin": "bin/miller-rabin" } }, "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA=="],
+
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
@@ -3659,6 +3817,10 @@
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
     "minimal-polyfills": ["minimal-polyfills@2.2.3", "", {}, "sha512-oxdmJ9cL+xV72h0xYxp4tP2d5/fTBpP45H8DIOn9pASuF8a3IYTf+25fMGDYGiWW+MFsuog6KD6nfmhZJQ+uUw=="],
+
+    "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
+
+    "minimalistic-crypto-utils": ["minimalistic-crypto-utils@1.0.1", "", {}, "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="],
 
     "minimatch": ["minimatch@10.1.2", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.1" } }, "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw=="],
 
@@ -3732,6 +3894,8 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
+    "node-stdlib-browser": ["node-stdlib-browser@1.3.1", "", { "dependencies": { "assert": "^2.0.0", "browser-resolve": "^2.0.0", "browserify-zlib": "^0.2.0", "buffer": "^5.7.1", "console-browserify": "^1.1.0", "constants-browserify": "^1.0.0", "create-require": "^1.1.1", "crypto-browserify": "^3.12.1", "domain-browser": "4.22.0", "events": "^3.0.0", "https-browserify": "^1.0.0", "isomorphic-timers-promises": "^1.0.1", "os-browserify": "^0.3.0", "path-browserify": "^1.0.1", "pkg-dir": "^5.0.0", "process": "^0.11.10", "punycode": "^1.4.1", "querystring-es3": "^0.2.1", "readable-stream": "^3.6.0", "stream-browserify": "^3.0.0", "stream-http": "^3.2.0", "string_decoder": "^1.0.0", "timers-browserify": "^2.0.4", "tty-browserify": "0.0.1", "url": "^0.11.4", "util": "^0.12.4", "vm-browserify": "^1.0.1" } }, "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw=="],
+
     "node-xlsx": ["node-xlsx@0.24.0", "", { "dependencies": { "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz" }, "bin": { "node-xlsx": "dist/bin/cli.js" } }, "sha512-1olwK48XK9nXZsyH/FCltvGrQYvXXZuxVitxXXv2GIuRm51aBi1+5KwR4rWM4KeO61sFU+00913WLZTD+AcXEg=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
@@ -3754,7 +3918,11 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
+
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
@@ -3792,6 +3960,8 @@
 
     "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
 
+    "os-browserify": ["os-browserify@0.3.0", "", {}, "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A=="],
+
     "os-paths": ["os-paths@7.4.0", "", { "optionalDependencies": { "fsevents": "*" } }, "sha512-Ux1J4NUqC6tZayBqLN1kUlDAEvLiQlli/53sSddU4IN+h+3xxnv2HmRSMpVSvr1hvJzotfMs3ERvETGK+f4OwA=="],
 
     "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
@@ -3816,6 +3986,8 @@
 
     "papaparse": ["papaparse@5.5.3", "", {}, "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="],
 
+    "parse-asn1": ["parse-asn1@5.1.9", "", { "dependencies": { "asn1.js": "^4.10.1", "browserify-aes": "^1.2.0", "evp_bytestokey": "^1.0.3", "pbkdf2": "^3.1.5", "safe-buffer": "^5.2.1" } }, "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg=="],
+
     "parse-duration": ["parse-duration@2.1.5", "", {}, "sha512-/IX1KRw6zHDOOJrgIz++gvFASbFl7nc8GEXaLdD7d1t1x/GnrK6hh5Fgk8G3RLpkIEi4tsGj9pupGLWNg0EiJA=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -3829,6 +4001,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "partysocket": ["partysocket@1.1.12", "", { "dependencies": { "event-target-polyfill": "^0.0.4" } }, "sha512-079YDW1QZsFwJ8syLmr9xFMbE+VwbK4SpcKSOPVApX8rpIMennkxx0MeWl4oWutP/Zjgy8TMnQZ3FOXTQvu3DA=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
@@ -3845,6 +4019,8 @@
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pbkdf2": ["pbkdf2@3.1.5", "", { "dependencies": { "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "ripemd160": "^2.0.3", "safe-buffer": "^5.2.1", "sha.js": "^2.4.12", "to-buffer": "^1.2.1" } }, "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ=="],
 
     "pdfjs-dist": ["pdfjs-dist@5.5.207", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.95", "node-readable-to-web-readable-stream": "^0.4.2" } }, "sha512-WMqqw06w1vUt9ZfT0gOFhMf3wHsWhaCrxGrckGs5Cci6ybDW87IvPaOd2pnBwT6BJuP/CzXDZxjFgmSULLdsdw=="],
 
@@ -3890,6 +4066,8 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "^5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
+
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "plaid": ["plaid@41.4.0", "", { "dependencies": { "axios": "^1.7.4" } }, "sha512-Ku5W9Ufsa2+TS0/kY8jS6RFPtBUbTq1xNyod89qQt/Jy2L9q9CYAnNL0WlUGa+Y5HEGP990BxCUUS2lGMRxY3g=="],
@@ -3905,6 +4083,8 @@
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "polka": ["polka@0.5.2", "", { "dependencies": { "@polka/url": "^0.5.0", "trouter": "^2.0.1" } }, "sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw=="],
+
+    "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postal-mime": ["postal-mime@2.7.3", "", {}, "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw=="],
 
@@ -4004,9 +4184,11 @@
 
     "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
 
+    "public-encrypt": ["public-encrypt@4.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "browserify-rsa": "^4.0.0", "create-hash": "^1.1.0", "parse-asn1": "^5.0.0", "randombytes": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q=="],
+
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
-    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+    "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
@@ -4019,6 +4201,8 @@
     "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
 
     "query-string": ["query-string@6.14.1", "", { "dependencies": { "decode-uri-component": "^0.2.0", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw=="],
+
+    "querystring-es3": ["querystring-es3@0.2.1", "", {}, "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="],
 
     "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
 
@@ -4033,6 +4217,8 @@
     "random-bytes": ["random-bytes@1.0.0", "", {}, "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ=="],
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "randomfill": ["randomfill@1.0.4", "", { "dependencies": { "randombytes": "^2.0.5", "safe-buffer": "^5.1.0" } }, "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
@@ -4180,6 +4366,8 @@
 
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
+    "ripemd160": ["ripemd160@2.0.3", "", { "dependencies": { "hash-base": "^3.1.2", "inherits": "^2.0.4" } }, "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA=="],
+
     "rndm": ["rndm@1.2.0", "", {}, "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw=="],
 
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
@@ -4212,6 +4400,8 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
     "safe-regex2": ["safe-regex2@5.1.0", "", { "dependencies": { "ret": "~0.5.0" }, "bin": { "safe-regex2": "bin/safe-regex2.js" } }, "sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
@@ -4221,6 +4411,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
+
+    "secure-exec": ["secure-exec@0.2.1", "", { "dependencies": { "@secure-exec/core": "0.2.1", "@secure-exec/nodejs": "0.2.1" } }, "sha512-oaQDzTPDSCOckYC8G0PimIqzEVxY6sYEvcx0fMGsRR/Wl4wkFVHaZgQ3kc2DHWysV6WHWt5g1AXc/6seafO2XQ=="],
 
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
@@ -4251,6 +4443,8 @@
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sha.js": ["sha.js@2.4.12", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": { "sha.js": "bin.js" } }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -4325,6 +4519,10 @@
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
     "stdin-discarder": ["stdin-discarder@0.3.1", "", {}, "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA=="],
+
+    "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
+
+    "stream-http": ["stream-http@3.2.0", "", { "dependencies": { "builtin-status-codes": "^3.0.0", "inherits": "^2.0.4", "readable-stream": "^3.6.0", "xtend": "^4.0.2" } }, "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A=="],
 
     "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
 
@@ -4426,6 +4624,8 @@
 
     "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
+    "timers-browserify": ["timers-browserify@2.0.12", "", { "dependencies": { "setimmediate": "^1.0.4" } }, "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ=="],
+
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
@@ -4445,6 +4645,8 @@
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tippy.js": ["tippy.js@6.3.7", "", { "dependencies": { "@popperjs/core": "^2.9.0" } }, "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ=="],
+
+    "to-buffer": ["to-buffer@1.2.2", "", { "dependencies": { "isarray": "^2.0.5", "safe-buffer": "^5.2.1", "typed-array-buffer": "^1.0.3" } }, "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -4490,6 +4692,8 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
+    "tty-browserify": ["tty-browserify@0.0.1", "", {}, "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="],
+
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "turbo": ["turbo@2.9.3", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.3", "@turbo/darwin-arm64": "2.9.3", "@turbo/linux-64": "2.9.3", "@turbo/linux-arm64": "2.9.3", "@turbo/windows-64": "2.9.3", "@turbo/windows-arm64": "2.9.3" }, "bin": { "turbo": "bin/turbo" } }, "sha512-J/VUvsGRykPb9R8Kh8dHVBOqioDexLk9BhLCU/ZybRR+HN9UR3cURdazFvNgMDt9zPP8TF6K73Z+tplfmi0PqQ=="],
@@ -4501,6 +4705,8 @@
     "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
@@ -4524,7 +4730,7 @@
 
     "underscore": ["underscore@1.13.7", "", {}, "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unicode-properties": ["unicode-properties@1.4.1", "", { "dependencies": { "base64-js": "^1.3.0", "unicode-trie": "^2.0.0" } }, "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg=="],
 
@@ -4556,6 +4762,8 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
+    "url": ["url@0.11.4", "", { "dependencies": { "punycode": "^1.4.1", "qs": "^6.12.3" } }, "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg=="],
+
     "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
 
     "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
@@ -4571,6 +4779,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
+
+    "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -4598,6 +4808,8 @@
 
     "vitest": ["vitest@4.1.1", "", { "dependencies": { "@vitest/expect": "4.1.1", "@vitest/mocker": "4.1.1", "@vitest/pretty-format": "4.1.1", "@vitest/runner": "4.1.1", "@vitest/snapshot": "4.1.1", "@vitest/spy": "4.1.1", "@vitest/utils": "4.1.1", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.1", "@vitest/browser-preview": "4.1.1", "@vitest/browser-webdriverio": "4.1.1", "@vitest/ui": "4.1.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA=="],
 
+    "vm-browserify": ["vm-browserify@1.1.2", "", {}, "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="],
+
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
     "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
@@ -4618,7 +4830,7 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
-    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
+    "web-streams-polyfill": ["web-streams-polyfill@4.2.0", "", {}, "sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -4635,6 +4847,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
+
+    "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
@@ -4698,7 +4912,7 @@
 
     "zod-error": ["zod-error@1.5.0", "", { "dependencies": { "zod": "^3.20.2" } }, "sha512-zzopKZ/skI9iXpqCEPj+iLCKl9b88E43ehcU+sbRoHuwGd9F1IDVGQ70TyO6kmfiRL1g4IXkjsXK+g1gLYl4WQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zod-validation-error": ["zod-validation-error@1.5.0", "", { "peerDependencies": { "zod": "^3.18.0" } }, "sha512-/7eFkAI4qV0tcxMBB/3+d2c1P6jzzZYdYSlBuAklzMuCrJu5bzJfHS0yVAS87dRHVlhftd6RFJDIvv03JgkSbw=="],
 
@@ -4756,11 +4970,15 @@
 
     "@browserbasehq/stagehand/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@browserbasehq/stagehand/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
     "@chevrotain/cst-dts-gen/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 
     "@chevrotain/gast/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 
     "@composio/core/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "@composio/core/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
@@ -4803,6 +5021,8 @@
     "@modelcontextprotocol/sdk/hono": ["hono@4.11.4", "", {}, "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA=="],
 
     "@modelcontextprotocol/sdk/jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
+    "@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
@@ -4994,6 +5214,12 @@
 
     "@scalar/types/nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
+    "@secure-exec/core/better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
+
+    "@secure-exec/nodejs/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "@secure-exec/typescript/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
     "@sentry-internal/browser-utils/@sentry/core": ["@sentry/core@10.38.0", "", {}, "sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g=="],
 
     "@sentry-internal/feedback/@sentry/core": ["@sentry/core@10.38.0", "", {}, "sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g=="],
@@ -5106,6 +5332,8 @@
 
     "@trigger.dev/schema-to-json/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@trigger.dev/schema-to-json/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
     "@trigger.dev/sdk/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@types/body-parser/@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
@@ -5152,15 +5380,17 @@
 
     "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
+    "asn1.js/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "autoprefixer/caniuse-lite": ["caniuse-lite@1.0.30001781", "", {}, "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "bullmq/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "browserify-sign/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
-    "bun-types/@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
+    "bullmq/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "c12/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -5171,6 +5401,8 @@
     "c12/jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
     "c12/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "cbor-extract/node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.1.1", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw=="],
 
     "chevrotain/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 
@@ -5184,6 +5416,8 @@
 
     "concat-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "create-ecdh/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
     "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
@@ -5194,11 +5428,15 @@
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
+    "diffie-hellman/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "effect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "elliptic/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
     "engine.io/@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
 
@@ -5232,6 +5470,8 @@
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "formdata-node/web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
+
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -5261,6 +5501,8 @@
     "ibm-cloud-sdk-core/file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
 
     "ibm-cloud-sdk-core/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
 
     "intuit-oauth/axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
 
@@ -5296,15 +5538,23 @@
 
     "markdown-it/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "md5.js/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
+
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "minizlib/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "node-stdlib-browser/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "node-stdlib-browser/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
@@ -5352,6 +5602,10 @@
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "psl/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "public-encrypt/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
@@ -5374,6 +5628,8 @@
 
     "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
+    "ripemd160/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
+
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.12", "", {}, "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw=="],
 
     "rrweb-snapshot/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -5395,6 +5651,10 @@
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
+
+    "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "stream-http/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -5423,6 +5683,8 @@
     "tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "tough-cookie/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "trigger.dev/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -5818,13 +6080,9 @@
 
     "@sentry/node-core/@sentry/opentelemetry/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
-    "@sentry/node-core/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
     "@sentry/node/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.213.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw=="],
 
     "@sentry/node/@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
-
-    "@sentry/node/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "@sentry/vercel-edge/@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
 
@@ -5843,6 +6101,8 @@
     "@slack/socket-mode/@slack/web-api/axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
 
     "@slack/socket-mode/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@slack/web-api/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@slack/web-api/axios/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
@@ -5872,6 +6132,8 @@
 
     "@types/pg-pool/@types/pg/pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
 
+    "@types/pg/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "@types/qrcode/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/readdir-glob/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
@@ -5892,7 +6154,11 @@
 
     "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "browserify-sign/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "browserify-sign/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "browserify-sign/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "c12/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -6022,6 +6288,8 @@
 
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "md5.js/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "officeparser/file-type/strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
@@ -6069,6 +6337,8 @@
     "rimraf/glob/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "ripemd160/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "rrweb-snapshot/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -6168,8 +6438,6 @@
 
     "@composio/core/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "@fastify/otel/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
     "@fastify/otel/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@fastify/static/glob/path-scurry/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
@@ -6206,53 +6474,7 @@
 
     "@midday/mcp-apps/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.11", "", {}, "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ=="],
 
-    "@opentelemetry/instrumentation-amqplib/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-connect/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-dataloader/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-express/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-fs/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-generic-pool/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-graphql/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-hapi/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-http/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-ioredis/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-kafkajs/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-knex/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-koa/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-lru-memoizer/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-mongodb/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-mongoose/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-mysql/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-mysql2/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-pg/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
     "@opentelemetry/instrumentation-pg/@types/pg/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "@opentelemetry/instrumentation-redis/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-tedious/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@opentelemetry/instrumentation-undici/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
-
-    "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "@react-email/preview-server/next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -6267,8 +6489,6 @@
     "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-pg/@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
 
     "@sentry/nextjs/@sentry/node/@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
-
-    "@sentry/nextjs/@sentry/node/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "@slack/bolt/@slack/web-api/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -6309,6 +6529,12 @@
     "langchain/langsmith/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "langsmith/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "md5.js/hash-base/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "md5.js/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "md5.js/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "officeparser/file-type/strtok3/peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
@@ -6429,6 +6655,12 @@
     "rimraf/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "ripemd160/hash-base/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "ripemd160/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "ripemd160/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/docs/midday-computer.md
+++ b/docs/midday-computer.md
@@ -1,0 +1,525 @@
+# Midday Computer
+
+Midday Computer is an autonomous agent runtime that lets users create AI-powered workflows on top of their Midday data. Agents run inside secure V8 isolates with direct access to all 117+ MCP tools, AI reasoning, persistent memory, proactive notifications (in-app + email), human-in-the-loop approval mode for write operations, and external service integrations via Composio connectors.
+
+## Architecture overview
+
+```
+CLI / Dashboard
+      │
+      ▼
+  apps/api  ────────────  REST routes at /computer/*
+      │                   Agent CRUD, catalog, NL generation,
+      │                   run triggers, proposal review
+      │
+      │  enqueueRun() / enqueueReplay()
+      │  (BullMQ via @midday/job-client)
+      ▼
+  REDIS_QUEUE_URL  ──────  Shared Redis (same as main worker)
+      │                    Queue name: "compute"
+      │                    Job types: execute-agent, replay-proposals
+      ▼
+  apps/compute  ─────────  Standalone Bun service
+      │                    BullMQ worker + cron scheduler
+      │
+      ├── scheduler.ts     Polls DB every 60s for enabled agents
+      │                    with cron schedules, registers croner jobs
+      │
+      ├── worker.ts        Processes BullMQ jobs: concurrency checks,
+      │                    loads agent code, delegates to runtime
+      │                    Dispatches execute-agent or replay-proposals
+      │
+      └── runtime.ts       Creates V8 isolate (Secure Exec),
+                           wires bindings, executes agent code
+                              │
+                              ├── In-process MCP (callTool + parseMcp)
+                              ├── OpenAI via AI SDK (generateText)
+                              ├── Postgres via queries (readMemory/writeMemory)
+                              ├── @midday/notifications (notify)
+                              ├── Composio connectors (callConnector)
+                              └── Approval mode (propose)
+```
+
+## Packages and services
+
+| Component | Location | Role |
+|-----------|----------|------|
+| Compute service | `apps/compute/` | BullMQ worker + cron scheduler + health endpoint |
+| API routes | `apps/api/src/rest/routers/computer.ts` | Agent CRUD, catalog, NL generation, run triggers |
+| Catalog agents | `apps/api/src/rest/routers/computer/catalog.ts` | Pre-built agent templates |
+| NL orchestrator | `apps/api/src/rest/routers/computer/orchestrator.ts` | GPT-4.1 agent code generator with type-check + repair loop |
+| Type stubs | `apps/api/src/rest/routers/computer/stubs.ts` | Auto-generates TypeScript declarations from `listTools()` |
+| Job client | `packages/job-client/src/compute.ts` | `enqueueRun()` and `enqueueReplay()` for the compute queue |
+| Notifications | `packages/notifications/src/types/computer-agent-alert.ts` | `agent_alert` notification type (in-app + email) |
+| DB queries | `packages/db/src/queries/computer.ts` | All `computer_*` table operations |
+| DB schema | `packages/db/src/schema.ts` (bottom) | Tables, enums, relations, RLS policies |
+| CLI commands | `packages/cli/src/commands/computer/index.ts` | `midday computer` subcommands |
+| Migration | `packages/db/migrations/0039_add_computer_tables.sql` | DDL for all compute tables, enums, indexes, and RLS policies |
+
+## Database tables
+
+### `computer_agents`
+
+One row per agent per team. Holds the agent's executable code.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid | PK |
+| `team_id` | uuid | FK to `teams` |
+| `name` | varchar(255) | Display name |
+| `slug` | varchar(255) | URL-safe, unique per team |
+| `description` | text | |
+| `source` | enum(`catalog`, `generated`) | How it was created |
+| `code` | text | Compiled JavaScript (from TypeScript source) executed in Secure Exec |
+| `template_id` | varchar(255) | Catalog template ID (if source=catalog) |
+| `schedule_cron` | varchar(255) | Cron expression for scheduled runs |
+| `config` | jsonb | User-configurable settings |
+| `enabled` | boolean | Whether the scheduler picks it up |
+| `created_by` | uuid | FK to `users` |
+
+### `computer_runs`
+
+One row per execution of an agent.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid | PK |
+| `agent_id` | uuid | FK to `computer_agents` |
+| `team_id` | uuid | FK to `teams` |
+| `status` | enum(`pending`, `running`, `completed`, `failed`, `waiting_approval`) | Lifecycle state |
+| `proposed_actions` | jsonb | Array of `{ tool, args, description? }` when status is `waiting_approval` |
+| `summary` | text | Agent-generated summary or notification |
+| `error` | text | Error message if failed |
+| `tool_call_count` | integer | Total MCP tool calls made |
+| `llm_call_count` | integer | Total AI generation calls made |
+| `started_at` / `completed_at` | timestamptz | Timing |
+
+### `computer_run_steps`
+
+Every operation performed during a run, for full observability.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `type` | enum(`tool_call`, `ai_generation`, `memory_read`, `memory_write`, `notification`, `proposal`, `connector_call`, `context`) | |
+| `name` | varchar(255) | Tool name or operation |
+| `input` | jsonb | Arguments passed |
+| `output` | jsonb | Result returned |
+| `duration_ms` | integer | Wall-clock time |
+
+### `computer_agent_memory`
+
+Persistent key-value memory scoped to agent + team. Survives across runs.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `agent_id` + `key` | unique constraint | One value per key per agent |
+| `content` | text | Serialized data (typically JSON) |
+| `type` | varchar(100) | Optional category (e.g. `learned`, `snapshot`) |
+| `metadata` | jsonb | Arbitrary metadata |
+
+## Execution flow
+
+### 1. Agent creation
+
+Three paths to create an agent:
+
+**Catalog** — `POST /computer/agents` with `{ templateId }`. Copies template code, name, schedule from `CATALOG_AGENTS`.
+
+**Natural language** — `POST /computer/generate` with `{ description }`. The orchestrator:
+1. Creates an in-process MCP client and calls `listTools()` to get all tool definitions with their `inputSchema` and `outputSchema`
+2. Auto-generates TypeScript declaration stubs (via `json-schema-to-typescript`) with typed `callTool` overloads for every tool
+3. Sends the stubs + prompt to GPT-4.1, which generates TypeScript agent code
+4. Type-checks the generated code against the stubs using `@secure-exec/typescript` (`typecheckSource`)
+5. If type errors exist, feeds them back to the LLM for repair (up to 2 attempts)
+6. Compiles the TypeScript to JavaScript via `compileSource`
+7. Returns the compiled JS as `code` along with the agent definition (name, slug, schedule, plan, tools used)
+
+User reviews, then `POST /computer/agents/confirm` to deploy.
+
+**CLI shortcut** — `midday computer create "description"` combines generate + interactive confirm in one command.
+
+### 2. Triggering a run
+
+**Manual** — `POST /computer/agents/:id/run`. Creates a `computer_runs` row with status `pending`, then calls `enqueueRun()` which adds a BullMQ job to the `compute` queue.
+
+**Scheduled** — The scheduler in `apps/compute/src/scheduler.ts` polls the DB every 60 seconds for enabled agents with cron expressions. Registers `croner` jobs that fire at the right time. On fire: creates a run row, enqueues it.
+
+### 3. Job processing
+
+`apps/compute/src/worker.ts` picks up the BullMQ job:
+
+1. **Load agent** — Fetches the `computer_agents` row to get the code.
+
+2. **Atomic claim** — `claimComputerRun` atomically transitions the run from `pending` to `running` only if no other run for the same agent is already `running`. Uses a single SQL `UPDATE ... WHERE NOT EXISTS` to avoid race conditions. If the claim fails, marks the run as `failed` with `skipped_concurrent`.
+
+3. **Load context** — Fetches the creator's timezone from the `users` table.
+
+4. **Execute** — Delegates to `runtime.ts` (see below).
+
+5. **Record steps** — Bulk-inserts all step records into `computer_run_steps`.
+
+6. **Mark complete** — Updates run status, summary, error, tool/LLM counts, and `completed_at`.
+
+7. **Safety guards** — The entire `processJob` is wrapped in a top-level `try/catch` that guarantees a terminal status (`failed`) even on unexpected errors. Result serialization uses a `safeStringify` utility to guard against circular references. The compute entry point (`index.ts`) has a `shuttingDown` flag to handle duplicate SIGTERM/SIGINT signals gracefully.
+
+### 4. Runtime (Secure Exec)
+
+`apps/compute/src/runtime.ts` creates an isolated V8 environment:
+
+1. **In-process MCP** — Creates an MCP server with the team's context (same as the API's MCP server), connects a client via `InMemoryTransport`. No HTTP, no auth overhead. The agent code calls tools through this bridge. The MCP context receives the agent creator's timezone (from the `users` table), so tools that interpret relative dates ("today", "this week") resolve correctly in the user's local time.
+
+2. **Bindings** — Ten functions are injected into the sandbox:
+
+   - `callTool(name, args)` — Proxies to the in-process MCP client. Returns `{ structuredContent?, content?, isError? }`. Counts toward the 50-call limit.
+   - `parseMcp(result)` — Reliably extracts data from a `callTool` result: returns `structuredContent` if present, falls back to `JSON.parse(content[0].text)`, throws on `isError`. All catalog agents use this.
+   - `generateText(prompt, opts?)` — Calls OpenAI via the AI SDK (default: `gpt-4.1-mini`). Counts toward the 10-call limit.
+   - `readMemory(opts?)` — Reads from `computer_agent_memory` filtered by agent + team + optional key/type.
+   - `writeMemory(key, content, type?, metadata?)` — Upserts into `computer_agent_memory`.
+   - `notify(message, priority?)` — Writes the message to the run's `summary` field and sends a notification via `@midday/notifications` (in-app activity always, email when priority is `"urgent"`).
+   - `getTrigger()` — Returns the trigger context (schedule, payload, etc.).
+   - `callConnector(toolName, args)` — Calls an external service via Composio (Gmail, Slack, Google Sheets, Linear, etc.). Counts toward the 50-call limit. Requires the user to have connected the service.
+   - `propose(actions)` — Submits an array of `{ tool, args, description? }` for human approval. Halts execution with `waiting_approval` status. Automatically sends an `agent_alert` notification so the user knows proposals are waiting. Approved actions are replayed via a separate BullMQ job.
+
+   The `propose` binding is for human-in-the-loop workflows. When called, the agent run transitions to `waiting_approval` and stops. A notification is sent automatically (e.g. "Invoice Chaser has 5 proposed action(s) waiting for your approval."). The user reviews proposals via CLI (`midday computer proposals`) or API, then approves or rejects. Approved actions are executed via `executeProposedActions` in a replay job.
+
+3. **Sandbox constraints**:
+   - No filesystem access
+   - No network access
+   - 64 MB memory limit
+   - 30 second CPU time limit
+   - 50 max tool calls per run
+   - 10 max LLM calls per run
+
+4. **Step tracing** — Every binding call is wrapped in a step logger that records type, name, input, output, and duration. These become `computer_run_steps` rows.
+
+## Agent code pattern
+
+Agent code is authored as TypeScript, type-checked against auto-generated stubs, compiled to JavaScript, and executed inside the Secure Exec isolate. Bindings are available at `SecureExec.bindings`:
+
+```typescript
+const { callTool, parseMcp, generateText, readMemory, writeMemory, notify, callConnector, propose } = SecureExec.bindings;
+
+// Fetch data via MCP tools — callTool returns { structuredContent?, content?, isError? }
+const result = await callTool("transactions_list", {
+  categories: ["uncategorized"],
+  start: "2025-01-01",
+  end: "2025-01-31",
+  pageSize: 50,
+});
+
+// parseMcp extracts structuredContent (typed) or falls back to JSON text parsing
+const data = parseMcp(result);
+const transactions = data?.data ?? [];
+
+// Use AI for reasoning
+const analysis = await generateText(
+  "Analyze these transactions: " + JSON.stringify(transactions),
+  { system: "You are a financial analyst." }
+);
+
+// Persist state across runs
+await writeMemory("last_analysis", analysis, "snapshot");
+
+// Notify the team (in-app + email for urgent)
+await notify("Found " + transactions.length + " items to review.", "normal");
+
+// Send to Slack via Composio connector
+await callConnector("SLACK_SEND_MESSAGE", {
+  channel: "#finance",
+  text: analysis,
+});
+
+// Return a result
+module.exports = { summary: analysis, count: transactions.length };
+```
+
+### Approval mode example
+
+```typescript
+const { callTool, parseMcp, propose } = SecureExec.bindings;
+
+// Find overdue invoices
+const result = await callTool("invoices_list", { statuses: ["overdue"] });
+const parsed = parseMcp(result)?.data ?? [];
+
+if (parsed.length === 0) {
+  module.exports = { summary: "No overdue invoices" };
+  return;
+}
+
+// Propose sending reminders (human reviews before execution)
+const actions = parsed.map((inv: any) => ({
+  tool: "invoices_remind",
+  args: { id: inv.id },
+  description: `Send reminder for invoice ${inv.invoiceNumber} (${inv.customer?.name})`,
+}));
+
+await propose(actions);
+// Execution stops here -- user reviews via CLI or API
+```
+
+### MCP tool response format
+
+MCP tools return `{ structuredContent?, content?, isError? }`. When `outputSchema` is defined (most tools), the typed data is in `structuredContent`. Always use `parseMcp(result)` to extract data reliably — it handles both `structuredContent` and legacy text-only responses.
+
+### outputSchema and structuredContent
+
+Most MCP tool registrations include an `outputSchema` (Zod schema) that declares the shape of the tool's response. The MCP SDK converts this to JSON Schema and advertises it via `listTools()`. When a tool handler returns a `structuredContent` object matching this schema, the client receives typed, parseable data instead of serialized JSON text.
+
+**Adding `outputSchema` to a tool:**
+
+```typescript
+// In apps/api/src/mcp/tools/transactions.ts
+server.tool(
+  "transactions_list",
+  "List transactions...",
+  { /* inputSchema (Zod) */ },
+  { outputSchema: { meta: mcpListMetaSchema, data: z.array(mcpTransactionSchema) } },
+  async (params, extra) => {
+    const result = await listTransactions(params);
+    return {
+      structuredContent: { meta: result.meta, data: result.data },
+      content: [{ type: "text" as const, text: JSON.stringify(result) }],
+    };
+  }
+);
+```
+
+Entity schemas live in `apps/api/src/mcp/schemas.ts` (e.g., `mcpTransactionSchema`, `mcpInvoiceSchema`, `mcpAccountSchema`). The `mcpListMetaSchema` provides a standard shape for paginated list metadata (`cursor`, `hasNextPage`, `hasPreviousPage`).
+
+### Type stub generation
+
+`apps/api/src/rest/routers/computer/stubs.ts` auto-generates TypeScript declarations from live MCP tool definitions:
+
+1. An in-process MCP client calls `listTools()` to get all tool definitions
+2. For each tool, `inputSchema` and `outputSchema` (JSON Schema) are converted to TypeScript interfaces via `json-schema-to-typescript`
+3. Typed `callTool` overloads are generated per tool (e.g., `callTool("transactions_list", TransactionsListInput): Promise<{ structuredContent?: TransactionsListOutput; ... }>`)
+4. A fallback overload handles unknown tool names
+5. Binding declarations for `parseMcp`, `generateText`, `readMemory`, `writeMemory`, `notify`, `getTrigger`, `callConnector`, and `propose` are appended
+
+These stubs are included in the LLM system prompt during NL generation so the model produces type-safe code. The same stubs are used by `@secure-exec/typescript` to type-check the generated code before compilation.
+
+## API routes
+
+All routes are under `/computer` and require authentication (behind `protectedMiddleware`).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/catalog` | List available catalog agents (code excluded) |
+| `GET` | `/agents` | List team's enabled agents |
+| `POST` | `/agents` | Enable a catalog agent (`{ templateId }`) |
+| `POST` | `/generate` | Generate agent from NL description (`{ description }`) |
+| `POST` | `/agents/confirm` | Deploy a generated agent (`{ name, slug, code, ... }`) |
+| `PUT` | `/agents/:id` | Update agent settings (enabled, schedule, config) |
+| `DELETE` | `/agents/:id` | Remove an agent and all its data |
+| `POST` | `/agents/:id/run` | Trigger a manual run |
+| `GET` | `/agents/:id/runs` | List run history (default 20) |
+| `GET` | `/agents/:id/runs/:runId` | Get run details with step trace |
+| `GET` | `/agents/:id/runs/:runId/proposals` | Get proposed actions for a `waiting_approval` run |
+| `POST` | `/agents/:id/runs/:runId/approve` | Approve proposals (`{ actions?: number[] }` for selective) |
+| `POST` | `/agents/:id/runs/:runId/reject` | Reject proposals (marks run as failed) |
+| `GET` | `/agents/:id/memory` | View agent's persistent memory |
+
+## CLI commands
+
+```
+midday computer                                    List your agents
+midday computer catalog                            Show available pre-built agents
+midday computer enable <templateId>                Enable a catalog agent
+midday computer create "<description>"             Create agent from natural language
+midday computer run <agentId>                      Manually trigger a run
+midday computer run <agentId> --wait               Trigger and wait for completion (polls every 2s)
+midday computer logs <agentId>                     View run history
+midday computer memory <agentId>                   Inspect persistent memory
+midday computer proposals <agentId> <runId>        View proposed actions awaiting approval
+midday computer approve <agentId> <runId>          Approve all proposals (or --pick 0,2)
+midday computer reject <agentId> <runId>           Reject proposals
+midday computer disable <agentId>                  Disable an agent
+midday computer remove <agentId>                   Delete an agent
+```
+
+## Infrastructure
+
+### Deployment
+
+- Runs as a standalone Docker service on Railway (`apps/compute/Dockerfile`)
+- Port 8081 with `/health` endpoint
+- Uses the shared `REDIS_QUEUE_URL` (same Redis as the main worker)
+- Uses `@midday/db/worker-client` (connection pool tuned for concurrent background jobs)
+- Sentry error reporting via `apps/compute/src/instrument.ts`
+- CI/CD wired in both `staging.yml` and `production.yml` (detect-changes + deploy)
+
+### Environment variables
+
+See `apps/compute/.env-template`:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATABASE_PRIMARY_POOLER_URL` | Yes (or `DATABASE_PRIMARY_URL`) | Postgres connection for worker-client |
+| `REDIS_QUEUE_URL` | Yes | Shared BullMQ Redis |
+| `OPENAI_API_KEY` | Yes | For agent LLM calls |
+| `COMPOSIO_API_KEY` | No | For Composio external integrations (Gmail, Slack, etc.) |
+| `SENTRY_DSN` | Production only | Error reporting |
+| `PORT` | No (default: 8081) | HTTP port |
+
+### Graceful shutdown
+
+On `SIGTERM`/`SIGINT`:
+1. Stop all cron schedulers
+2. Close BullMQ worker (waits for active jobs)
+3. Wait 5 seconds for drain
+4. Close database pool
+5. Flush Sentry events
+6. Exit (30s hard timeout)
+
+## Catalog agents
+
+### Month-End Close
+
+**Template ID:** `month-end-close`
+**Schedule:** `0 8 28-31 * *` (8 AM on the 28th-31st of each month)
+
+Runs a close-the-books checklist:
+1. Finds uncategorized transactions for the current month
+2. Checks for pending (unmatched) inbox items
+3. Finds draft invoices that haven't been sent
+4. Pulls the current month's P&L and spending breakdown
+5. Loads previous month's summary from memory for comparison
+6. Uses AI to produce a numbered checklist of open items, flag spending anomalies (>25% change), and give an overall health assessment
+7. Saves this month's snapshot to memory
+8. Notifies the team with the full analysis
+
+### Invoice Chaser
+
+**Template ID:** `invoice-chaser`
+**Schedule:** `0 9 * * 2` (Tuesdays 9 AM)
+
+Intelligent collections assistant using approval mode:
+1. Fetches all overdue and unpaid invoices
+2. Pulls customer details for context (payment history, contact info)
+3. Loads escalation history from memory (how many times each invoice was flagged)
+4. Uses AI to prioritize by urgency: oldest debt first, largest amounts, repeat late payers
+5. Proposes sending reminders via `propose()` — user reviews and approves before any emails go out
+6. Saves escalation counts to memory for next run
+7. Notifies team with prioritized collections summary
+
+**Showcases:** Approval mode (`propose` + `invoices_remind`), persistent memory for escalation tracking.
+
+### Weekly Financial Briefing
+
+**Template ID:** `weekly-financial-briefing`
+**Schedule:** `0 8 * * 1` (Mondays 8 AM)
+
+Executive summary combining data from across all of Midday:
+1. Gets team currency and bank account balances for cash position
+2. Pulls profit, revenue, spending, and cash flow reports for the past week
+3. Fetches invoice summary for outstanding amounts
+4. Loads previous week's snapshot and rolling 12-week trend history from memory
+5. Uses AI to produce a structured briefing: cash position, revenue vs profit with % change, top spending categories, invoice status, multi-week trend patterns, and 2-3 specific action items
+6. Saves weekly snapshot and updates trend history in memory
+7. Notifies team with the full briefing
+
+**Showcases:** Cross-domain intelligence (7 different tool calls combined), rolling trend memory across months.
+
+### Expense Anomaly Detector
+
+**Template ID:** `expense-anomaly-detector`
+**Schedule:** `0 10 * * *` (daily 10 AM)
+
+Silent-unless-important daily expense monitor:
+1. Fetches expenses from the last 24 hours
+2. Pulls 90-day spending baseline by category
+3. Loads previously flagged transaction IDs from memory (avoids repeat alerts)
+4. Uses AI to compare new expenses against baselines — flags: transactions >3x category daily average, new/unknown spending categories, potential duplicate charges, any single transaction over 2000
+5. Updates flagged IDs and baseline snapshots in memory
+6. Only notifies if anomalies are found (urgent priority for amounts over 5000). Stays completely silent on normal days.
+
+**Showcases:** Silent-unless-important pattern (no noise), baseline learning via memory, conservative anomaly detection.
+
+## Adding a new catalog agent
+
+1. Add an entry to `CATALOG_AGENTS` in `apps/api/src/rest/routers/computer/catalog.ts`:
+
+```typescript
+{
+  templateId: "your-agent-id",
+  name: "Your Agent",
+  slug: "your-agent",
+  description: "What it does in one sentence.",
+  scheduleCron: "0 9 * * 1",  // cron expression
+  code: `const { callTool, generateText, readMemory, writeMemory, notify, callConnector, propose } = SecureExec.bindings;
+// ... agent code ...
+module.exports = { summary: "done" };`,
+}
+```
+
+2. The agent becomes immediately available in the catalog (`GET /computer/catalog`) and can be enabled via `POST /computer/agents` with `{ templateId: "your-agent-id" }` or `midday computer enable your-agent-id`.
+
+## Adding a new binding
+
+To expose a new function to agent code:
+
+1. Add the binding function to the `bindings` object in `apps/compute/src/runtime.ts`
+2. Add a step type to the `computerRunStepTypeEnum` in `packages/db/src/schema.ts` if it's a new category
+3. Update the migration if the enum changes
+4. Document the binding in the orchestrator's `SYSTEM_PROMPT` in `apps/api/src/rest/routers/computer/orchestrator.ts` so the NL generator knows about it
+
+## Limits and safety
+
+| Limit | Value | Enforced in |
+|-------|-------|-------------|
+| Tool calls per run | 50 | `runtime.ts` (throws on exceed) |
+| LLM calls per run | 10 | `runtime.ts` (throws on exceed) |
+| Memory per isolate | 64 MB | Secure Exec `NodeExecutionDriver` |
+| CPU time per run | 30 seconds | Secure Exec `NodeExecutionDriver` |
+| Concurrency per agent | 1 active run | `claimComputerRun` atomic SQL in `queries/computer.ts` |
+| Filesystem access | Denied | Secure Exec permissions |
+| Network access | Denied | Secure Exec permissions |
+
+## Approval mode flow
+
+The approval mode enables human-in-the-loop workflows for write operations:
+
+1. **Agent runs and calls `propose(actions)`** — The binding stores the proposed actions in `computer_runs.proposed_actions`, transitions the run to `waiting_approval` status, sends an `agent_alert` notification (so the user knows proposals are waiting), and throws `ProposalSubmittedError` to halt the isolate cleanly.
+
+2. **User reviews** — Via CLI (`midday computer proposals <agentId> <runId>`) or API (`GET /agents/:id/runs/:runId/proposals`).
+
+3. **User approves or rejects**:
+   - **Approve all**: `midday computer approve <agentId> <runId>` or `POST /approve`
+   - **Selective approve**: `midday computer approve <agentId> <runId> --pick 0,2` or `POST /approve { actions: [0, 2] }`
+   - **Reject**: `midday computer reject <agentId> <runId>` or `POST /reject`
+
+4. **Replay** — On approval, `approveComputerRun` filters the actions, transitions the run back to `pending`, and `enqueueReplay` adds a `replay-proposals` job to the BullMQ queue.
+
+5. **Execution** — The compute worker dispatches the replay job to `processReplay`, which calls `executeProposedActions`. This creates an in-process MCP client and calls each approved tool in sequence, recording steps.
+
+## Composio connectors
+
+Agents can call external services via the `callConnector` binding. This uses [Composio](https://composio.dev/) to provide tool-based access to 100+ services (Gmail, Slack, Google Sheets, Linear, etc.).
+
+- **Auth model**: Composio manages per-user OAuth connections. The user connects services through the Midday dashboard, and agents inherit access.
+- **Tool naming**: Composio tools follow the `SERVICE_ACTION_NAME` convention (e.g., `SLACK_SEND_MESSAGE`, `GMAIL_SEND_EMAIL`).
+- **Rate limits**: `callConnector` calls count toward the same 50-call-per-run limit as `callTool`.
+- **Dependency**: Requires `COMPOSIO_API_KEY` environment variable. Returns an error if the user hasn't connected the requested service.
+
+## Notification delivery
+
+The `notify` binding sends notifications via `@midday/notifications`:
+
+- **In-app**: Every notification creates an activity entry visible in the Midday notification center.
+- **Email**: Sent automatically when priority is `"urgent"`. Uses the `plain` email template.
+
+The notification type is `agent_alert` and appears in user notification settings under the "computer" category.
+
+Bot platform delivery (Slack, WhatsApp, Telegram, iMessage) requires wiring `agent_alert` into the `@midday/bot` `sendToProviders` pipeline with platform-specific formatters — planned for v1.1.
+
+## Future (v1.1)
+
+- Agent notifications to Slack, Telegram, WhatsApp, iMessage via `@midday/bot` pipeline
+- Event-based triggers (on new transaction, on overdue invoice, etc.)
+- Custom `.ts` agent deployment (user-submitted code)
+- Unified daily briefing across all agents
+- Dashboard UI for agent management and proposal review
+- Streaming visibility for long-running agents
+- Additional catalog agents (Cash Flow Watchdog, Revenue Forecaster)
+- Cross-agent communication (agent-to-agent triggers)

--- a/packages/cli/src/commands/computer/index.ts
+++ b/packages/cli/src/commands/computer/index.ts
@@ -1,0 +1,752 @@
+import readline from "node:readline";
+import chalk from "chalk";
+import { Command } from "commander";
+import { del, get, post, put } from "../../client/api.js";
+import { type GlobalFlags, resolveFormat } from "../../output/formatter.js";
+import { printJson, printJsonList } from "../../output/json.js";
+import { printTable } from "../../output/table.js";
+import { createSpinner, withSpinner } from "../../ui/spinner.js";
+import { handleError } from "../../utils/errors.js";
+
+interface Agent {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  source: string;
+  templateId?: string | null;
+  scheduleCron?: string | null;
+  enabled: boolean;
+  createdAt: string;
+}
+
+interface CatalogAgent {
+  templateId: string;
+  name: string;
+  slug: string;
+  description: string;
+  scheduleCron: string;
+}
+
+interface Run {
+  id: string;
+  status: string;
+  summary: string | null;
+  error: string | null;
+  toolCallCount: number;
+  llmCallCount: number;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+}
+
+interface GeneratedAgent {
+  name: string;
+  slug: string;
+  description: string;
+  scheduleCron: string | null;
+  plan: string[];
+  toolsUsed: string[];
+  code: string;
+}
+
+interface MemoryEntry {
+  id: string;
+  key: string;
+  content: string;
+  type: string | null;
+  metadata: Record<string, unknown> | null;
+  updatedAt: string;
+}
+
+export function createComputerCommand(): Command {
+  const cmd = new Command("computer").description(
+    "Midday Computer — create and manage autonomous agents",
+  );
+
+  // Default action: list agents
+  cmd.action(async () => {
+    const globals = cmd.parent?.opts() as GlobalFlags;
+    const format = resolveFormat(globals);
+
+    try {
+      const data = await withSpinner(
+        "Fetching agents...",
+        () =>
+          get<{ data: Agent[] }>(
+            "/computer/agents",
+            {},
+            {
+              apiUrl: globals.apiUrl,
+              debug: globals.debug,
+            },
+          ),
+        globals.quiet,
+      );
+
+      if (format === "json") {
+        printJsonList(data.data);
+        return;
+      }
+
+      if (data.data.length === 0) {
+        console.log(
+          chalk.dim(
+            "\n  No agents enabled yet. Try:\n\n" +
+              '    midday computer create "your workflow description"\n' +
+              "    midday computer catalog\n",
+          ),
+        );
+        return;
+      }
+
+      printTable({
+        title: "Midday Computer",
+        head: ["ID", "Name", "Slug", "Source", "Schedule", "Enabled"],
+        rows: data.data.map((a) => [
+          chalk.dim(a.id.slice(0, 8)),
+          a.name,
+          a.slug,
+          a.source,
+          a.scheduleCron || "manual",
+          a.enabled ? chalk.green("●") : chalk.dim("○"),
+        ]),
+      });
+    } catch (error) {
+      handleError(error, format);
+    }
+  });
+
+  // midday computer create "..."
+  cmd
+    .command("create <description>")
+    .description("Create an agent from a natural language description")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  midday computer create "Every Friday check unbilled hours and draft invoices"
+  midday computer create "Alert me when any single expense exceeds 5000"
+  midday computer create "Weekly summary of revenue, expenses, and outstanding invoices"`,
+    )
+    .action(async (description: string) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        console.log(chalk.dim("\n  Creating workflow...\n"));
+
+        const result = await withSpinner(
+          "Generating agent...",
+          () =>
+            post<{ data: GeneratedAgent }>(
+              "/computer/generate",
+              { description },
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        const agent = result.data;
+
+        if (format === "json") {
+          printJson(agent);
+          return;
+        }
+
+        console.log(chalk.bold(`  ━━━ ${agent.name} ━━━`));
+        console.log(
+          chalk.dim("  Schedule: ") +
+            (agent.scheduleCron || "manual trigger only"),
+        );
+        console.log(chalk.dim("  Tools: ") + agent.toolsUsed.join(", "));
+        console.log();
+        console.log(chalk.dim("  Plan:"));
+        for (let i = 0; i < agent.plan.length; i++) {
+          console.log(`  ${i + 1}. ${agent.plan[i]}`);
+        }
+        console.log();
+
+        // Auto-confirm in agent mode or --yes flag
+        if (globals.yes || globals.agent) {
+          await withSpinner(
+            "Enabling agent...",
+            () =>
+              post<{ data: Agent }>(
+                "/computer/agents/confirm",
+                {
+                  name: agent.name,
+                  slug: agent.slug,
+                  description: agent.description,
+                  code: agent.code,
+                  scheduleCron: agent.scheduleCron,
+                },
+                { apiUrl: globals.apiUrl, debug: globals.debug },
+              ),
+            globals.quiet,
+          );
+
+          console.log(
+            chalk.green("  ✓ Enabled.") +
+              (agent.scheduleCron
+                ? chalk.dim(` Scheduled: ${agent.scheduleCron}`)
+                : ""),
+          );
+          return;
+        }
+
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+
+        const answer = await new Promise<string>((resolve) => {
+          rl.question(
+            chalk.bold("  Enable this agent? ") + chalk.dim("(y/n) "),
+            resolve,
+          );
+        });
+        rl.close();
+
+        if (answer.toLowerCase() === "y" || answer.toLowerCase() === "yes") {
+          await withSpinner(
+            "Enabling agent...",
+            () =>
+              post<{ data: Agent }>(
+                "/computer/agents/confirm",
+                {
+                  name: agent.name,
+                  slug: agent.slug,
+                  description: agent.description,
+                  code: agent.code,
+                  scheduleCron: agent.scheduleCron,
+                },
+                { apiUrl: globals.apiUrl, debug: globals.debug },
+              ),
+            globals.quiet,
+          );
+
+          console.log(
+            chalk.green("\n  ✓ Enabled.") +
+              (agent.scheduleCron
+                ? chalk.dim(` Scheduled: ${agent.scheduleCron}`)
+                : ""),
+          );
+        } else {
+          console.log(chalk.dim("\n  Cancelled."));
+        }
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer catalog
+  cmd
+    .command("catalog")
+    .description("List available pre-built agents")
+    .action(async () => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const data = await withSpinner(
+          "Fetching catalog...",
+          () =>
+            get<{ data: CatalogAgent[] }>(
+              "/computer/catalog",
+              {},
+              {
+                apiUrl: globals.apiUrl,
+                debug: globals.debug,
+              },
+            ),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJsonList(data.data);
+          return;
+        }
+
+        console.log(chalk.bold("\n  Available Agents\n"));
+        for (const agent of data.data) {
+          console.log(
+            `  ${chalk.cyan(agent.slug.padEnd(25))} ${agent.description}`,
+          );
+          console.log(
+            chalk.dim(`  ${"".padEnd(25)} Schedule: ${agent.scheduleCron}`),
+          );
+          console.log();
+        }
+        console.log(
+          chalk.dim("  Enable with: midday computer enable <slug>\n"),
+        );
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer enable <slug>
+  cmd
+    .command("enable <templateId>")
+    .description("Enable a catalog agent")
+    .action(async (templateId: string) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const data = await withSpinner(
+          `Enabling ${templateId}...`,
+          () =>
+            post<{ data: Agent }>(
+              "/computer/agents",
+              { templateId },
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJson(data.data);
+          return;
+        }
+
+        console.log(
+          chalk.green(`\n  ✓ ${data.data.name} enabled.`) +
+            (data.data.scheduleCron
+              ? chalk.dim(` Schedule: ${data.data.scheduleCron}`)
+              : ""),
+        );
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer disable <slug>
+  cmd
+    .command("disable <id>")
+    .description("Disable an agent")
+    .action(async (id: string) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const data = await withSpinner(
+          "Disabling agent...",
+          () =>
+            put<{ data: Agent }>(
+              `/computer/agents/${id}`,
+              { enabled: false },
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJson(data.data);
+          return;
+        }
+
+        console.log(chalk.yellow(`\n  ○ ${data.data.name} disabled.`));
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer run <id>
+  cmd
+    .command("run <id>")
+    .description("Manually trigger an agent run")
+    .option("--wait", "Wait for the run to complete and show results")
+    .action(async (id: string, opts: { wait?: boolean }) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const data = await withSpinner(
+          "Triggering run...",
+          () =>
+            post<{ data: { runId: string } }>(
+              `/computer/agents/${id}/run`,
+              {},
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        const { runId } = data.data;
+
+        if (!opts.wait) {
+          if (format === "json") {
+            printJson(data.data);
+            return;
+          }
+          console.log(
+            chalk.green("\n  ✓ Run triggered.") +
+              chalk.dim(` Run ID: ${runId}`),
+          );
+          return;
+        }
+
+        const spinner = createSpinner("Running agent...", globals.quiet);
+        spinner.start();
+        const startTime = Date.now();
+        const POLL_INTERVAL = 2000;
+        const TIMEOUT = 120_000;
+        let run: Run | null = null;
+
+        while (Date.now() - startTime < TIMEOUT) {
+          await new Promise((r) => setTimeout(r, POLL_INTERVAL));
+          const elapsed = Math.round((Date.now() - startTime) / 1000);
+          spinner.text = `Running agent... ${elapsed}s`;
+
+          try {
+            const result = await get<{ data: Run }>(
+              `/computer/agents/${id}/runs/${runId}`,
+              {},
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            );
+            run = result.data;
+            if (
+              run.status === "completed" ||
+              run.status === "failed" ||
+              run.status === "waiting_approval"
+            ) {
+              break;
+            }
+          } catch {
+            // transient error, keep polling
+          }
+        }
+
+        if (!run || (run.status !== "completed" && run.status !== "failed" && run.status !== "waiting_approval")) {
+          spinner.warn("Run still in progress (timed out waiting)");
+          console.log(chalk.dim(`\n  Check status: midday computer logs ${id}\n`));
+          return;
+        }
+
+        if (run.status === "completed") {
+          spinner.succeed("Run completed");
+          if (format === "json") {
+            printJson(run);
+            return;
+          }
+          if (run.summary) {
+            console.log(chalk.dim("\n  Summary:\n"));
+            for (const line of run.summary.split("\n")) {
+              console.log(`  ${line}`);
+            }
+            console.log();
+          }
+        } else if (run.status === "waiting_approval") {
+          spinner.info("Agent is waiting for approval");
+          if (format === "json") {
+            printJson(run);
+            return;
+          }
+          console.log(
+            chalk.dim(`\n  Review: `) +
+              `midday computer proposals ${id} ${runId}\n`,
+          );
+        } else {
+          spinner.fail("Run failed");
+          if (format === "json") {
+            printJson(run);
+            return;
+          }
+          if (run.error) {
+            console.log(chalk.red(`\n  Error: ${run.error}\n`));
+          }
+        }
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer logs <id>
+  cmd
+    .command("logs <id>")
+    .description("View recent run history for an agent")
+    .option("--limit <n>", "Number of runs to show", "10")
+    .action(async (id: string, opts: { limit: string }) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const data = await withSpinner(
+          "Fetching runs...",
+          () =>
+            get<{ data: Run[] }>(
+              `/computer/agents/${id}/runs`,
+              { limit: opts.limit },
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJsonList(data.data);
+          return;
+        }
+
+        if (data.data.length === 0) {
+          console.log(chalk.dim("\n  No runs yet.\n"));
+          return;
+        }
+
+        printTable({
+          head: ["ID", "Status", "Tools", "LLM", "Summary", "Completed"],
+          rows: data.data.map((r) => [
+            r.id.slice(0, 8),
+            r.status === "completed"
+              ? chalk.green(r.status)
+              : r.status === "failed"
+                ? chalk.red(r.status)
+                : r.status === "running"
+                  ? chalk.yellow(r.status)
+                  : r.status === "waiting_approval"
+                    ? chalk.magenta(r.status)
+                    : chalk.dim(r.status),
+            String(r.toolCallCount),
+            String(r.llmCallCount),
+            r.summary
+              ? r.summary.slice(0, 60)
+              : r.error
+                ? chalk.red(r.error.slice(0, 60))
+                : chalk.dim("—"),
+            r.completedAt
+              ? new Date(r.completedAt).toLocaleString()
+              : chalk.dim("—"),
+          ]),
+        });
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer memory <id>
+  cmd
+    .command("memory <id>")
+    .description("View an agent's persistent memory")
+    .action(async (id: string) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const data = await withSpinner(
+          "Fetching memory...",
+          () =>
+            get<{ data: MemoryEntry[] }>(
+              `/computer/agents/${id}/memory`,
+              {},
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJsonList(data.data);
+          return;
+        }
+
+        if (data.data.length === 0) {
+          console.log(chalk.dim("\n  No memories stored yet.\n"));
+          return;
+        }
+
+        console.log(chalk.bold("\n  Agent Memory\n"));
+        for (const entry of data.data) {
+          console.log(
+            `  ${chalk.cyan(entry.key)} ${chalk.dim(`(${entry.type || "general"})`)}`,
+          );
+          const preview =
+            entry.content.length > 120
+              ? `${entry.content.slice(0, 120)}...`
+              : entry.content;
+          console.log(chalk.dim(`  ${preview}`));
+          console.log(
+            chalk.dim(
+              `  Updated: ${new Date(entry.updatedAt).toLocaleString()}`,
+            ),
+          );
+          console.log();
+        }
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer proposals <agentId> <runId>
+  cmd
+    .command("proposals <agentId> <runId>")
+    .description("View proposed actions awaiting approval")
+    .action(async (agentId: string, runId: string) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const data = await withSpinner(
+          "Fetching proposals...",
+          () =>
+            get<{
+              data: {
+                runId: string;
+                status: string;
+                actions: Array<{
+                  tool: string;
+                  args: Record<string, unknown>;
+                  description?: string;
+                }>;
+              };
+            }>(
+              `/computer/agents/${agentId}/runs/${runId}/proposals`,
+              {},
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJson(data.data);
+          return;
+        }
+
+        const { actions } = data.data;
+        if (actions.length === 0) {
+          console.log(chalk.dim("\n  No proposed actions.\n"));
+          return;
+        }
+
+        console.log(chalk.bold("\n  Proposed Actions\n"));
+        console.log(chalk.dim(`  Run: ${runId}\n`));
+
+        for (let i = 0; i < actions.length; i++) {
+          const action = actions[i]!;
+          console.log(
+            `  ${chalk.cyan(`[${i}]`)} ${chalk.bold(action.tool)}`,
+          );
+          if (action.description) {
+            console.log(`      ${chalk.dim(action.description)}`);
+          }
+          console.log(
+            `      ${chalk.dim(JSON.stringify(action.args, null, 2).split("\n").join("\n      "))}`,
+          );
+          console.log();
+        }
+
+        console.log(
+          chalk.dim(
+            `  Approve: midday computer approve ${agentId} ${runId}\n` +
+              `  Reject:  midday computer reject ${agentId} ${runId}\n`,
+          ),
+        );
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer approve <agentId> <runId>
+  cmd
+    .command("approve <agentId> <runId>")
+    .description("Approve proposed actions for execution")
+    .option("--pick <indices>", "Comma-separated indices to approve (e.g. 0,2)")
+    .action(async (agentId: string, runId: string, opts: { pick?: string }) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const body: { actions?: number[] } = {};
+        if (opts.pick) {
+          body.actions = opts.pick.split(",").map((s) => Number.parseInt(s.trim(), 10));
+        }
+
+        const data = await withSpinner(
+          "Approving proposals...",
+          () =>
+            post<{
+              data: { runId: string; status: string; actionsQueued: number };
+            }>(
+              `/computer/agents/${agentId}/runs/${runId}/approve`,
+              body,
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJson(data.data);
+          return;
+        }
+
+        console.log(
+          chalk.green(`\n  ✓ Approved.`) +
+            chalk.dim(` ${data.data.actionsQueued} action(s) queued for execution.\n`),
+        );
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer reject <agentId> <runId>
+  cmd
+    .command("reject <agentId> <runId>")
+    .description("Reject proposed actions")
+    .action(async (agentId: string, runId: string) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        const data = await withSpinner(
+          "Rejecting proposals...",
+          () =>
+            post<{ data: { runId: string; status: string } }>(
+              `/computer/agents/${agentId}/runs/${runId}/reject`,
+              {},
+              { apiUrl: globals.apiUrl, debug: globals.debug },
+            ),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJson(data.data);
+          return;
+        }
+
+        console.log(chalk.yellow(`\n  ○ Proposals rejected.\n`));
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  // midday computer remove <id>
+  cmd
+    .command("remove <id>")
+    .description("Remove an agent")
+    .action(async (id: string) => {
+      const globals = cmd.parent?.opts() as GlobalFlags;
+      const format = resolveFormat(globals);
+
+      try {
+        await withSpinner(
+          "Removing agent...",
+          () =>
+            del<{ success: boolean }>(`/computer/agents/${id}`, {
+              apiUrl: globals.apiUrl,
+              debug: globals.debug,
+            }),
+          globals.quiet,
+        );
+
+        if (format === "json") {
+          printJson({ success: true });
+          return;
+        }
+
+        console.log(chalk.green("\n  ✓ Agent removed.\n"));
+      } catch (error) {
+        handleError(error, format);
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { createAuthCommand } from "./commands/auth/index.js";
 import { createBankAccountsCommand } from "./commands/bank-accounts/index.js";
 import { createCategoriesCommand } from "./commands/categories/index.js";
+import { createComputerCommand } from "./commands/computer/index.js";
 import { createCustomersCommand } from "./commands/customers/index.js";
 import { createDocumentsCommand } from "./commands/documents/index.js";
 import { createInboxCommand } from "./commands/inbox/index.js";
@@ -35,6 +36,7 @@ export function createProgram(): Command {
     .option("--debug", "Verbose HTTP logging to stderr");
 
   program.addCommand(createAuthCommand());
+  program.addCommand(createComputerCommand());
   program.addCommand(createTransactionsCommand());
   program.addCommand(createInvoicesCommand());
   program.addCommand(createCustomersCommand());
@@ -56,6 +58,8 @@ Run midday <command> --help for detailed usage and examples.
 
 Examples:
   midday auth login                              # Authenticate via browser
+  midday computer create "check unbilled hours"  # Create an agent from description
+  midday computer catalog                        # List pre-built agents
   midday transactions list --from 2026-01-01     # List recent transactions
   midday invoices create --customer cust_123     # Create a new invoice
   midday tracker start --project proj_abc        # Start time tracking

--- a/packages/db/migrations/0039_add_computer_tables.sql
+++ b/packages/db/migrations/0039_add_computer_tables.sql
@@ -1,0 +1,125 @@
+-- Enums
+CREATE TYPE computer_agent_source AS ENUM ('catalog', 'generated');
+CREATE TYPE computer_run_status AS ENUM ('pending', 'running', 'completed', 'failed', 'waiting_approval');
+CREATE TYPE computer_run_step_type AS ENUM ('tool_call', 'ai_generation', 'memory_read', 'memory_write', 'notification', 'proposal', 'connector_call', 'context');
+
+-- computer_agents
+CREATE TABLE computer_agents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  team_id uuid NOT NULL,
+  name varchar(255) NOT NULL,
+  slug varchar(255) NOT NULL,
+  description text,
+  source computer_agent_source NOT NULL,
+  code text NOT NULL,
+  template_id varchar(255),
+  schedule_cron varchar(255),
+  config jsonb,
+  enabled boolean NOT NULL DEFAULT false,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT computer_agents_team_id_fkey
+    FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE,
+  CONSTRAINT computer_agents_created_by_fkey
+    FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+  CONSTRAINT computer_agents_team_slug
+    UNIQUE (team_id, slug)
+);
+
+CREATE INDEX computer_agents_team_id_idx ON computer_agents (team_id);
+CREATE INDEX computer_agents_enabled_idx ON computer_agents (team_id, enabled);
+
+ALTER TABLE computer_agents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Team members can manage their computer agents"
+  ON computer_agents
+  AS PERMISSIVE
+  FOR ALL
+  TO public;
+
+-- computer_runs
+CREATE TABLE computer_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  agent_id uuid NOT NULL,
+  team_id uuid NOT NULL,
+  status computer_run_status NOT NULL DEFAULT 'pending',
+  proposed_actions jsonb,
+  summary text,
+  error text,
+  tool_call_count integer NOT NULL DEFAULT 0,
+  llm_call_count integer NOT NULL DEFAULT 0,
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT computer_runs_agent_id_fkey
+    FOREIGN KEY (agent_id) REFERENCES computer_agents(id) ON DELETE CASCADE,
+  CONSTRAINT computer_runs_team_id_fkey
+    FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE
+);
+
+CREATE INDEX computer_runs_agent_id_idx ON computer_runs (agent_id);
+CREATE INDEX computer_runs_team_id_idx ON computer_runs (team_id);
+CREATE INDEX computer_runs_status_idx ON computer_runs (agent_id, status);
+
+ALTER TABLE computer_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Team members can view their computer runs"
+  ON computer_runs
+  AS PERMISSIVE
+  FOR SELECT
+  TO public;
+
+-- computer_run_steps
+CREATE TABLE computer_run_steps (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  run_id uuid NOT NULL,
+  type computer_run_step_type NOT NULL,
+  name varchar(255) NOT NULL,
+  input jsonb,
+  output jsonb,
+  duration_ms integer,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT computer_run_steps_run_id_fkey
+    FOREIGN KEY (run_id) REFERENCES computer_runs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX computer_run_steps_run_id_idx ON computer_run_steps (run_id);
+
+ALTER TABLE computer_run_steps ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Team members can view their computer run steps"
+  ON computer_run_steps
+  AS PERMISSIVE
+  FOR SELECT
+  TO public;
+
+-- computer_agent_memory
+CREATE TABLE computer_agent_memory (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  agent_id uuid NOT NULL,
+  team_id uuid NOT NULL,
+  key varchar(255) NOT NULL,
+  content text NOT NULL,
+  type varchar(100),
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT computer_agent_memory_agent_id_fkey
+    FOREIGN KEY (agent_id) REFERENCES computer_agents(id) ON DELETE CASCADE,
+  CONSTRAINT computer_agent_memory_team_id_fkey
+    FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE,
+  CONSTRAINT computer_agent_memory_agent_key
+    UNIQUE (agent_id, key)
+);
+
+CREATE INDEX computer_agent_memory_agent_id_idx ON computer_agent_memory (agent_id);
+CREATE INDEX computer_agent_memory_team_id_idx ON computer_agent_memory (team_id);
+
+ALTER TABLE computer_agent_memory ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Team members can manage their computer agent memory"
+  ON computer_agent_memory
+  AS PERMISSIVE
+  FOR ALL
+  TO public;

--- a/packages/db/src/queries/computer.ts
+++ b/packages/db/src/queries/computer.ts
@@ -1,0 +1,691 @@
+import { and, desc, eq, isNotNull, lt, sql } from "drizzle-orm";
+import type { Database } from "../client";
+import {
+  computerAgentMemory,
+  computerAgents,
+  computerRunSteps,
+  computerRuns,
+  users,
+} from "../schema";
+
+// ---------------------------------------------------------------------------
+// Agents
+// ---------------------------------------------------------------------------
+
+type GetComputerAgentsParams = {
+  teamId: string;
+};
+
+export const getComputerAgents = async (
+  db: Database,
+  params: GetComputerAgentsParams,
+) => {
+  return db
+    .select({
+      id: computerAgents.id,
+      name: computerAgents.name,
+      slug: computerAgents.slug,
+      description: computerAgents.description,
+      source: computerAgents.source,
+      templateId: computerAgents.templateId,
+      scheduleCron: computerAgents.scheduleCron,
+      enabled: computerAgents.enabled,
+      createdAt: computerAgents.createdAt,
+    })
+    .from(computerAgents)
+    .where(eq(computerAgents.teamId, params.teamId))
+    .orderBy(desc(computerAgents.createdAt));
+};
+
+type GetComputerAgentByIdParams = {
+  id: string;
+};
+
+export const getComputerAgentById = async (
+  db: Database,
+  params: GetComputerAgentByIdParams,
+) => {
+  const [result] = await db
+    .select()
+    .from(computerAgents)
+    .where(eq(computerAgents.id, params.id))
+    .limit(1);
+
+  return result;
+};
+
+type GetComputerAgentBySlugParams = {
+  teamId: string;
+  slug: string;
+};
+
+export const getComputerAgentBySlug = async (
+  db: Database,
+  params: GetComputerAgentBySlugParams,
+) => {
+  const [result] = await db
+    .select({ id: computerAgents.id })
+    .from(computerAgents)
+    .where(
+      and(
+        eq(computerAgents.teamId, params.teamId),
+        eq(computerAgents.slug, params.slug),
+      ),
+    )
+    .limit(1);
+
+  return result;
+};
+
+type GetComputerAgentForRunParams = {
+  id: string;
+  teamId: string;
+};
+
+export const getComputerAgentForRun = async (
+  db: Database,
+  params: GetComputerAgentForRunParams,
+) => {
+  const [result] = await db
+    .select({ id: computerAgents.id, enabled: computerAgents.enabled })
+    .from(computerAgents)
+    .where(
+      and(
+        eq(computerAgents.id, params.id),
+        eq(computerAgents.teamId, params.teamId),
+      ),
+    )
+    .limit(1);
+
+  return result;
+};
+
+export const getEnabledScheduledAgents = async (db: Database) => {
+  return db
+    .select({
+      id: computerAgents.id,
+      teamId: computerAgents.teamId,
+      slug: computerAgents.slug,
+      scheduleCron: computerAgents.scheduleCron,
+      timezone: users.timezone,
+    })
+    .from(computerAgents)
+    .leftJoin(users, eq(computerAgents.createdBy, users.id))
+    .where(
+      and(
+        eq(computerAgents.enabled, true),
+        isNotNull(computerAgents.scheduleCron),
+      ),
+    );
+};
+
+type CreateComputerAgentParams = {
+  teamId: string;
+  name: string;
+  slug: string;
+  description?: string | null;
+  source: "catalog" | "generated";
+  code: string;
+  templateId?: string | null;
+  scheduleCron?: string | null;
+  enabled?: boolean;
+  createdBy?: string | null;
+};
+
+export const createComputerAgent = async (
+  db: Database,
+  params: CreateComputerAgentParams,
+) => {
+  const [result] = await db
+    .insert(computerAgents)
+    .values({
+      teamId: params.teamId,
+      name: params.name,
+      slug: params.slug,
+      description: params.description ?? null,
+      source: params.source,
+      code: params.code,
+      templateId: params.templateId ?? null,
+      scheduleCron: params.scheduleCron ?? null,
+      enabled: params.enabled ?? false,
+      createdBy: params.createdBy ?? null,
+    })
+    .returning();
+
+  return result;
+};
+
+type UpdateComputerAgentParams = {
+  id: string;
+  teamId: string;
+  enabled?: boolean;
+  scheduleCron?: string;
+  config?: Record<string, unknown>;
+};
+
+export const updateComputerAgent = async (
+  db: Database,
+  params: UpdateComputerAgentParams,
+) => {
+  const { id, teamId, ...fields } = params;
+
+  const [result] = await db
+    .update(computerAgents)
+    .set({
+      ...(fields.enabled !== undefined ? { enabled: fields.enabled } : {}),
+      ...(fields.scheduleCron !== undefined
+        ? { scheduleCron: fields.scheduleCron }
+        : {}),
+      ...(fields.config !== undefined ? { config: fields.config } : {}),
+      updatedAt: new Date(),
+    })
+    .where(and(eq(computerAgents.id, id), eq(computerAgents.teamId, teamId)))
+    .returning();
+
+  return result;
+};
+
+type DeleteComputerAgentParams = {
+  id: string;
+  teamId: string;
+};
+
+export const deleteComputerAgent = async (
+  db: Database,
+  params: DeleteComputerAgentParams,
+) => {
+  const [result] = await db
+    .delete(computerAgents)
+    .where(
+      and(
+        eq(computerAgents.id, params.id),
+        eq(computerAgents.teamId, params.teamId),
+      ),
+    )
+    .returning({ id: computerAgents.id });
+
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+type CreateComputerRunParams = {
+  id?: string;
+  agentId: string;
+  teamId: string;
+  status?: "pending" | "running" | "completed" | "failed" | "waiting_approval";
+};
+
+export const createComputerRun = async (
+  db: Database,
+  params: CreateComputerRunParams,
+) => {
+  const [result] = await db
+    .insert(computerRuns)
+    .values({
+      ...(params.id ? { id: params.id } : {}),
+      agentId: params.agentId,
+      teamId: params.teamId,
+      status: params.status ?? "pending",
+    })
+    .returning();
+
+  return result;
+};
+
+type GetActiveRunForAgentParams = {
+  agentId: string;
+};
+
+export const getActiveRunForAgent = async (
+  db: Database,
+  params: GetActiveRunForAgentParams,
+) => {
+  const [result] = await db
+    .select({ id: computerRuns.id })
+    .from(computerRuns)
+    .where(
+      and(
+        eq(computerRuns.agentId, params.agentId),
+        eq(computerRuns.status, "running"),
+      ),
+    )
+    .limit(1);
+
+  return result;
+};
+
+type ClaimComputerRunParams = {
+  runId: string;
+  agentId: string;
+};
+
+export const claimComputerRun = async (
+  db: Database,
+  params: ClaimComputerRunParams,
+): Promise<{ id: string } | null> => {
+  const result = await db.execute(sql`
+    UPDATE computer_runs
+    SET status = 'running', started_at = NOW()
+    WHERE id = ${params.runId}
+      AND status = 'pending'
+      AND NOT EXISTS (
+        SELECT 1 FROM computer_runs
+        WHERE agent_id = ${params.agentId} AND status = 'running'
+      )
+    RETURNING id
+  `);
+
+  const row = result.rows?.[0] as { id: string } | undefined;
+  return row ?? null;
+};
+
+export const failStaleRunningRuns = async (
+  db: Database,
+  params: { staleMinutes: number },
+): Promise<number> => {
+  const result = await db
+    .update(computerRuns)
+    .set({
+      status: "failed",
+      error: "stale_timeout",
+      completedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(computerRuns.status, "running"),
+        lt(
+          computerRuns.startedAt,
+          sql`NOW() - INTERVAL '${sql.raw(String(params.staleMinutes))} minutes'`,
+        ),
+      ),
+    )
+    .returning({ id: computerRuns.id });
+
+  return result.length;
+};
+
+type UpdateComputerRunParams = {
+  id: string;
+  status?: "pending" | "running" | "completed" | "failed" | "waiting_approval";
+  proposedActions?: Array<{ tool: string; args: Record<string, unknown>; description?: string }> | null;
+  summary?: string | null;
+  error?: string | null;
+  toolCallCount?: number;
+  llmCallCount?: number;
+  startedAt?: Date;
+  completedAt?: Date;
+};
+
+export const updateComputerRun = async (
+  db: Database,
+  params: UpdateComputerRunParams,
+) => {
+  const { id, proposedActions, ...rest } = params;
+
+  const [result] = await db
+    .update(computerRuns)
+    .set({
+      ...rest,
+      ...(proposedActions !== undefined
+        ? { proposedActions }
+        : {}),
+    })
+    .where(eq(computerRuns.id, id))
+    .returning();
+
+  return result;
+};
+
+type InsertComputerRunStepsParams = {
+  runId: string;
+  steps: Array<{
+    type:
+      | "tool_call"
+      | "ai_generation"
+      | "memory_read"
+      | "memory_write"
+      | "notification"
+      | "proposal"
+      | "connector_call"
+      | "context";
+    name: string;
+    input: unknown;
+    output: unknown;
+    durationMs: number;
+  }>;
+};
+
+export const insertComputerRunSteps = async (
+  db: Database,
+  params: InsertComputerRunStepsParams,
+) => {
+  if (params.steps.length === 0) return;
+
+  await db.insert(computerRunSteps).values(
+    params.steps.map((step) => ({
+      runId: params.runId,
+      type: step.type,
+      name: step.name,
+      input: step.input as Record<string, unknown> | null,
+      output: step.output as Record<string, unknown> | null,
+      durationMs: step.durationMs,
+    })),
+  );
+};
+
+type GetComputerRunsParams = {
+  agentId: string;
+  teamId: string;
+  limit?: number;
+};
+
+export const getComputerRuns = async (
+  db: Database,
+  params: GetComputerRunsParams,
+) => {
+  return db
+    .select({
+      id: computerRuns.id,
+      status: computerRuns.status,
+      summary: computerRuns.summary,
+      error: computerRuns.error,
+      toolCallCount: computerRuns.toolCallCount,
+      llmCallCount: computerRuns.llmCallCount,
+      startedAt: computerRuns.startedAt,
+      completedAt: computerRuns.completedAt,
+      createdAt: computerRuns.createdAt,
+    })
+    .from(computerRuns)
+    .where(
+      and(
+        eq(computerRuns.agentId, params.agentId),
+        eq(computerRuns.teamId, params.teamId),
+      ),
+    )
+    .orderBy(desc(computerRuns.createdAt))
+    .limit(params.limit ?? 20);
+};
+
+type GetComputerRunWithStepsParams = {
+  runId: string;
+  agentId: string;
+  teamId: string;
+};
+
+export const getComputerRunWithSteps = async (
+  db: Database,
+  params: GetComputerRunWithStepsParams,
+) => {
+  const [run] = await db
+    .select()
+    .from(computerRuns)
+    .where(
+      and(
+        eq(computerRuns.id, params.runId),
+        eq(computerRuns.agentId, params.agentId),
+        eq(computerRuns.teamId, params.teamId),
+      ),
+    )
+    .limit(1);
+
+  if (!run) return null;
+
+  const steps = await db
+    .select()
+    .from(computerRunSteps)
+    .where(eq(computerRunSteps.runId, params.runId))
+    .orderBy(computerRunSteps.createdAt);
+
+  return { ...run, steps };
+};
+
+// ---------------------------------------------------------------------------
+// Proposals (Approval Mode)
+// ---------------------------------------------------------------------------
+
+type GetComputerRunProposalsParams = {
+  runId: string;
+  agentId: string;
+  teamId: string;
+};
+
+export const getComputerRunProposals = async (
+  db: Database,
+  params: GetComputerRunProposalsParams,
+) => {
+  const [run] = await db
+    .select({
+      id: computerRuns.id,
+      status: computerRuns.status,
+      proposedActions: computerRuns.proposedActions,
+      agentId: computerRuns.agentId,
+    })
+    .from(computerRuns)
+    .where(
+      and(
+        eq(computerRuns.id, params.runId),
+        eq(computerRuns.agentId, params.agentId),
+        eq(computerRuns.teamId, params.teamId),
+        eq(computerRuns.status, "waiting_approval"),
+      ),
+    )
+    .limit(1);
+
+  return run ?? null;
+};
+
+type ApproveComputerRunParams = {
+  runId: string;
+  approvedIndices?: number[];
+};
+
+export const approveComputerRun = async (
+  db: Database,
+  params: ApproveComputerRunParams,
+) => {
+  const [run] = await db
+    .select({
+      id: computerRuns.id,
+      proposedActions: computerRuns.proposedActions,
+    })
+    .from(computerRuns)
+    .where(
+      and(
+        eq(computerRuns.id, params.runId),
+        eq(computerRuns.status, "waiting_approval"),
+      ),
+    )
+    .limit(1);
+
+  if (!run?.proposedActions) return null;
+
+  const allActions = run.proposedActions as Array<{
+    tool: string;
+    args: Record<string, unknown>;
+    description?: string;
+  }>;
+
+  const approvedActions = params.approvedIndices
+    ? params.approvedIndices
+        .filter((i) => i >= 0 && i < allActions.length)
+        .map((i) => allActions[i]!)
+    : allActions;
+
+  const [updated] = await db
+    .update(computerRuns)
+    .set({ proposedActions: approvedActions, status: "pending" })
+    .where(eq(computerRuns.id, params.runId))
+    .returning();
+
+  return updated;
+};
+
+type RejectComputerRunParams = {
+  runId: string;
+};
+
+export const rejectComputerRun = async (
+  db: Database,
+  params: RejectComputerRunParams,
+) => {
+  const [result] = await db
+    .update(computerRuns)
+    .set({
+      status: "failed",
+      error: "rejected_by_user",
+      completedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(computerRuns.id, params.runId),
+        eq(computerRuns.status, "waiting_approval"),
+      ),
+    )
+    .returning();
+
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Memory
+// ---------------------------------------------------------------------------
+
+type GetAgentMemoryParams = {
+  agentId: string;
+  teamId: string;
+  key?: string;
+  type?: string;
+};
+
+export const getAgentMemory = async (
+  db: Database,
+  params: GetAgentMemoryParams,
+) => {
+  return db
+    .select()
+    .from(computerAgentMemory)
+    .where(
+      and(
+        eq(computerAgentMemory.agentId, params.agentId),
+        eq(computerAgentMemory.teamId, params.teamId),
+        ...(params.key ? [eq(computerAgentMemory.key, params.key)] : []),
+        ...(params.type ? [eq(computerAgentMemory.type, params.type)] : []),
+      ),
+    );
+};
+
+type UpsertAgentMemoryParams = {
+  agentId: string;
+  teamId: string;
+  key: string;
+  content: string;
+  type?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export const upsertAgentMemory = async (
+  db: Database,
+  params: UpsertAgentMemoryParams,
+) => {
+  const existing = await db
+    .select({ id: computerAgentMemory.id })
+    .from(computerAgentMemory)
+    .where(
+      and(
+        eq(computerAgentMemory.agentId, params.agentId),
+        eq(computerAgentMemory.key, params.key),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db
+      .update(computerAgentMemory)
+      .set({
+        content: params.content,
+        type: params.type ?? null,
+        metadata: params.metadata ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(computerAgentMemory.id, existing[0]!.id));
+  } else {
+    await db.insert(computerAgentMemory).values({
+      agentId: params.agentId,
+      teamId: params.teamId,
+      key: params.key,
+      content: params.content,
+      type: params.type ?? null,
+      metadata: params.metadata ?? null,
+    });
+  }
+};
+
+type GetComputerAgentMemoryEntriesParams = {
+  agentId: string;
+  teamId: string;
+};
+
+export const getComputerAgentMemoryEntries = async (
+  db: Database,
+  params: GetComputerAgentMemoryEntriesParams,
+) => {
+  return db
+    .select({
+      id: computerAgentMemory.id,
+      key: computerAgentMemory.key,
+      content: computerAgentMemory.content,
+      type: computerAgentMemory.type,
+      metadata: computerAgentMemory.metadata,
+      updatedAt: computerAgentMemory.updatedAt,
+    })
+    .from(computerAgentMemory)
+    .where(
+      and(
+        eq(computerAgentMemory.agentId, params.agentId),
+        eq(computerAgentMemory.teamId, params.teamId),
+      ),
+    )
+    .orderBy(desc(computerAgentMemory.updatedAt));
+};
+
+// ---------------------------------------------------------------------------
+// User helpers
+// ---------------------------------------------------------------------------
+
+type GetUserTimezoneParams = {
+  userId: string;
+};
+
+export const getUserTimezone = async (
+  db: Database,
+  params: GetUserTimezoneParams,
+) => {
+  const [result] = await db
+    .select({ timezone: users.timezone })
+    .from(users)
+    .where(eq(users.id, params.userId))
+    .limit(1);
+
+  return result?.timezone ?? null;
+};
+
+// ---------------------------------------------------------------------------
+// Scheduler lock (advisory lock to prevent duplicate schedulers)
+// ---------------------------------------------------------------------------
+
+const SCHEDULER_LOCK_ID = 8675309;
+
+export const acquireSchedulerLock = async (db: Database): Promise<boolean> => {
+  const result = await db.execute(
+    sql`SELECT pg_try_advisory_lock(${SCHEDULER_LOCK_ID}) as acquired`,
+  );
+  const row = result.rows?.[0] as { acquired: boolean } | undefined;
+  return row?.acquired === true;
+};
+
+export const releaseSchedulerLock = async (db: Database): Promise<void> => {
+  await db.execute(sql`SELECT pg_advisory_unlock(${SCHEDULER_LOCK_ID})`);
+};

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -4,6 +4,7 @@ export * from "./api-keys";
 export * from "./apps";
 export * from "./bank-accounts";
 export * from "./bank-connections";
+export * from "./computer";
 export * from "./customer-analytics";
 export * from "./customer-enrichment";
 export * from "./customers";

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -4213,3 +4213,219 @@ export const insightUserStatusRelations = relations(
     }),
   }),
 );
+
+// ---------------------------------------------------------------------------
+// Midday Computer -- agents, triggers, runs, steps, memory
+// ---------------------------------------------------------------------------
+
+export const computerAgentSourceEnum = pgEnum("computer_agent_source", [
+  "catalog",
+  "generated",
+]);
+
+export const computerRunStatusEnum = pgEnum("computer_run_status", [
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "waiting_approval",
+]);
+
+export const computerRunStepTypeEnum = pgEnum("computer_run_step_type", [
+  "tool_call",
+  "ai_generation",
+  "memory_read",
+  "memory_write",
+  "notification",
+  "proposal",
+  "connector_call",
+  "context",
+]);
+
+export const computerAgents = pgTable(
+  "computer_agents",
+  {
+    id: uuid().defaultRandom().primaryKey(),
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    name: varchar({ length: 255 }).notNull(),
+    slug: varchar({ length: 255 }).notNull(),
+    description: text(),
+    source: computerAgentSourceEnum().notNull(),
+    code: text().notNull(),
+    templateId: varchar("template_id", { length: 255 }),
+    scheduleCron: varchar("schedule_cron", { length: 255 }),
+    config: jsonb().$type<Record<string, unknown>>(),
+    enabled: boolean().default(false).notNull(),
+    createdBy: uuid("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    unique("computer_agents_team_slug").on(table.teamId, table.slug),
+    index("computer_agents_team_id_idx").on(table.teamId),
+    index("computer_agents_enabled_idx").on(table.teamId, table.enabled),
+    pgPolicy("Team members can manage their computer agents", {
+      as: "permissive",
+      for: "all",
+      to: ["public"],
+    }),
+  ],
+);
+
+export const computerAgentsRelations = relations(
+  computerAgents,
+  ({ one, many }) => ({
+    team: one(teams, {
+      fields: [computerAgents.teamId],
+      references: [teams.id],
+    }),
+    createdByUser: one(users, {
+      fields: [computerAgents.createdBy],
+      references: [users.id],
+    }),
+    runs: many(computerRuns),
+    memory: many(computerAgentMemory),
+  }),
+);
+
+export const computerRuns = pgTable(
+  "computer_runs",
+  {
+    id: uuid().defaultRandom().primaryKey(),
+    agentId: uuid("agent_id")
+      .notNull()
+      .references(() => computerAgents.id, { onDelete: "cascade" }),
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    status: computerRunStatusEnum().default("pending").notNull(),
+    proposedActions: jsonb("proposed_actions").$type<
+      Array<{ tool: string; args: Record<string, unknown>; description?: string }>
+    >(),
+    summary: text(),
+    error: text(),
+    toolCallCount: integer("tool_call_count").default(0).notNull(),
+    llmCallCount: integer("llm_call_count").default(0).notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("computer_runs_agent_id_idx").on(table.agentId),
+    index("computer_runs_team_id_idx").on(table.teamId),
+    index("computer_runs_status_idx").on(table.agentId, table.status),
+    pgPolicy("Team members can view their computer runs", {
+      as: "permissive",
+      for: "select",
+      to: ["public"],
+    }),
+  ],
+);
+
+export const computerRunsRelations = relations(
+  computerRuns,
+  ({ one, many }) => ({
+    agent: one(computerAgents, {
+      fields: [computerRuns.agentId],
+      references: [computerAgents.id],
+    }),
+    team: one(teams, {
+      fields: [computerRuns.teamId],
+      references: [teams.id],
+    }),
+    steps: many(computerRunSteps),
+  }),
+);
+
+export const computerRunSteps = pgTable(
+  "computer_run_steps",
+  {
+    id: uuid().defaultRandom().primaryKey(),
+    runId: uuid("run_id")
+      .notNull()
+      .references(() => computerRuns.id, { onDelete: "cascade" }),
+    type: computerRunStepTypeEnum().notNull(),
+    name: varchar({ length: 255 }).notNull(),
+    input: jsonb(),
+    output: jsonb(),
+    durationMs: integer("duration_ms"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    index("computer_run_steps_run_id_idx").on(table.runId),
+    pgPolicy("Team members can view their computer run steps", {
+      as: "permissive",
+      for: "select",
+      to: ["public"],
+    }),
+  ],
+);
+
+export const computerRunStepsRelations = relations(
+  computerRunSteps,
+  ({ one }) => ({
+    run: one(computerRuns, {
+      fields: [computerRunSteps.runId],
+      references: [computerRuns.id],
+    }),
+  }),
+);
+
+export const computerAgentMemory = pgTable(
+  "computer_agent_memory",
+  {
+    id: uuid().defaultRandom().primaryKey(),
+    agentId: uuid("agent_id")
+      .notNull()
+      .references(() => computerAgents.id, { onDelete: "cascade" }),
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    key: varchar({ length: 255 }).notNull(),
+    content: text().notNull(),
+    type: varchar({ length: 100 }),
+    metadata: jsonb().$type<Record<string, unknown>>(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    unique("computer_agent_memory_agent_key").on(table.agentId, table.key),
+    index("computer_agent_memory_agent_id_idx").on(table.agentId),
+    index("computer_agent_memory_team_id_idx").on(table.teamId),
+    pgPolicy("Team members can manage their computer agent memory", {
+      as: "permissive",
+      for: "all",
+      to: ["public"],
+    }),
+  ],
+);
+
+export const computerAgentMemoryRelations = relations(
+  computerAgentMemory,
+  ({ one }) => ({
+    agent: one(computerAgents, {
+      fields: [computerAgentMemory.agentId],
+      references: [computerAgents.id],
+    }),
+    team: one(teams, {
+      fields: [computerAgentMemory.teamId],
+      references: [teams.id],
+    }),
+  }),
+);

--- a/packages/job-client/src/compute.ts
+++ b/packages/job-client/src/compute.ts
@@ -1,0 +1,94 @@
+import { createLoggerWithContext } from "@midday/logger";
+import { getQueue } from "./queues";
+
+const logger = createLoggerWithContext("job-client:compute");
+
+export const COMPUTE_QUEUE_NAME = "compute";
+
+export interface EnqueueRunOptions {
+  agentId: string;
+  teamId: string;
+  triggerType?: "manual" | "schedule";
+  runId: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface EnqueueReplayOptions {
+  runId: string;
+  agentId: string;
+  teamId: string;
+  actions: Array<{ tool: string; args: Record<string, unknown>; description?: string }>;
+}
+
+export async function enqueueReplay(
+  options: EnqueueReplayOptions,
+): Promise<void> {
+  const queue = getQueue(COMPUTE_QUEUE_NAME);
+  const startTime = Date.now();
+
+  try {
+    const job = await queue.add("replay-proposals", options, {
+      jobId: `replay:${options.runId}`,
+      attempts: 1,
+      removeOnComplete: { age: 7 * 24 * 3600, count: 5000 },
+      removeOnFail: { age: 14 * 24 * 3600 },
+    });
+
+    if (!job?.id) {
+      throw new Error(`Failed to enqueue replay for run: ${options.runId}`);
+    }
+
+    const duration = Date.now() - startTime;
+    logger.info("Enqueued replay job", {
+      runId: options.runId,
+      agentId: options.agentId,
+      actionCount: options.actions.length,
+      jobId: job.id,
+      duration: `${duration}ms`,
+    });
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    logger.error("Failed to enqueue replay", {
+      runId: options.runId,
+      duration: `${duration}ms`,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
+}
+
+export async function enqueueRun(options: EnqueueRunOptions): Promise<void> {
+  const queue = getQueue(COMPUTE_QUEUE_NAME);
+  const startTime = Date.now();
+
+  try {
+    const job = await queue.add("execute-agent", options, {
+      jobId: `run:${options.runId}`,
+      attempts: 1,
+      removeOnComplete: { age: 7 * 24 * 3600, count: 5000 },
+      removeOnFail: { age: 14 * 24 * 3600 },
+    });
+
+    if (!job?.id) {
+      throw new Error(`Failed to enqueue run for agent: ${options.agentId}`);
+    }
+
+    const duration = Date.now() - startTime;
+    logger.info("Enqueued compute run", {
+      agentId: options.agentId,
+      runId: options.runId,
+      teamId: options.teamId,
+      jobId: job.id,
+      duration: `${duration}ms`,
+    });
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    logger.error("Failed to enqueue compute run", {
+      agentId: options.agentId,
+      runId: options.runId,
+      duration: `${duration}ms`,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
+}

--- a/packages/job-client/src/index.ts
+++ b/packages/job-client/src/index.ts
@@ -4,8 +4,10 @@ import type { JobStatus, JobStatusResponse, JobTriggerResponse } from "./types";
 import { decodeJobId, encodeJobId } from "./utils";
 
 // Re-export utilities
-export { getQueue } from "./queues";
+export { getConnectionOptions, getQueue } from "./queues";
 export { decodeJobId, encodeJobId } from "./utils";
+export { COMPUTE_QUEUE_NAME, enqueueReplay, enqueueRun } from "./compute";
+export type { EnqueueReplayOptions, EnqueueRunOptions } from "./compute";
 
 // Create logger with job-client context
 export const logger = createLoggerWithContext("job-client");

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -20,6 +20,7 @@ import { inboxAutoMatched } from "./types/inbox-auto-matched";
 import { inboxCrossCurrencyMatched } from "./types/inbox-cross-currency-matched";
 import { inboxNeedsReview } from "./types/inbox-needs-review";
 import { inboxNew } from "./types/inbox-new";
+import { agentAlert } from "./types/computer-agent-alert";
 import { insightReady } from "./types/insight-ready";
 import { invoiceCancelled } from "./types/invoice-cancelled";
 import { invoiceCreated } from "./types/invoice-created";
@@ -62,6 +63,7 @@ const handlers = {
   recurring_series_paused: recurringSeriesPaused,
   recurring_invoice_upcoming: recurringInvoiceUpcoming,
   insight_ready: insightReady,
+  agent_alert: agentAlert,
 } as const;
 
 export class Notifications {
@@ -410,6 +412,7 @@ export {
 export type { NotificationTypes } from "./schemas";
 // Export schemas and types
 export {
+  agentAlertSchema,
   documentProcessedSchema,
   documentUploadedSchema,
   inboxAutoMatchedSchema,

--- a/packages/notifications/src/notification-types.ts
+++ b/packages/notifications/src/notification-types.ts
@@ -135,6 +135,13 @@ export const allNotificationTypes: NotificationType[] = [
     category: "invoices",
     order: 1,
   },
+  {
+    type: "agent_alert",
+    channels: ["in_app", "email"],
+    showInSettings: true,
+    category: "computer",
+    order: 1,
+  },
 ];
 
 // Get all notification types (including hidden ones)

--- a/packages/notifications/src/schemas.ts
+++ b/packages/notifications/src/schemas.ts
@@ -36,6 +36,7 @@ export const createActivitySchema = z.object({
     "recurring_series_paused",
     "recurring_invoice_upcoming",
     "insight_ready",
+    "agent_alert",
   ]),
   source: z.enum(["system", "user"]).default("system"),
   priority: z.number().int().min(1).max(10).default(5),
@@ -310,6 +311,15 @@ export const transactionsAssignedSchema = z.object({
   transactionIds: z.array(z.string()),
 });
 
+export const agentAlertSchema = z.object({
+  users: z.array(userSchema),
+  agentName: z.string(),
+  agentSlug: z.string(),
+  runId: z.string().uuid(),
+  message: z.string(),
+  priority: z.enum(["low", "normal", "urgent"]).default("normal"),
+});
+
 export const insightReadySchema = z.object({
   users: z.array(userSchema),
   insightId: z.string(),
@@ -371,6 +381,7 @@ export type TransactionsCategorizedInput = z.infer<
 export type TransactionsAssignedInput = z.infer<
   typeof transactionsAssignedSchema
 >;
+export type AgentAlertInput = z.infer<typeof agentAlertSchema>;
 export type InsightReadyInput = z.infer<typeof insightReadySchema>;
 
 // Notification types map - all available notification types with their data structures
@@ -398,4 +409,5 @@ export type NotificationTypes = {
   recurring_series_paused: RecurringSeriesPausedInput;
   recurring_invoice_upcoming: RecurringInvoiceUpcomingInput;
   insight_ready: InsightReadyInput;
+  agent_alert: AgentAlertInput;
 };

--- a/packages/notifications/src/types/computer-agent-alert.ts
+++ b/packages/notifications/src/types/computer-agent-alert.ts
@@ -1,0 +1,32 @@
+import type { NotificationHandler } from "../base";
+import { agentAlertSchema } from "../schemas";
+
+export const agentAlert: NotificationHandler = {
+  schema: agentAlertSchema,
+
+  createActivity: (data, user) => ({
+    teamId: user.team_id,
+    userId: user.id,
+    type: "agent_alert",
+    source: "system",
+    priority: data.priority === "urgent" ? 2 : data.priority === "low" ? 6 : 4,
+    metadata: {
+      agentName: data.agentName,
+      agentSlug: data.agentSlug,
+      runId: data.runId,
+      message: data.message,
+      priority: data.priority,
+    },
+  }),
+
+  createEmail: (data, user) => ({
+    template: "plain",
+    emailType: "team",
+    subject: `Midday Agent: ${data.agentName}`,
+    data: {
+      fullName: user.full_name,
+      agentName: data.agentName,
+      message: data.message,
+    },
+  }),
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Adds a new production service that executes generated code and triggers write actions via automation, plus broad changes to MCP tool output schemas that could break tool clients or agent code generation if mismatched.
> 
> **Overview**
> Adds **Midday Computer agents** end-to-end: a new REST router (`/computer`) and MCP tool suite (`computer_*`) to list catalog agents, enable/deploy generated agents, trigger runs, and inspect run history/proposals.
> 
> Introduces a new `apps/compute` service (Docker/Railway-deployable) that consumes a BullMQ `compute` queue to execute agent code in a sandbox (`secure-exec`), supports scheduled runs via cron + DB lock, records step logs/memory, and implements an approval workflow by persisting proposed actions and replaying them after approval.
> 
> Hardens MCP tool schemas across many domains by replacing `record(any)` outputs with typed Zod schemas, adding a shared `mcpListMetaSchema`, and improving structured outputs for several write/destructive operations (e.g., invoices send/remind responses, recurring invoice preview sanitization). CI/CD is updated to detect/deploy the new `@midday/compute` service in staging and production, and the dashboard chat UI recognizes `computer_*` tool calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8789882bf4993bab528b33fc0b8d3a1eff2c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->