### PR TITLE
[codex] Local-first Tauri desktop bootstrap

### DIFF
--- a/apps/api/src/__tests__/trpc/local-desktop.test.ts
+++ b/apps/api/src/__tests__/trpc/local-desktop.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  LOCAL_DESKTOP_SESSION_TOKEN,
+  LOCAL_DESKTOP_TEAM_ID,
+  LOCAL_DESKTOP_USER_ID,
+} from "@midday/utils/envs";
+
+const originalEnv = {
+  FILE_KEY_SECRET: process.env.FILE_KEY_SECRET,
+  MIDDAY_DESKTOP_RUNTIME: process.env.MIDDAY_DESKTOP_RUNTIME,
+  MIDDAY_LOCAL_FIRST: process.env.MIDDAY_LOCAL_FIRST,
+  MIDDAY_SQLITE_PATH: process.env.MIDDAY_SQLITE_PATH,
+};
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "midday-api-local-desktop-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+beforeEach(() => {
+  process.env.MIDDAY_DESKTOP_RUNTIME = "local";
+  process.env.MIDDAY_LOCAL_FIRST = "true";
+  process.env.FILE_KEY_SECRET = "test-local-desktop-file-key-secret";
+  process.env.MIDDAY_SQLITE_PATH = join(createTempDir(), "midday.sqlite");
+});
+
+afterEach(async () => {
+  const { closeLocalDb } = await import("@midday/db/local-client");
+  closeLocalDb();
+  Bun.gc(true);
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  restoreEnv();
+});
+
+async function createLocalCaller() {
+  const [{ createCallerFactory }, { appRouter }] = await Promise.all([
+    import("../../trpc/init"),
+    import("../../trpc/routers/_app"),
+  ]);
+  const createCaller = createCallerFactory(appRouter);
+
+  return createCaller({
+    cfRay: undefined,
+    db: {} as never,
+    forcePrimary: false,
+    geo: {
+      city: null,
+      continent: null,
+      country: "US",
+      ip: "127.0.0.1",
+      locale: "en-US",
+      region: null,
+      timezone: "America/New_York",
+    },
+    isInternalRequest: false,
+    requestId: "local-desktop-test",
+    session: {
+      teamId: LOCAL_DESKTOP_TEAM_ID,
+      user: {
+        email: "local@midday.local",
+        full_name: "Local Owner",
+        id: LOCAL_DESKTOP_USER_ID,
+      },
+    },
+    supabase: {} as never,
+  });
+}
+
+describe("local desktop tRPC bootstrap", () => {
+  test("serves initial dashboard data from embedded SQLite", async () => {
+    const caller = await createLocalCaller();
+
+    const user = await caller.user.me();
+    const team = await caller.team.current();
+    const teams = await caller.team.list();
+    const overview = await caller.overview.summary();
+    const searchResults = await caller.search.global({});
+    const notifications = await caller.notifications.list();
+    const invoiceDefaults = await caller.invoice.defaultSettings();
+
+    expect(user).toMatchObject({
+      id: LOCAL_DESKTOP_USER_ID,
+      email: "local@midday.local",
+      teamId: LOCAL_DESKTOP_TEAM_ID,
+      team: { id: LOCAL_DESKTOP_TEAM_ID, name: "Local Workspace" },
+    });
+    expect(user?.fileKey).toBeTruthy();
+    expect(team).toMatchObject({
+      id: LOCAL_DESKTOP_TEAM_ID,
+      name: "Local Workspace",
+      baseCurrency: "USD",
+    });
+    expect(teams).toHaveLength(1);
+    expect(overview).toMatchObject({
+      cashBalance: { totalBalance: 0, currency: "USD", accountCount: 0 },
+      openInvoices: { count: 0, totalAmount: 0, currency: "USD" },
+      transactionsToReview: { count: 0 },
+    });
+    expect(searchResults).toEqual([]);
+    expect(notifications).toEqual({
+      meta: {
+        cursor: null,
+        hasPreviousPage: false,
+        hasNextPage: false,
+      },
+      data: [],
+    });
+    expect(invoiceDefaults).toMatchObject({
+      currency: "USD",
+      invoiceNumber: "INV-0001",
+      status: "draft",
+    });
+  });
+
+  test("accepts the desktop session token through context auth", async () => {
+    const [{ createTRPCContext }, { Hono }] = await Promise.all([
+      import("../../trpc/init"),
+      import("hono"),
+    ]);
+    const app = new Hono();
+    let context: Awaited<ReturnType<typeof createTRPCContext>> | undefined;
+
+    app.get("/", async (c) => {
+      context = await createTRPCContext(undefined, c);
+      return c.text("ok");
+    });
+
+    await app.request("http://localhost/", {
+      headers: {
+        Authorization: `Bearer ${LOCAL_DESKTOP_SESSION_TOKEN}`,
+        "x-request-id": "local-desktop-test",
+      },
+    });
+
+    expect(context?.session?.user.id).toBe(LOCAL_DESKTOP_USER_ID);
+    expect(context?.session?.teamId).toBe(LOCAL_DESKTOP_TEAM_ID);
+  });
+});

--- a/apps/api/src/composio/client.test.ts
+++ b/apps/api/src/composio/client.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const originalEnv = {
+  COMPOSIO_API_KEY: process.env.COMPOSIO_API_KEY,
+  MIDDAY_DESKTOP_RUNTIME: process.env.MIDDAY_DESKTOP_RUNTIME,
+  MIDDAY_LOCAL_FIRST: process.env.MIDDAY_LOCAL_FIRST,
+};
+
+beforeEach(() => {
+  process.env.MIDDAY_DESKTOP_RUNTIME = "local";
+  process.env.MIDDAY_LOCAL_FIRST = "true";
+  delete process.env.COMPOSIO_API_KEY;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("local Composio client", () => {
+  test("imports without an API key and returns empty local data", async () => {
+    const { composio, getComposioTools } = await import("./client");
+    const session = await composio.create("local_user");
+    const toolkits = await session.toolkits({ limit: 50 });
+    const tools = await getComposioTools("local_user");
+
+    expect(toolkits.items).toEqual([]);
+    expect(tools).toEqual({});
+  });
+});

--- a/apps/api/src/composio/client.ts
+++ b/apps/api/src/composio/client.ts
@@ -3,16 +3,37 @@ import { VercelProvider } from "@composio/vercel";
 import { connectorsCache } from "@midday/cache/connectors-cache";
 import { CURATED_TOOLKIT_SLUGS } from "@midday/connectors";
 import { logger } from "@midday/logger";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { LRUCache } from "lru-cache";
 
-export const composio = new Composio({
-  apiKey: process.env.COMPOSIO_API_KEY,
-  provider: new VercelProvider(),
-});
+function createLocalComposio() {
+  return {
+    connectedAccounts: {
+      delete: async () => ({}),
+      list: async () => ({ items: [] }),
+    },
+    create: async () => ({
+      authorize: async () => ({ redirectUrl: null }),
+      toolkits: async () => ({ items: [] }),
+      tools: async () => ({}),
+    }),
+  } as unknown as Composio;
+}
+
+export const composio = isLocalDesktopRuntime()
+  ? createLocalComposio()
+  : new Composio({
+      apiKey: process.env.COMPOSIO_API_KEY,
+      provider: new VercelProvider(),
+    });
 
 const COMPOSIO_API_BASE = "https://backend.composio.dev/api/v3";
 
 export async function composioFetch<T>(path: string): Promise<T> {
+  if (!process.env.COMPOSIO_API_KEY) {
+    throw new Error("Composio API key is not configured");
+  }
+
   const res = await fetch(`${COMPOSIO_API_BASE}${path}`, {
     headers: { "x-api-key": process.env.COMPOSIO_API_KEY! },
   });
@@ -108,7 +129,7 @@ export async function getComposioTools(
       manageConnections: false,
       workbench: { enable: false },
     });
-    const tools = await session.tools();
+    const tools = (await session.tools()) as Record<string, unknown>;
     toolsCache.set(userId, tools);
     return tools;
   } catch (err) {

--- a/apps/api/src/services/resend.test.ts
+++ b/apps/api/src/services/resend.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const originalEnv = {
+  MIDDAY_DESKTOP_RUNTIME: process.env.MIDDAY_DESKTOP_RUNTIME,
+  MIDDAY_LOCAL_FIRST: process.env.MIDDAY_LOCAL_FIRST,
+  RESEND_API_KEY: process.env.RESEND_API_KEY,
+};
+
+beforeEach(() => {
+  process.env.MIDDAY_DESKTOP_RUNTIME = "local";
+  process.env.MIDDAY_LOCAL_FIRST = "true";
+  delete process.env.RESEND_API_KEY;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("local Resend service", () => {
+  test("imports without an API key and no-ops email calls", async () => {
+    const { resend } = await import("./resend");
+    const result = (await resend.emails.send({} as never)) as unknown as {
+      data: null;
+      error: null;
+    };
+
+    expect(result).toEqual({
+      data: null,
+      error: null,
+    });
+  });
+});

--- a/apps/api/src/services/resend.ts
+++ b/apps/api/src/services/resend.ts
@@ -1,3 +1,23 @@
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { Resend } from "resend";
 
-export const resend = new Resend(process.env.RESEND_API_KEY!);
+function createLocalResend() {
+  const ok = async () => ({ data: null, error: null });
+
+  return {
+    batch: {
+      send: ok,
+    },
+    contacts: {
+      create: ok,
+      remove: ok,
+    },
+    emails: {
+      send: ok,
+    },
+  } as unknown as Resend;
+}
+
+export const resend = isLocalDesktopRuntime()
+  ? createLocalResend()
+  : new Resend(process.env.RESEND_API_KEY!);

--- a/apps/api/src/services/supabase.ts
+++ b/apps/api/src/services/supabase.ts
@@ -1,7 +1,15 @@
 import type { Database } from "@midday/supabase/types";
+import {
+  createLocalSupabaseClient,
+  isLocalDesktopRuntime,
+} from "@midday/supabase/local-client";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 
 export async function createClient(accessToken?: string) {
+  if (isLocalDesktopRuntime()) {
+    return createLocalSupabaseClient();
+  }
+
   return createSupabaseClient<Database>(
     process.env.SUPABASE_URL!,
     process.env.SUPABASE_SECRET_KEY!,
@@ -14,6 +22,10 @@ export async function createClient(accessToken?: string) {
 }
 
 export async function createAdminClient() {
+  if (isLocalDesktopRuntime()) {
+    return createLocalSupabaseClient();
+  }
+
   return createSupabaseClient<Database>(
     process.env.SUPABASE_URL!,
     process.env.SUPABASE_SECRET_KEY!,

--- a/apps/api/src/trpc/init.ts
+++ b/apps/api/src/trpc/init.ts
@@ -6,7 +6,9 @@ import { getRequestTrace } from "@api/utils/request-trace";
 import { safeCompare } from "@api/utils/safe-compare";
 import type { Database } from "@midday/db/client";
 import { db } from "@midday/db/client";
+import { getSeededLocalDb } from "@midday/db/local-queries";
 import { createLoggerWithContext } from "@midday/logger";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { initTRPC, TRPCError } from "@trpc/server";
 import type { Context } from "hono";
@@ -47,6 +49,10 @@ export const createTRPCContext = async (
   const jwtStart = DEBUG_PERF ? performance.now() : 0;
   const session = await verifyAccessToken(accessToken);
   const jwtMs = DEBUG_PERF ? performance.now() - jwtStart : 0;
+
+  if (isLocalDesktopRuntime()) {
+    getSeededLocalDb();
+  }
 
   const supaStart = DEBUG_PERF ? performance.now() : 0;
   const supabase = await createClient(accessToken);

--- a/apps/api/src/trpc/middleware/primary-read-after-write.ts
+++ b/apps/api/src/trpc/middleware/primary-read-after-write.ts
@@ -2,6 +2,7 @@ import type { Session } from "@api/utils/auth";
 import { replicationCache } from "@midday/cache/replication-cache";
 import type { Database, DatabaseWithPrimary } from "@midday/db/client";
 import { createLoggerWithContext } from "@midday/logger";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 
 const DEBUG_PERF = process.env.DEBUG_PERF === "true";
 const perfLogger = createLoggerWithContext("perf:trpc");
@@ -26,6 +27,10 @@ export const withPrimaryReadAfterWrite = async <TReturn>(opts: {
   const { ctx, type, next } = opts;
   const teamId = ctx.teamId;
   const forcePrimary = ctx.forcePrimary;
+
+  if (isLocalDesktopRuntime()) {
+    return next({ ctx });
+  }
 
   if (forcePrimary && type !== "mutation") {
     const dbWithPrimary = ctx.db as DatabaseWithPrimary;

--- a/apps/api/src/trpc/middleware/team-permission.ts
+++ b/apps/api/src/trpc/middleware/team-permission.ts
@@ -2,7 +2,13 @@ import type { Session } from "@api/utils/auth";
 import { withRetryOnPrimary } from "@api/utils/db-retry";
 import { teamCache } from "@midday/cache/team-cache";
 import type { Database } from "@midday/db/client";
+import {
+  getLocalUserById,
+  getSeededLocalDb,
+  hasLocalTeamAccess,
+} from "@midday/db/local-queries";
 import { createLoggerWithContext } from "@midday/logger";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { TRPCError } from "@trpc/server";
 
 const DEBUG_PERF = process.env.DEBUG_PERF === "true";
@@ -36,6 +42,43 @@ async function resolveTeamPermission(
       code: "UNAUTHORIZED",
       message: "No permission to access this team",
     });
+  }
+
+  if (isLocalDesktopRuntime()) {
+    const local = getSeededLocalDb();
+    const user = getLocalUserById(local, userId);
+
+    if (!user) {
+      teamPermissionLogger.warn("permission denied: local user not found", {
+        procedurePath,
+        userId,
+        requestId,
+        cfRay,
+      });
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "User not found",
+      });
+    }
+
+    if (
+      user.teamId &&
+      !hasLocalTeamAccess(local, user.teamId, userId)
+    ) {
+      teamPermissionLogger.warn("permission denied: local team access missing", {
+        procedurePath,
+        userId,
+        teamId: user.teamId,
+        requestId,
+        cfRay,
+      });
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "No permission to access this team",
+      });
+    }
+
+    return { teamId: user.teamId };
   }
 
   const dbStart = DEBUG_PERF ? performance.now() : 0;

--- a/apps/api/src/trpc/routers/invoice.ts
+++ b/apps/api/src/trpc/routers/invoice.ts
@@ -44,11 +44,17 @@ import {
   searchInvoiceNumber,
   updateInvoice,
 } from "@midday/db/queries";
+import {
+  getLocalTeamById,
+  getLocalUserById,
+  getSeededLocalDb,
+} from "@midday/db/local-queries";
 import { DEFAULT_TEMPLATE } from "@midday/invoice";
 import { verify } from "@midday/invoice/token";
 import { transformCustomerToContent } from "@midday/invoice/utils";
 import { decodeJobId, getQueue, triggerJob } from "@midday/job-client";
 import { createLoggerWithContext } from "@midday/logger";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { TRPCError } from "@trpc/server";
 import { addDays, format, parseISO } from "date-fns";
 import { v4 as uuidv4 } from "uuid";
@@ -278,6 +284,112 @@ export const invoiceRouter = createTRPCRouter({
 
   defaultSettings: protectedProcedure.query(
     async ({ ctx: { db, teamId, session, geo } }) => {
+      if (isLocalDesktopRuntime()) {
+        const local = getSeededLocalDb();
+        const team = getLocalTeamById(local, teamId!);
+        const user = getLocalUserById(local, session.user.id);
+        const locale = user?.locale ?? geo?.locale ?? "en";
+        const timezone =
+          user?.timezone ?? geo?.timezone ?? "America/New_York";
+        const currency = team?.baseCurrency ?? defaultTemplate.currency;
+        const dateFormat = user?.dateFormat ?? defaultTemplate.dateFormat;
+        const logoUrl = defaultTemplate.logoUrl;
+        const countryCode = geo?.country ?? "US";
+        const size = ["US", "CA"].includes(countryCode) ? "letter" : "a4";
+        const includeTax = ["US", "CA", "AU", "NZ", "SG", "MY", "IN"].includes(
+          countryCode,
+        );
+        const savedTemplate = {
+          id: undefined,
+          name: "Default",
+          isDefault: true,
+          title: defaultTemplate.title,
+          logoUrl,
+          currency,
+          size: defaultTemplate.size,
+          includeTax,
+          includeVat: !includeTax,
+          includeDiscount: defaultTemplate.includeDiscount,
+          includeDecimals: defaultTemplate.includeDecimals,
+          includeUnits: defaultTemplate.includeUnits,
+          includeQr: defaultTemplate.includeQr,
+          includeLineItemTax: defaultTemplate.includeLineItemTax,
+          lineItemTaxLabel: defaultTemplate.lineItemTaxLabel,
+          includePdf: defaultTemplate.includePdf,
+          sendCopy: defaultTemplate.sendCopy,
+          customerLabel: defaultTemplate.customerLabel,
+          fromLabel: defaultTemplate.fromLabel,
+          invoiceNoLabel: defaultTemplate.invoiceNoLabel,
+          subtotalLabel: defaultTemplate.subtotalLabel,
+          issueDateLabel: defaultTemplate.issueDateLabel,
+          totalSummaryLabel: defaultTemplate.totalSummaryLabel,
+          dueDateLabel: defaultTemplate.dueDateLabel,
+          discountLabel: defaultTemplate.discountLabel,
+          descriptionLabel: defaultTemplate.descriptionLabel,
+          priceLabel: defaultTemplate.priceLabel,
+          quantityLabel: defaultTemplate.quantityLabel,
+          totalLabel: defaultTemplate.totalLabel,
+          vatLabel: defaultTemplate.vatLabel,
+          taxLabel: defaultTemplate.taxLabel,
+          paymentLabel: defaultTemplate.paymentLabel,
+          noteLabel: defaultTemplate.noteLabel,
+          dateFormat,
+          deliveryType: defaultTemplate.deliveryType,
+          taxRate: defaultTemplate.taxRate,
+          vatRate: defaultTemplate.vatRate,
+          fromDetails: defaultTemplate.fromDetails,
+          paymentDetails: defaultTemplate.paymentDetails,
+          noteDetails: defaultTemplate.noteDetails,
+          timezone,
+          locale,
+          paymentEnabled: defaultTemplate.paymentEnabled,
+          paymentTermsDays: defaultTemplate.paymentTermsDays,
+          emailSubject: null,
+          emailHeading: null,
+          emailBody: null,
+          emailButtonText: null,
+        };
+
+        const paymentTermsDays = savedTemplate.paymentTermsDays ?? 30;
+
+        return {
+          id: uuidv4(),
+          currency,
+          status: "draft",
+          size,
+          includeTax: savedTemplate.includeTax,
+          includeVat: savedTemplate.includeVat,
+          includeDiscount: false,
+          includeDecimals: false,
+          includePdf: false,
+          sendCopy: false,
+          includeUnits: false,
+          includeQr: true,
+          invoiceNumber: "INV-0001",
+          timezone,
+          locale,
+          fromDetails: savedTemplate.fromDetails,
+          paymentDetails: savedTemplate.paymentDetails,
+          customerDetails: undefined,
+          noteDetails: savedTemplate.noteDetails,
+          customerId: undefined,
+          issueDate: new UTCDate().toISOString(),
+          dueDate: addDays(new UTCDate(), paymentTermsDays).toISOString(),
+          lineItems: [{ name: "", quantity: 0, price: 0, vat: 0 }],
+          tax: undefined,
+          token: undefined,
+          discount: undefined,
+          subtotal: undefined,
+          topBlock: undefined,
+          bottomBlock: undefined,
+          amount: undefined,
+          customerName: undefined,
+          logoUrl: undefined,
+          vat: undefined,
+          template: savedTemplate,
+        };
+      }
+
       // Fetch invoice number, template, and team details concurrently
       const [nextInvoiceNumber, template, team, user] = await Promise.all([
         getNextInvoiceNumber(db, teamId!),

--- a/apps/api/src/trpc/routers/notifications.ts
+++ b/apps/api/src/trpc/routers/notifications.ts
@@ -9,11 +9,23 @@ import {
   updateActivityStatus,
   updateAllActivitiesStatus,
 } from "@midday/db/queries";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 
 export const notificationsRouter = createTRPCRouter({
   list: protectedProcedure
     .input(getNotificationsSchema.optional())
     .query(async ({ ctx: { teamId, db, session }, input }) => {
+      if (isLocalDesktopRuntime()) {
+        return {
+          meta: {
+            cursor: null,
+            hasPreviousPage: false,
+            hasNextPage: false,
+          },
+          data: [],
+        };
+      }
+
       return getActivities(db, {
         teamId: teamId!,
         userId: session.user.id,
@@ -24,12 +36,20 @@ export const notificationsRouter = createTRPCRouter({
   updateStatus: protectedProcedure
     .input(updateNotificationStatusSchema)
     .mutation(async ({ ctx: { db, teamId }, input }) => {
+      if (isLocalDesktopRuntime()) {
+        return [];
+      }
+
       return updateActivityStatus(db, input.activityId, input.status, teamId!);
     }),
 
   updateAllStatus: protectedProcedure
     .input(updateAllNotificationsStatusSchema)
     .mutation(async ({ ctx: { db, teamId, session }, input }) => {
+      if (isLocalDesktopRuntime()) {
+        return [];
+      }
+
       return updateAllActivitiesStatus(db, teamId!, input.status, {
         userId: session.user.id,
       });

--- a/apps/api/src/trpc/routers/overview.ts
+++ b/apps/api/src/trpc/routers/overview.ts
@@ -1,8 +1,17 @@
 import { createTRPCRouter, protectedProcedure } from "@api/trpc/init";
 import { getOverviewSummary } from "@midday/db/queries";
+import {
+  getLocalOverviewSummary,
+  getSeededLocalDb,
+} from "@midday/db/local-queries";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 
 export const overviewRouter = createTRPCRouter({
   summary: protectedProcedure.query(async ({ ctx: { db, teamId } }) => {
+    if (isLocalDesktopRuntime()) {
+      return getLocalOverviewSummary(getSeededLocalDb(), { teamId: teamId! });
+    }
+
     return getOverviewSummary(db, { teamId: teamId! });
   }),
 });

--- a/apps/api/src/trpc/routers/search.ts
+++ b/apps/api/src/trpc/routers/search.ts
@@ -10,11 +10,16 @@ import {
   globalSearchQuery,
   globalSemanticSearchQuery,
 } from "@midday/db/queries";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 
 export const searchRouter = createTRPCRouter({
   global: protectedProcedure
     .input(globalSearchSchema)
     .query(async ({ input, ctx: { db, teamId } }) => {
+      if (isLocalDesktopRuntime()) {
+        return [];
+      }
+
       const { searchTerm } = input;
 
       // Determine if we should fall back to LLM-generated filters:
@@ -60,6 +65,10 @@ export const searchRouter = createTRPCRouter({
   attachments: protectedProcedure
     .input(searchAttachmentsSchema)
     .query(async ({ input, ctx: { db, teamId } }) => {
+      if (isLocalDesktopRuntime()) {
+        return [];
+      }
+
       const { q, transactionId, limit = 30 } = input;
 
       const [inboxResults, invoiceResults] = await Promise.all([

--- a/apps/api/src/trpc/routers/team.ts
+++ b/apps/api/src/trpc/routers/team.ts
@@ -37,7 +37,15 @@ import {
   updateTeamById,
   updateTeamMember,
 } from "@midday/db/queries";
+import {
+  getLocalTeamById,
+  getLocalTeamMembersByTeamId,
+  getLocalTeamsByUserId,
+  getSeededLocalDb,
+  updateLocalTeamById,
+} from "@midday/db/local-queries";
 import { triggerJob } from "@midday/job-client";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { tasks } from "@trigger.dev/sdk";
 import { TRPCError } from "@trpc/server";
 
@@ -47,12 +55,23 @@ export const teamRouter = createTRPCRouter({
       return null;
     }
 
+    if (isLocalDesktopRuntime()) {
+      return getLocalTeamById(getSeededLocalDb(), teamId) ?? null;
+    }
+
     return getTeamById(db, teamId!);
   }),
 
   update: protectedProcedure
     .input(updateTeamByIdSchema)
     .mutation(async ({ ctx: { db, teamId }, input }) => {
+      if (isLocalDesktopRuntime()) {
+        return updateLocalTeamById(getSeededLocalDb(), {
+          id: teamId!,
+          data: input,
+        });
+      }
+
       return updateTeamById(db, {
         id: teamId!,
         data: input,
@@ -60,10 +79,18 @@ export const teamRouter = createTRPCRouter({
     }),
 
   members: protectedProcedure.query(async ({ ctx: { db, teamId } }) => {
+    if (isLocalDesktopRuntime()) {
+      return getLocalTeamMembersByTeamId(getSeededLocalDb(), teamId!);
+    }
+
     return getTeamMembersByTeamId(db, teamId!);
   }),
 
   list: protectedProcedure.query(async ({ ctx: { db, session } }) => {
+    if (isLocalDesktopRuntime()) {
+      return getLocalTeamsByUserId(getSeededLocalDb(), session.user.id);
+    }
+
     return getTeamsByUserId(db, session.user.id);
   }),
 
@@ -305,10 +332,18 @@ export const teamRouter = createTRPCRouter({
     }),
 
   teamInvites: protectedProcedure.query(async ({ ctx: { db, teamId } }) => {
+    if (isLocalDesktopRuntime()) {
+      return [];
+    }
+
     return getTeamInvites(db, teamId!);
   }),
 
   invitesByEmail: protectedProcedure.query(async ({ ctx: { db, session } }) => {
+    if (isLocalDesktopRuntime()) {
+      return [];
+    }
+
     return getInvitesByEmail(db, session.user.email!);
   }),
 
@@ -381,6 +416,10 @@ export const teamRouter = createTRPCRouter({
     }),
 
   availablePlans: protectedProcedure.query(async ({ ctx: { db, teamId } }) => {
+    if (isLocalDesktopRuntime()) {
+      return { starter: true, pro: true };
+    }
+
     return getAvailablePlans(db, teamId!);
   }),
 
@@ -425,6 +464,10 @@ export const teamRouter = createTRPCRouter({
   connectionStatus: protectedProcedure.query(
     async ({ ctx: { db, teamId } }) => {
       if (!teamId) {
+        return { bankConnections: [], inboxAccounts: [] };
+      }
+
+      if (isLocalDesktopRuntime()) {
         return { bankConnections: [], inboxAccounts: [] };
       }
 

--- a/apps/api/src/trpc/routers/user.ts
+++ b/apps/api/src/trpc/routers/user.ts
@@ -11,12 +11,32 @@ import {
   switchUserTeam,
   updateUser,
 } from "@midday/db/queries";
+import {
+  getLocalUserById,
+  getSeededLocalDb,
+  switchLocalUserTeam,
+  updateLocalUser,
+} from "@midday/db/local-queries";
 import { generateFileKey } from "@midday/encryption";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 export const userRouter = createTRPCRouter({
   me: protectedProcedure.query(async ({ ctx: { db, session } }) => {
+    if (isLocalDesktopRuntime()) {
+      const result = getLocalUserById(getSeededLocalDb(), session.user.id);
+
+      if (!result) {
+        return undefined;
+      }
+
+      return {
+        ...result,
+        fileKey: result.teamId ? await generateFileKey(result.teamId) : null,
+      };
+    }
+
     // Cookie-based approach handles replication lag for new users via x-force-primary header
     // Retry logic still handles connection errors/timeouts
     const result = await withRetryOnPrimary(db, async (dbInstance) =>
@@ -36,6 +56,13 @@ export const userRouter = createTRPCRouter({
   update: protectedProcedure
     .input(updateUserSchema)
     .mutation(async ({ ctx: { db, session }, input }) => {
+      if (isLocalDesktopRuntime()) {
+        return updateLocalUser(getSeededLocalDb(), {
+          id: session.user.id,
+          ...input,
+        });
+      }
+
       return updateUser(db, {
         id: session.user.id,
         ...input,
@@ -45,6 +72,13 @@ export const userRouter = createTRPCRouter({
   switchTeam: protectedProcedure
     .input(z.object({ teamId: z.string().uuid() }))
     .mutation(async ({ ctx: { db, session }, input }) => {
+      if (isLocalDesktopRuntime()) {
+        return switchLocalUserTeam(getSeededLocalDb(), {
+          userId: session.user.id,
+          teamId: input.teamId,
+        });
+      }
+
       let result: Awaited<ReturnType<typeof switchUserTeam>>;
 
       try {
@@ -87,6 +121,10 @@ export const userRouter = createTRPCRouter({
   }),
 
   invites: protectedProcedure.query(async ({ ctx: { db, session } }) => {
+    if (isLocalDesktopRuntime()) {
+      return [];
+    }
+
     if (!session.user.email) {
       return [];
     }

--- a/apps/api/src/utils/auth.ts
+++ b/apps/api/src/utils/auth.ts
@@ -1,4 +1,10 @@
 import { createRemoteJWKSet, type JWTPayload, jwtVerify } from "jose";
+import {
+  isLocalDesktopRuntime,
+  LOCAL_DESKTOP_SESSION_TOKEN,
+  LOCAL_DESKTOP_TEAM_ID,
+  LOCAL_DESKTOP_USER_ID,
+} from "@midday/utils/envs";
 
 export type Session = {
   user: {
@@ -17,17 +23,29 @@ type SupabaseJWTPayload = JWTPayload & {
   };
 };
 
-// Primary: verify via JWKS (asymmetric ES256/RS256). jose caches the
-// keyset in memory so only the first call hits the network.
-const JWKS = createRemoteJWKSet(
-  new URL(`${process.env.SUPABASE_URL}/auth/v1/.well-known/jwks.json`),
-);
-
 // Fallback: HS256 shared secret for tokens issued before key rotation.
 // Remove this once the legacy JWT secret is revoked in Supabase.
 const HS256_SECRET = process.env.SUPABASE_JWT_SECRET
   ? new TextEncoder().encode(process.env.SUPABASE_JWT_SECRET)
   : null;
+
+let remoteJwks: ReturnType<typeof createRemoteJWKSet> | null | undefined;
+
+function getRemoteJwks() {
+  if (remoteJwks !== undefined) {
+    return remoteJwks;
+  }
+
+  if (!process.env.SUPABASE_URL) {
+    remoteJwks = null;
+    return remoteJwks;
+  }
+
+  remoteJwks = createRemoteJWKSet(
+    new URL(`${process.env.SUPABASE_URL}/auth/v1/.well-known/jwks.json`),
+  );
+  return remoteJwks;
+}
 
 function extractSession(payload: JWTPayload): Session {
   const p = payload as SupabaseJWTPayload;
@@ -45,11 +63,28 @@ export async function verifyAccessToken(
 ): Promise<Session | null> {
   if (!accessToken) return null;
 
-  try {
-    const { payload } = await jwtVerify(accessToken, JWKS);
-    return extractSession(payload);
-  } catch {
-    // JWKS verification failed -- try HS256 fallback if configured.
+  if (
+    isLocalDesktopRuntime() &&
+    accessToken === LOCAL_DESKTOP_SESSION_TOKEN
+  ) {
+    return {
+      teamId: LOCAL_DESKTOP_TEAM_ID,
+      user: {
+        id: LOCAL_DESKTOP_USER_ID,
+        email: "local@midday.local",
+        full_name: "Local User",
+      },
+    };
+  }
+
+  const jwks = getRemoteJwks();
+  if (jwks) {
+    try {
+      const { payload } = await jwtVerify(accessToken, jwks);
+      return extractSession(payload);
+    } catch {
+      // JWKS verification failed -- try HS256 fallback if configured.
+    }
   }
 
   if (HS256_SECRET) {

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,79 +1,71 @@
 # Midday Desktop App
 
-A Tauri-based desktop application for Midday that supports multiple environments with a native transparent titlebar on macOS.
+A Tauri-based local-first desktop application for Midday with a native transparent titlebar on macOS.
 
 ## Features
 
-- **Environment Support**: Development, Staging, and Production environments
+- **Local-First Runtime**: Loads the local dashboard and API by default
+- **Remote Diagnostics**: Hosted app modes remain available for diagnostics
 - **Transparent Titlebar**: Native macOS transparent titlebar with traffic light buttons
 - **Responsive Design**: Minimum window size of 1450x900 for optimal experience
 
-## Environment Configuration
+## Runtime Configuration
 
-The desktop app supports three environments, each loading a different URL:
+The desktop app is local-first by default. It opens the local dashboard at
+`http://localhost:3001`, and the dashboard talks to the local API at
+`http://localhost:3003`.
 
-- **Development**: `http://localhost:3001`
-- **Staging**: `https://beta.midday.ai`
-- **Production**: `https://app.midday.ai`
+### Development With Existing Dev Servers
 
-## Running the App
+Run the dashboard and API in separate terminals from the repository root:
 
-### Development Mode
 ```bash
-# Run in development environment (loads localhost:3001)
-bun run tauri:dev
+bun run dev:api
+bun run dev:dashboard
 ```
 
-### Staging Mode
+Then run the desktop shell:
+
 ```bash
-# Run in staging environment (loads beta.midday.ai)
-bun run tauri:staging
+bun run --filter @midday/desktop tauri:dev
 ```
 
-### Production Mode
+### Development With Desktop-Managed Services
+
+The desktop shell can also start the dashboard and API dev servers:
+
 ```bash
-# Run in production environment (loads app.midday.ai)
-bun run tauri:prod
+bun run --filter @midday/desktop tauri:dev:managed
+```
+
+This mode is the Phase 1 bridge toward packaged sidecars. The packaged build
+will replace dev commands with bundled sidecar binaries.
+
+### Remote Diagnostics
+
+Remote mode is kept only for diagnosing hosted app behavior:
+
+```bash
+bun run --filter @midday/desktop tauri:remote:staging
+bun run --filter @midday/desktop tauri:remote:prod
 ```
 
 ## Building the App
 
 ### Development Build
+
 ```bash
-bun run tauri:build
+bun run tauri:build:dev
 ```
 
 ### Staging Build
+
 ```bash
 bun run tauri:build:staging
 ```
 
 ### Production Build
+
 ```bash
 bun run tauri:build:prod
-```
-
-## Environment Variable
-
-The environment is controlled by the `MIDDAY_ENV` environment variable:
-
-- `development` or `dev` → `http://localhost:3001`
-- `staging` → `https://beta.midday.ai`
-- `production` or `prod` → `https://app.midday.ai`
-
-If no environment is specified, it defaults to development mode.
-
-## Manual Environment Setting
-
-You can also set the environment manually:
-
-```bash
-# macOS/Linux
-MIDDAY_ENV=staging tauri dev
-
-# Windows (PowerShell)
-$env:MIDDAY_ENV="staging"; tauri dev
-
-# Windows (Command Prompt)
-set MIDDAY_ENV=staging && tauri dev
 ```

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,9 +8,10 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
-    "tauri:dev": "MIDDAY_ENV=development tauri dev --config src-tauri/tauri.dev.conf.json",
-    "tauri:staging": "MIDDAY_ENV=staging tauri dev --config src-tauri/tauri.staging.conf.json",
-    "tauri:prod": "MIDDAY_ENV=production tauri dev",
+    "tauri:dev": "MIDDAY_DESKTOP_RUNTIME=local MIDDAY_DESKTOP_MANAGE_SERVICES=false MIDDAY_DASHBOARD_URL=http://localhost:3001 MIDDAY_API_URL=http://localhost:3003 tauri dev --config src-tauri/tauri.dev.conf.json",
+    "tauri:dev:managed": "MIDDAY_DESKTOP_RUNTIME=local MIDDAY_DESKTOP_MANAGE_SERVICES=true MIDDAY_DASHBOARD_URL=http://localhost:3001 MIDDAY_API_URL=http://localhost:3003 tauri dev --config src-tauri/tauri.dev.conf.json",
+    "tauri:remote:staging": "MIDDAY_DESKTOP_RUNTIME=remote MIDDAY_REMOTE_APP_URL=https://beta.midday.ai MIDDAY_REMOTE_API_URL=https://api.midday.ai tauri dev --config src-tauri/tauri.staging.conf.json",
+    "tauri:remote:prod": "MIDDAY_DESKTOP_RUNTIME=remote MIDDAY_REMOTE_APP_URL=https://app.midday.ai MIDDAY_REMOTE_API_URL=https://api.midday.ai tauri dev",
     "tauri:build:dev": "tauri build --config src-tauri/tauri.dev.conf.json",
     "tauri:build:staging": "tauri build --config src-tauri/tauri.staging.conf.json",
     "tauri:build:prod": "tauri build"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-upload",
  "tokio",
+ "ureq",
 ]
 
 [[package]]
@@ -1804,7 +1805,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3485,7 +3486,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3609,6 +3610,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4900,6 +4902,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "windows-sys 0.61.2",
 ]
@@ -5223,6 +5226,22 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -5552,6 +5571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -26,12 +26,13 @@ tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 image = "0.24"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "process", "io-util"] }
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2.2.2"
 tauri-plugin-process = "2.2.1"
 tauri-plugin-upload = "2"
 tauri-plugin-fs = "2"
+ureq = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-global-shortcut = "2"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -47,5 +47,5 @@
       "https://app.midday.ai/**"
     ]
   },
-  "platforms": ["macOS"]
+  "platforms": ["macOS", "windows", "linux"]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,5 @@
 use image;
 use serde_json;
-use std::env;
 use std::sync::{Arc, Mutex};
 #[cfg(target_os = "macos")]
 use tauri::TitleBarStyle;
@@ -282,7 +281,7 @@ async fn create_preloaded_search_window(
     let search_window_label = "search";
     let search_url = format!("{}/desktop/search", app_url);
 
-    let mut search_builder = WebviewWindowBuilder::new(
+    let search_builder = WebviewWindowBuilder::new(
         app,
         search_window_label,
         WebviewUrl::External(tauri::Url::parse(&search_url)?),
@@ -303,11 +302,9 @@ async fn create_preloaded_search_window(
 
     // Platform-specific styling
     #[cfg(target_os = "macos")]
-    {
-        search_builder = search_builder
-            .hidden_title(true)
-            .title_bar_style(TitleBarStyle::Overlay);
-    }
+    let search_builder = search_builder
+        .hidden_title(true)
+        .title_bar_style(TitleBarStyle::Overlay);
 
     let search_window = search_builder.shadow(false).build()?;
 
@@ -345,38 +342,10 @@ async fn create_preloaded_search_window(
 }
 
 fn get_app_url() -> String {
-    // Try runtime environment variable first, then fall back to compile-time
-    let env = env::var("MIDDAY_ENV").unwrap_or_else(|_| {
-        option_env!("MIDDAY_ENV")
-            .unwrap_or("development")
-            .to_string()
-    });
-
-    println!("🌍 Environment detected: {}", env);
-
-    match env.as_str() {
-        "development" | "dev" => {
-            let url = "http://localhost:3001".to_string();
-            println!("🌍 Using development URL: {}", url);
-            url
-        }
-        "staging" => {
-            let url = "https://beta.midday.ai".to_string();
-            println!("🌍 Using staging URL: {}", url);
-            url
-        }
-        "production" | "prod" => {
-            let url = "https://app.midday.ai".to_string();
-            println!("🌍 Using production URL: {}", url);
-            url
-        }
-        _ => {
-            eprintln!("Unknown environment: {}, defaulting to development", env);
-            let url = "http://localhost:3001".to_string();
-            println!("🌍 Using fallback development URL: {}", url);
-            url
-        }
-    }
+    let config = local_services::resolve_config_from_env(&local_services::current_env());
+    println!("🌍 Desktop runtime: {:?}", config.mode);
+    println!("🌍 Dashboard URL: {}", config.dashboard_url);
+    config.dashboard_url
 }
 
 fn is_external_url(url: &str, app_url: &str) -> bool {
@@ -457,6 +426,37 @@ pub fn run() {
                 });
             }
 
+            let local_config =
+                local_services::resolve_config_from_env(&local_services::current_env());
+            let mut local_manager = local_services::LocalServiceManager::new(local_config.clone());
+
+            if local_config.manage_processes {
+                local_manager
+                    .start_dev_services(local_services::repo_root_from_manifest())
+                    .map_err(|error| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("Failed to start local services: {error}"),
+                        )
+                    })?;
+            }
+
+            if matches!(
+                local_config.mode,
+                local_services::DesktopRuntimeMode::Local
+            ) {
+                tauri::async_runtime::block_on(local_manager.wait_until_ready()).map_err(
+                    |error| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("Local services were not ready: {error}"),
+                        )
+                    },
+                )?;
+            }
+
+            app.manage(Mutex::new(local_manager));
+
             let app_url_clone = app_url.clone();
             let app_handle = app.handle().clone();
 
@@ -534,7 +534,7 @@ pub fn run() {
                 handle_deep_link_event(&app_handle_for_deep_links, url_strings);
             });
 
-            let mut win_builder = WebviewWindowBuilder::new(
+            let win_builder = WebviewWindowBuilder::new(
                 app,
                 "main",
                 WebviewUrl::External(tauri::Url::parse(&app_url).unwrap()),
@@ -549,11 +549,9 @@ pub fn run() {
             .shadow(true);
 
             #[cfg(target_os = "macos")]
-            {
-                win_builder = win_builder
-                    .hidden_title(true)
-                    .title_bar_style(TitleBarStyle::Overlay);
-            }
+            let win_builder = win_builder
+                .hidden_title(true)
+                .title_bar_style(TitleBarStyle::Overlay);
 
             let win_builder = win_builder
             .disable_drag_drop_handler()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,18 +1,19 @@
+use image;
 use serde_json;
 use std::env;
 use std::sync::{Arc, Mutex};
+#[cfg(target_os = "macos")]
+use tauri::TitleBarStyle;
+use tauri::image::Image;
+use tauri::menu::{Menu, MenuItem};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{
-    Emitter, Listener, Manager, PhysicalPosition, Position, TitleBarStyle, WebviewUrl,
-    WebviewWindowBuilder,
+    Emitter, Listener, Manager, PhysicalPosition, Position, WebviewUrl, WebviewWindowBuilder,
 };
 use tauri_plugin_deep_link::DeepLinkExt;
-use tauri_plugin_updater;
 use tauri_plugin_dialog;
 use tauri_plugin_process;
-use tauri::menu::{Menu, MenuItem};
-use tauri::image::Image;
-use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use image;
+use tauri_plugin_updater;
 
 pub mod local_services;
 
@@ -44,22 +45,28 @@ fn show_window(window: tauri::Window) -> Result<(), String> {
 /// Shared by both manual and silent update flows.
 #[cfg(desktop)]
 async fn prompt_and_install_update(app: &tauri::AppHandle, update: tauri_plugin_updater::Update) {
-    use tauri_plugin_dialog::{DialogExt, MessageDialogKind, MessageDialogButtons};
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
-    let answer = app.dialog()
-        .message(format!("A new version {} is available. Would you like to update now?", update.version))
+    let answer = app
+        .dialog()
+        .message(format!(
+            "A new version {} is available. Would you like to update now?",
+            update.version
+        ))
         .title("Update Available")
         .kind(MessageDialogKind::Info)
         .buttons(MessageDialogButtons::OkCancel)
         .blocking_show();
 
     if answer {
-        let _ = update.download_and_install(
-            |_chunk_length, _content_length| {},
-            || {
-                println!("Update download finished");
-            }
-        ).await;
+        let _ = update
+            .download_and_install(
+                |_chunk_length, _content_length| {},
+                || {
+                    println!("Update download finished");
+                },
+            )
+            .await;
     }
 }
 
@@ -89,9 +96,9 @@ async fn silent_update_check(app: tauri::AppHandle) {
 /// Shows dialogs for all outcomes: update available, up-to-date, and errors.
 #[tauri::command]
 async fn check_for_updates(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri_plugin_dialog::{DialogExt, MessageDialogKind, MessageDialogButtons};
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
     use tauri_plugin_updater::UpdaterExt;
-    
+
     #[cfg(desktop)]
     {
         if let Ok(updater) = app.updater() {
@@ -126,7 +133,7 @@ async fn check_for_updates(app: tauri::AppHandle) -> Result<(), String> {
                 .blocking_show();
         }
     }
-    
+
     #[cfg(not(desktop))]
     {
         app.dialog()
@@ -136,7 +143,7 @@ async fn check_for_updates(app: tauri::AppHandle) -> Result<(), String> {
             .buttons(MessageDialogButtons::Ok)
             .blocking_show();
     }
-    
+
     Ok(())
 }
 
@@ -295,9 +302,12 @@ async fn create_preloaded_search_window(
     });
 
     // Platform-specific styling
-    search_builder = search_builder
-        .hidden_title(true)
-        .title_bar_style(TitleBarStyle::Overlay);
+    #[cfg(target_os = "macos")]
+    {
+        search_builder = search_builder
+            .hidden_title(true)
+            .title_bar_style(TitleBarStyle::Overlay);
+    }
 
     let search_window = search_builder.shadow(false).build()?;
 
@@ -336,12 +346,11 @@ async fn create_preloaded_search_window(
 
 fn get_app_url() -> String {
     // Try runtime environment variable first, then fall back to compile-time
-    let env = env::var("MIDDAY_ENV")
-        .unwrap_or_else(|_| {
-            option_env!("MIDDAY_ENV")
-                .unwrap_or("development")
-                .to_string()
-        });
+    let env = env::var("MIDDAY_ENV").unwrap_or_else(|_| {
+        option_env!("MIDDAY_ENV")
+            .unwrap_or("development")
+            .to_string()
+    });
 
     println!("🌍 Environment detected: {}", env);
 
@@ -350,17 +359,17 @@ fn get_app_url() -> String {
             let url = "http://localhost:3001".to_string();
             println!("🌍 Using development URL: {}", url);
             url
-        },
+        }
         "staging" => {
             let url = "https://beta.midday.ai".to_string();
             println!("🌍 Using staging URL: {}", url);
             url
-        },
+        }
         "production" | "prod" => {
             let url = "https://app.midday.ai".to_string();
             println!("🌍 Using production URL: {}", url);
             url
-        },
+        }
         _ => {
             eprintln!("Unknown environment: {}, defaulting to development", env);
             let url = "http://localhost:3001".to_string();
@@ -453,14 +462,14 @@ pub fn run() {
 
             // Create shared search window state
             let search_state: SearchWindowState = Arc::new(Mutex::new(false));
-            
+
             // Add search state to managed state so commands can access it
             app.manage(search_state.clone());
 
             // Clone app_handle before it gets moved into closures
             let app_handle_for_deep_links = app_handle.clone();
             let app_handle_for_navigation = app_handle.clone();
-            
+
             // Auth state is now accessed via managed state for consistency
 
             // Initialize global shortcuts
@@ -483,7 +492,7 @@ pub fn run() {
                                 if let Some(managed_search_state) = app_handle.try_state::<SearchWindowState>() {
                                     let current_search_state = *managed_search_state.lock().unwrap();
                                     println!("🔍 Shortcut: Search state from managed state: {}", current_search_state);
-                                    
+
                                     // Use the same app_handle for both search state and toggle function
                                     let result = toggle_search_window(app_handle, &managed_search_state);
                                     match result {
@@ -525,7 +534,7 @@ pub fn run() {
                 handle_deep_link_event(&app_handle_for_deep_links, url_strings);
             });
 
-            let win_builder = WebviewWindowBuilder::new(
+            let mut win_builder = WebviewWindowBuilder::new(
                 app,
                 "main",
                 WebviewUrl::External(tauri::Url::parse(&app_url).unwrap()),
@@ -537,9 +546,16 @@ pub fn run() {
             .decorations(false)
             .visible(false)
             .transparent(true)
-            .shadow(true)
-            .hidden_title(true)
-            .title_bar_style(TitleBarStyle::Overlay)
+            .shadow(true);
+
+            #[cfg(target_os = "macos")]
+            {
+                win_builder = win_builder
+                    .hidden_title(true)
+                    .title_bar_style(TitleBarStyle::Overlay);
+            }
+
+            let win_builder = win_builder
             .disable_drag_drop_handler()
             .on_download(|_window, _event| {
                 println!("Download triggered!");
@@ -579,7 +595,7 @@ pub fn run() {
                     println!("🔍 Event received: search-window-enabled = {}", enabled);
                     *search_state_for_events.lock().unwrap() = enabled;
                     println!("🔍 Search window state updated to {}", enabled);
-                    
+
                     // If search is disabled, clean up search window to prevent interference
                     if !enabled {
                         println!("🔍 Search disabled, cleaning up search window");
@@ -675,6 +691,7 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri app")
         .run(|app_handle, event| match event {
+            #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen { .. } => {
                 if let Some(main_window) = app_handle.get_webview_window("main") {
                     let _ = main_window.show();
@@ -684,7 +701,7 @@ pub fn run() {
             tauri::RunEvent::ExitRequested { api, .. } => {
                 // Prevent app from quitting to keep global shortcuts working
                 api.prevent_exit();
-                
+
                 // Hide all windows instead of quitting
                 if let Some(main_window) = app_handle.get_webview_window("main") {
                     let _ = main_window.hide();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,8 @@ use tauri::image::Image;
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use image;
 
+pub mod local_services;
+
 // Global state for search window availability
 type SearchWindowState = Arc<Mutex<bool>>;
 

--- a/apps/desktop/src-tauri/src/local_services.rs
+++ b/apps/desktop/src-tauri/src/local_services.rs
@@ -171,6 +171,10 @@ fn port_from_url(url: &str, fallback: &str) -> String {
 
 fn local_runtime_env() -> Vec<(String, String)> {
     vec![
+        (
+            "FILE_KEY_SECRET".to_string(),
+            "midday-local-desktop-file-key-secret".to_string(),
+        ),
         ("MIDDAY_DESKTOP_RUNTIME".to_string(), "local".to_string()),
         ("MIDDAY_LOCAL_FIRST".to_string(), "true".to_string()),
     ]

--- a/apps/desktop/src-tauri/src/local_services.rs
+++ b/apps/desktop/src-tauri/src/local_services.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -142,6 +144,134 @@ pub async fn wait_for_url(
     Err(LocalServiceError::Timeout { service, url })
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceCommand {
+    pub program: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+}
+
+fn port_from_url(url: &str, fallback: &str) -> String {
+    url.rsplit(':')
+        .next()
+        .and_then(|part| part.split('/').next())
+        .filter(|part| part.chars().all(|ch| ch.is_ascii_digit()))
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+pub fn dashboard_dev_command(config: &LocalServiceConfig) -> ServiceCommand {
+    ServiceCommand {
+        program: "bun".to_string(),
+        args: vec!["run".to_string(), "dev:dashboard".to_string()],
+        env: vec![
+            ("NEXT_PUBLIC_API_URL".to_string(), config.api_url.clone()),
+            ("API_INTERNAL_URL".to_string(), config.api_url.clone()),
+        ],
+    }
+}
+
+pub fn api_dev_command(config: &LocalServiceConfig) -> ServiceCommand {
+    ServiceCommand {
+        program: "bun".to_string(),
+        args: vec!["run".to_string(), "dev:api".to_string()],
+        env: vec![
+            ("PORT".to_string(), port_from_url(&config.api_url, "3003")),
+            (
+                "ALLOWED_API_ORIGINS".to_string(),
+                config.dashboard_url.clone(),
+            ),
+        ],
+    }
+}
+
+pub struct LocalServiceManager {
+    config: LocalServiceConfig,
+    children: Vec<Child>,
+}
+
+impl LocalServiceManager {
+    pub fn new(config: LocalServiceConfig) -> Self {
+        Self {
+            config,
+            children: Vec::new(),
+        }
+    }
+
+    pub fn dashboard_url(&self) -> &str {
+        &self.config.dashboard_url
+    }
+
+    pub fn config(&self) -> &LocalServiceConfig {
+        &self.config
+    }
+
+    pub fn start_dev_services(&mut self, repo_root: PathBuf) -> Result<(), String> {
+        if self.config.mode == DesktopRuntimeMode::Remote || !self.config.manage_processes {
+            return Ok(());
+        }
+
+        self.children.push(spawn_service(
+            repo_root.clone(),
+            api_dev_command(&self.config),
+        )?);
+        self.children.push(spawn_service(
+            repo_root,
+            dashboard_dev_command(&self.config),
+        )?);
+
+        Ok(())
+    }
+
+    pub async fn wait_until_ready(&self) -> Result<(), String> {
+        if let Some(url) = api_health_url(&self.config) {
+            wait_for_url("api", url, Duration::from_secs(45))
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+
+        if let Some(url) = dashboard_health_url(&self.config) {
+            wait_for_url("dashboard", url, Duration::from_secs(90))
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+
+        Ok(())
+    }
+
+    pub fn shutdown(&mut self) {
+        for child in &mut self.children {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        self.children.clear();
+    }
+}
+
+impl Drop for LocalServiceManager {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn spawn_service(repo_root: PathBuf, command: ServiceCommand) -> Result<Child, String> {
+    let mut process = Command::new(&command.program);
+    process
+        .args(&command.args)
+        .current_dir(repo_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    for (key, value) in command.env {
+        process.env(key, value);
+    }
+
+    process
+        .spawn()
+        .map_err(|error| format!("failed to spawn {}: {}", command.program, error))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,5 +343,38 @@ mod tests {
 
         assert_eq!(api_health_url(&config), None);
         assert_eq!(dashboard_health_url(&config), None);
+    }
+
+    #[test]
+    fn builds_dashboard_dev_command() {
+        let command = dashboard_dev_command(&resolve_config_from_env(&env(&[])));
+
+        assert_eq!(command.program, "bun");
+        assert_eq!(command.args, vec!["run", "dev:dashboard"]);
+        assert!(command.env.iter().any(|(key, value)| {
+            key == "NEXT_PUBLIC_API_URL" && value == "http://localhost:3003"
+        }));
+        assert!(
+            command.env.iter().any(|(key, value)| {
+                key == "API_INTERNAL_URL" && value == "http://localhost:3003"
+            })
+        );
+    }
+
+    #[test]
+    fn builds_api_dev_command() {
+        let command = api_dev_command(&resolve_config_from_env(&env(&[])));
+
+        assert_eq!(command.program, "bun");
+        assert_eq!(command.args, vec!["run", "dev:api"]);
+        assert!(
+            command
+                .env
+                .iter()
+                .any(|(key, value)| key == "PORT" && value == "3003")
+        );
+        assert!(command.env.iter().any(|(key, value)| {
+            key == "ALLOWED_API_ORIGINS" && value == "http://localhost:3001"
+        }));
     }
 }

--- a/apps/desktop/src-tauri/src/local_services.rs
+++ b/apps/desktop/src-tauri/src/local_services.rs
@@ -169,28 +169,49 @@ fn port_from_url(url: &str, fallback: &str) -> String {
         .to_string()
 }
 
+fn local_runtime_env() -> Vec<(String, String)> {
+    vec![
+        ("MIDDAY_DESKTOP_RUNTIME".to_string(), "local".to_string()),
+        ("MIDDAY_LOCAL_FIRST".to_string(), "true".to_string()),
+    ]
+}
+
 pub fn dashboard_dev_command(config: &LocalServiceConfig) -> ServiceCommand {
+    let mut env = local_runtime_env();
+    env.extend([
+        (
+            "NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME".to_string(),
+            "local".to_string(),
+        ),
+        (
+            "NEXT_PUBLIC_MIDDAY_LOCAL_FIRST".to_string(),
+            "true".to_string(),
+        ),
+        ("NEXT_PUBLIC_API_URL".to_string(), config.api_url.clone()),
+        ("API_INTERNAL_URL".to_string(), config.api_url.clone()),
+    ]);
+
     ServiceCommand {
         program: "bun".to_string(),
         args: vec!["run".to_string(), "dev:dashboard".to_string()],
-        env: vec![
-            ("NEXT_PUBLIC_API_URL".to_string(), config.api_url.clone()),
-            ("API_INTERNAL_URL".to_string(), config.api_url.clone()),
-        ],
+        env,
     }
 }
 
 pub fn api_dev_command(config: &LocalServiceConfig) -> ServiceCommand {
+    let mut env = local_runtime_env();
+    env.extend([
+        ("PORT".to_string(), port_from_url(&config.api_url, "3003")),
+        (
+            "ALLOWED_API_ORIGINS".to_string(),
+            config.dashboard_url.clone(),
+        ),
+    ]);
+
     ServiceCommand {
         program: "bun".to_string(),
         args: vec!["run".to_string(), "dev:api".to_string()],
-        env: vec![
-            ("PORT".to_string(), port_from_url(&config.api_url, "3003")),
-            (
-                "ALLOWED_API_ORIGINS".to_string(),
-                config.dashboard_url.clone(),
-            ),
-        ],
+        env,
     }
 }
 
@@ -360,6 +381,24 @@ mod tests {
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["run", "dev:dashboard"]);
+        assert!(
+            command
+                .env
+                .iter()
+                .any(|(key, value)| key == "MIDDAY_DESKTOP_RUNTIME" && value == "local")
+        );
+        assert!(
+            command
+                .env
+                .iter()
+                .any(|(key, value)| key == "MIDDAY_LOCAL_FIRST" && value == "true")
+        );
+        assert!(command.env.iter().any(|(key, value)| {
+            key == "NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME" && value == "local"
+        }));
+        assert!(command.env.iter().any(|(key, value)| {
+            key == "NEXT_PUBLIC_MIDDAY_LOCAL_FIRST" && value == "true"
+        }));
         assert!(command.env.iter().any(|(key, value)| {
             key == "NEXT_PUBLIC_API_URL" && value == "http://localhost:3003"
         }));
@@ -376,6 +415,18 @@ mod tests {
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["run", "dev:api"]);
+        assert!(
+            command
+                .env
+                .iter()
+                .any(|(key, value)| key == "MIDDAY_DESKTOP_RUNTIME" && value == "local")
+        );
+        assert!(
+            command
+                .env
+                .iter()
+                .any(|(key, value)| key == "MIDDAY_LOCAL_FIRST" && value == "true")
+        );
         assert!(
             command
                 .env

--- a/apps/desktop/src-tauri/src/local_services.rs
+++ b/apps/desktop/src-tauri/src/local_services.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DesktopRuntimeMode {
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalServiceConfig {
+    pub mode: DesktopRuntimeMode,
+    pub dashboard_url: String,
+    pub api_url: String,
+    pub manage_processes: bool,
+}
+
+pub fn resolve_config_from_env(env: &HashMap<String, String>) -> LocalServiceConfig {
+    let runtime = env
+        .get("MIDDAY_DESKTOP_RUNTIME")
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_else(|| "local".to_string());
+
+    if runtime == "remote" {
+        return LocalServiceConfig {
+            mode: DesktopRuntimeMode::Remote,
+            dashboard_url: env
+                .get("MIDDAY_REMOTE_APP_URL")
+                .cloned()
+                .unwrap_or_else(|| "https://app.midday.ai".to_string()),
+            api_url: env
+                .get("MIDDAY_REMOTE_API_URL")
+                .cloned()
+                .unwrap_or_else(|| "https://api.midday.ai".to_string()),
+            manage_processes: false,
+        };
+    }
+
+    let manage_processes = env
+        .get("MIDDAY_DESKTOP_MANAGE_SERVICES")
+        .map(|value| value != "false" && value != "0")
+        .unwrap_or(true);
+
+    LocalServiceConfig {
+        mode: DesktopRuntimeMode::Local,
+        dashboard_url: env
+            .get("MIDDAY_DASHBOARD_URL")
+            .cloned()
+            .unwrap_or_else(|| "http://localhost:3001".to_string()),
+        api_url: env
+            .get("MIDDAY_API_URL")
+            .cloned()
+            .unwrap_or_else(|| "http://localhost:3003".to_string()),
+        manage_processes,
+    }
+}
+
+pub fn current_env() -> HashMap<String, String> {
+    std::env::vars().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn defaults_to_local_runtime() {
+        let config = resolve_config_from_env(&env(&[]));
+
+        assert_eq!(config.mode, DesktopRuntimeMode::Local);
+        assert_eq!(config.dashboard_url, "http://localhost:3001");
+        assert_eq!(config.api_url, "http://localhost:3003");
+        assert!(config.manage_processes);
+    }
+
+    #[test]
+    fn allows_external_local_servers_without_process_management() {
+        let config = resolve_config_from_env(&env(&[
+            ("MIDDAY_DESKTOP_MANAGE_SERVICES", "false"),
+            ("MIDDAY_DASHBOARD_URL", "http://localhost:4101"),
+            ("MIDDAY_API_URL", "http://localhost:4103"),
+        ]));
+
+        assert_eq!(config.mode, DesktopRuntimeMode::Local);
+        assert_eq!(config.dashboard_url, "http://localhost:4101");
+        assert_eq!(config.api_url, "http://localhost:4103");
+        assert!(!config.manage_processes);
+    }
+
+    #[test]
+    fn keeps_remote_mode_available_for_diagnostics() {
+        let config = resolve_config_from_env(&env(&[
+            ("MIDDAY_DESKTOP_RUNTIME", "remote"),
+            ("MIDDAY_REMOTE_APP_URL", "https://app.midday.ai"),
+        ]));
+
+        assert_eq!(config.mode, DesktopRuntimeMode::Remote);
+        assert_eq!(config.dashboard_url, "https://app.midday.ai");
+        assert_eq!(config.api_url, "https://api.midday.ai");
+        assert!(!config.manage_processes);
+    }
+}

--- a/apps/desktop/src-tauri/src/local_services.rs
+++ b/apps/desktop/src-tauri/src/local_services.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DesktopRuntimeMode {
@@ -58,6 +59,89 @@ pub fn current_env() -> HashMap<String, String> {
     std::env::vars().collect()
 }
 
+pub fn api_health_url(config: &LocalServiceConfig) -> Option<String> {
+    match config.mode {
+        DesktopRuntimeMode::Local => {
+            Some(format!("{}/health", config.api_url.trim_end_matches('/')))
+        }
+        DesktopRuntimeMode::Remote => None,
+    }
+}
+
+pub fn dashboard_health_url(config: &LocalServiceConfig) -> Option<String> {
+    match config.mode {
+        DesktopRuntimeMode::Local => Some(config.dashboard_url.trim_end_matches('/').to_string()),
+        DesktopRuntimeMode::Remote => None,
+    }
+}
+
+#[derive(Debug)]
+pub enum LocalServiceError {
+    Timeout {
+        service: &'static str,
+        url: String,
+    },
+    Request {
+        service: &'static str,
+        url: String,
+        message: String,
+    },
+}
+
+impl std::fmt::Display for LocalServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LocalServiceError::Timeout { service, url } => {
+                write!(f, "{service} did not become ready at {url}")
+            }
+            LocalServiceError::Request {
+                service,
+                url,
+                message,
+            } => write!(f, "{service} health request failed at {url}: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for LocalServiceError {}
+
+fn is_ready(url: &str) -> Result<bool, String> {
+    match ureq::get(url).call() {
+        Ok(response) => Ok((200..500).contains(&response.status())),
+        Err(ureq::Error::Status(status, _)) => Ok((200..500).contains(&status)),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub async fn wait_for_url(
+    service: &'static str,
+    url: String,
+    timeout: Duration,
+) -> Result<(), LocalServiceError> {
+    let start = Instant::now();
+    let mut last_error: Option<String> = None;
+
+    while start.elapsed() < timeout {
+        match is_ready(&url) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(message) => last_error = Some(message),
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    if let Some(message) = last_error {
+        return Err(LocalServiceError::Request {
+            service,
+            url,
+            message,
+        });
+    }
+
+    Err(LocalServiceError::Timeout { service, url })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,5 +188,30 @@ mod tests {
         assert_eq!(config.dashboard_url, "https://app.midday.ai");
         assert_eq!(config.api_url, "https://api.midday.ai");
         assert!(!config.manage_processes);
+    }
+
+    #[test]
+    fn builds_health_urls_for_local_services() {
+        let config = resolve_config_from_env(&env(&[]));
+
+        assert_eq!(
+            api_health_url(&config),
+            Some("http://localhost:3003/health".to_string())
+        );
+        assert_eq!(
+            dashboard_health_url(&config),
+            Some("http://localhost:3001".to_string())
+        );
+    }
+
+    #[test]
+    fn remote_runtime_has_no_local_health_urls() {
+        let config = resolve_config_from_env(&env(&[
+            ("MIDDAY_DESKTOP_RUNTIME", "remote"),
+            ("MIDDAY_REMOTE_APP_URL", "https://app.midday.ai"),
+        ]));
+
+        assert_eq!(api_health_url(&config), None);
+        assert_eq!(dashboard_health_url(&config), None);
     }
 }

--- a/apps/desktop/src-tauri/src/local_services.rs
+++ b/apps/desktop/src-tauri/src/local_services.rs
@@ -61,6 +61,15 @@ pub fn current_env() -> HashMap<String, String> {
     std::env::vars().collect()
 }
 
+pub fn repo_root_from_manifest() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
 pub fn api_health_url(config: &LocalServiceConfig) -> Option<String> {
     match config.mode {
         DesktopRuntimeMode::Local => {
@@ -376,5 +385,13 @@ mod tests {
         assert!(command.env.iter().any(|(key, value)| {
             key == "ALLOWED_API_ORIGINS" && value == "http://localhost:3001"
         }));
+    }
+
+    #[test]
+    fn repo_root_from_manifest_points_to_workspace_root() {
+        let root = repo_root_from_manifest();
+
+        assert!(root.join("apps").join("desktop").exists());
+        assert!(root.join("packages").exists());
     }
 }

--- a/docs/superpowers/plans/2026-06-14-local-first-sqlite-foundation.md
+++ b/docs/superpowers/plans/2026-06-14-local-first-sqlite-foundation.md
@@ -1,0 +1,829 @@
+# Local First SQLite Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a tested embedded SQLite database foundation for the desktop runtime without replacing the existing Postgres query layer yet.
+
+**Architecture:** Keep the current `@midday/db/client` Postgres export untouched and add a parallel `@midday/db/local-client` export. The local client owns SQLite file resolution, Bun SQLite connection setup, PRAGMA configuration, versioned bootstrap migrations, and local identity/session seed data that later Supabase replacement work can consume.
+
+**Tech Stack:** Bun `bun:sqlite`, Drizzle `drizzle-orm/bun-sqlite`, Drizzle SQLite schema helpers, Bun test.
+
+---
+
+## File Structure
+
+- Create `packages/db/src/local/path.ts`
+  - Resolves the local SQLite file path from `MIDDAY_SQLITE_PATH`, `MIDDAY_DESKTOP_DATA_DIR`, or a workspace-local `.midday/midday.sqlite` fallback.
+  - Creates the parent directory by default so callers can open the file immediately.
+- Create `packages/db/src/local/schema.ts`
+  - Defines small SQLite bootstrap tables for local metadata, migrations, users, teams, team membership, and sessions.
+  - This is intentionally not a full port of `packages/db/src/schema.ts`; that file is Postgres-specific and is too large for a safe first SQLite pass.
+- Create `packages/db/src/local/migrations.ts`
+  - Applies versioned raw SQL migrations using Bun SQLite transactions.
+  - Records applied versions in `local_migrations`.
+- Create `packages/db/src/local/client.ts`
+  - Opens the Bun SQLite file, configures PRAGMAs, creates the Drizzle client, runs migrations, exposes close helpers, and seeds a local workspace.
+- Create `packages/db/src/local/client.test.ts`
+  - Verifies path resolution, migration idempotence, Drizzle queries, and local workspace seeding against temporary SQLite files.
+- Modify `packages/db/package.json`
+  - Add `./local-client` export and `test:local` script.
+
+---
+
+### Task 1: Local SQLite Path Resolution
+
+**Files:**
+- Create: `packages/db/src/local/path.ts`
+- Test: `packages/db/src/local/client.test.ts`
+
+- [ ] **Step 1: Write failing path tests**
+
+Add this initial test file:
+
+```ts
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveLocalDbPath } from "./path";
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "midday-local-db-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveLocalDbPath", () => {
+  test("uses a workspace-local default path and creates the parent directory", () => {
+    const cwd = createTempDir();
+
+    const dbPath = resolveLocalDbPath({ cwd, env: {} });
+
+    expect(dbPath).toBe(join(cwd, ".midday", "midday.sqlite"));
+    expect(existsSync(dirname(dbPath))).toBe(true);
+  });
+
+  test("uses MIDDAY_SQLITE_PATH before the desktop data directory", () => {
+    const cwd = createTempDir();
+    const desktopDataDir = join(cwd, "desktop-data");
+
+    const dbPath = resolveLocalDbPath({
+      cwd,
+      env: {
+        MIDDAY_DESKTOP_DATA_DIR: desktopDataDir,
+        MIDDAY_SQLITE_PATH: "custom/local.sqlite",
+      },
+    });
+
+    expect(dbPath).toBe(join(cwd, "custom", "local.sqlite"));
+    expect(existsSync(dirname(dbPath))).toBe(true);
+  });
+
+  test("uses MIDDAY_DESKTOP_DATA_DIR when no explicit SQLite path is set", () => {
+    const cwd = createTempDir();
+    const desktopDataDir = join(cwd, "desktop-data");
+
+    const dbPath = resolveLocalDbPath({
+      cwd,
+      env: { MIDDAY_DESKTOP_DATA_DIR: desktopDataDir },
+    });
+
+    expect(dbPath).toBe(join(desktopDataDir, "midday.sqlite"));
+    expect(existsSync(dirname(dbPath))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cmd /c bun test packages/db/src/local/client.test.ts`
+
+Expected: FAIL because `packages/db/src/local/path.ts` does not exist.
+
+- [ ] **Step 3: Implement path resolution**
+
+Create `packages/db/src/local/path.ts`:
+
+```ts
+import { mkdirSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+export const DEFAULT_LOCAL_DB_RELATIVE_PATH = join(".midday", "midday.sqlite");
+
+type LocalDbPathEnv = Pick<
+  NodeJS.ProcessEnv,
+  "MIDDAY_DESKTOP_DATA_DIR" | "MIDDAY_SQLITE_PATH"
+>;
+
+export type ResolveLocalDbPathOptions = {
+  cwd?: string;
+  ensureDir?: boolean;
+  env?: LocalDbPathEnv;
+};
+
+export function resolveLocalDbPath(options: ResolveLocalDbPathOptions = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const explicitPath = env.MIDDAY_SQLITE_PATH?.trim();
+  const desktopDataDir = env.MIDDAY_DESKTOP_DATA_DIR?.trim();
+  const dbPath =
+    explicitPath ||
+    (desktopDataDir
+      ? join(desktopDataDir, "midday.sqlite")
+      : DEFAULT_LOCAL_DB_RELATIVE_PATH);
+  const resolvedPath = isAbsolute(dbPath) ? dbPath : resolve(cwd, dbPath);
+
+  if (options.ensureDir !== false) {
+    mkdirSync(dirname(resolvedPath), { recursive: true });
+  }
+
+  return resolvedPath;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk cmd /c bun test packages/db/src/local/client.test.ts`
+
+Expected: PASS for the path tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/db/src/local/path.ts packages/db/src/local/client.test.ts
+rtk git commit -m "feat(db): resolve local sqlite path"
+```
+
+---
+
+### Task 2: Local Schema and Migrations
+
+**Files:**
+- Create: `packages/db/src/local/schema.ts`
+- Create: `packages/db/src/local/migrations.ts`
+- Modify: `packages/db/src/local/client.test.ts`
+
+- [ ] **Step 1: Add failing migration tests**
+
+Append these imports:
+
+```ts
+import { Database as BunDatabase } from "bun:sqlite";
+import { migrateLocalDb } from "./migrations";
+```
+
+Append these tests:
+
+```ts
+describe("migrateLocalDb", () => {
+  test("creates the local bootstrap tables and records the migration", () => {
+    const cwd = createTempDir();
+    const sqlite = new BunDatabase(join(cwd, "midday.sqlite"), {
+      create: true,
+      readwrite: true,
+    });
+
+    try {
+      const result = migrateLocalDb(sqlite);
+      const tables = sqlite
+        .query("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+        .all() as Array<{ name: string }>;
+      const versions = sqlite
+        .query("SELECT version FROM local_migrations ORDER BY version")
+        .all() as Array<{ version: number }>;
+
+      expect(result.applied).toEqual([1]);
+      expect(tables.map((table) => table.name)).toContain("local_meta");
+      expect(tables.map((table) => table.name)).toContain("local_sessions");
+      expect(versions).toEqual([{ version: 1 }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("is idempotent after migrations have already run", () => {
+    const cwd = createTempDir();
+    const sqlite = new BunDatabase(join(cwd, "midday.sqlite"), {
+      create: true,
+      readwrite: true,
+    });
+
+    try {
+      migrateLocalDb(sqlite);
+      const result = migrateLocalDb(sqlite);
+      const versions = sqlite
+        .query("SELECT version FROM local_migrations ORDER BY version")
+        .all() as Array<{ version: number }>;
+
+      expect(result.applied).toEqual([]);
+      expect(versions).toEqual([{ version: 1 }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `rtk cmd /c bun test packages/db/src/local/client.test.ts`
+
+Expected: FAIL because `migrations.ts` and `schema.ts` do not exist.
+
+- [ ] **Step 3: Implement SQLite schema**
+
+Create `packages/db/src/local/schema.ts`:
+
+```ts
+import { sql } from "drizzle-orm";
+import {
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+export const localMeta = sqliteTable("local_meta", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+});
+
+export const localMigrations = sqliteTable("local_migrations", {
+  version: integer("version").primaryKey(),
+  name: text("name").notNull(),
+  appliedAt: text("applied_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+});
+
+export const localUsers = sqliteTable(
+  "local_users",
+  {
+    id: text("id").primaryKey(),
+    email: text("email").notNull(),
+    name: text("name"),
+    avatarUrl: text("avatar_url"),
+    createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [uniqueIndex("local_users_email_idx").on(table.email)],
+);
+
+export const localTeams = sqliteTable("local_teams", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  baseCurrency: text("base_currency").notNull().default("USD"),
+  createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+});
+
+export const localUsersOnTeams = sqliteTable(
+  "local_users_on_teams",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => localUsers.id, { onDelete: "cascade" }),
+    teamId: text("team_id")
+      .notNull()
+      .references(() => localTeams.id, { onDelete: "cascade" }),
+    role: text("role").notNull().default("owner"),
+    createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.teamId] }),
+    index("local_users_on_teams_team_id_idx").on(table.teamId),
+  ],
+);
+
+export const localSessions = sqliteTable(
+  "local_sessions",
+  {
+    token: text("token").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => localUsers.id, { onDelete: "cascade" }),
+    teamId: text("team_id")
+      .notNull()
+      .references(() => localTeams.id, { onDelete: "cascade" }),
+    expiresAt: text("expires_at"),
+    createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    index("local_sessions_user_id_idx").on(table.userId),
+    index("local_sessions_team_id_idx").on(table.teamId),
+  ],
+);
+```
+
+- [ ] **Step 4: Implement migration runner**
+
+Create `packages/db/src/local/migrations.ts`:
+
+```ts
+import type { Database as BunDatabase } from "bun:sqlite";
+
+export type LocalMigration = {
+  name: string;
+  statements: string[];
+  version: number;
+};
+
+export type LocalMigrationResult = {
+  applied: number[];
+  version: number;
+};
+
+export const LOCAL_MIGRATIONS: LocalMigration[] = [
+  {
+    version: 1,
+    name: "bootstrap_local_identity",
+    statements: [
+      `CREATE TABLE IF NOT EXISTS local_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )`,
+      `CREATE TABLE IF NOT EXISTS local_users (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL UNIQUE,
+        name TEXT,
+        avatar_url TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )`,
+      `CREATE TABLE IF NOT EXISTS local_teams (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        base_currency TEXT NOT NULL DEFAULT 'USD',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )`,
+      `CREATE TABLE IF NOT EXISTS local_users_on_teams (
+        user_id TEXT NOT NULL REFERENCES local_users(id) ON DELETE CASCADE,
+        team_id TEXT NOT NULL REFERENCES local_teams(id) ON DELETE CASCADE,
+        role TEXT NOT NULL DEFAULT 'owner',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (user_id, team_id)
+      )`,
+      `CREATE INDEX IF NOT EXISTS local_users_on_teams_team_id_idx
+        ON local_users_on_teams(team_id)`,
+      `CREATE TABLE IF NOT EXISTS local_sessions (
+        token TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL REFERENCES local_users(id) ON DELETE CASCADE,
+        team_id TEXT NOT NULL REFERENCES local_teams(id) ON DELETE CASCADE,
+        expires_at TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )`,
+      `CREATE INDEX IF NOT EXISTS local_sessions_user_id_idx
+        ON local_sessions(user_id)`,
+      `CREATE INDEX IF NOT EXISTS local_sessions_team_id_idx
+        ON local_sessions(team_id)`,
+    ],
+  },
+];
+
+function getCurrentVersion(sqlite: BunDatabase) {
+  const row = sqlite
+    .query("SELECT COALESCE(MAX(version), 0) AS version FROM local_migrations")
+    .get() as { version: number } | null;
+
+  return row?.version ?? 0;
+}
+
+export function migrateLocalDb(sqlite: BunDatabase): LocalMigrationResult {
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  sqlite.exec(`CREATE TABLE IF NOT EXISTS local_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  )`);
+
+  const currentVersion = getCurrentVersion(sqlite);
+  const applied: number[] = [];
+
+  for (const migration of LOCAL_MIGRATIONS) {
+    if (migration.version <= currentVersion) {
+      continue;
+    }
+
+    const applyMigration = sqlite.transaction(() => {
+      for (const statement of migration.statements) {
+        sqlite.exec(statement);
+      }
+
+      sqlite
+        .query("INSERT INTO local_migrations (version, name) VALUES (?, ?)")
+        .run(migration.version, migration.name);
+    });
+
+    applyMigration();
+    applied.push(migration.version);
+  }
+
+  return {
+    applied,
+    version: LOCAL_MIGRATIONS.at(-1)?.version ?? 0,
+  };
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `rtk cmd /c bun test packages/db/src/local/client.test.ts`
+
+Expected: PASS for path and migration tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add packages/db/src/local/schema.ts packages/db/src/local/migrations.ts packages/db/src/local/client.test.ts
+rtk git commit -m "feat(db): add local sqlite migrations"
+```
+
+---
+
+### Task 3: Local Client and Workspace Seed
+
+**Files:**
+- Create: `packages/db/src/local/client.ts`
+- Modify: `packages/db/src/local/client.test.ts`
+
+- [ ] **Step 1: Add failing client tests**
+
+Append these imports:
+
+```ts
+import {
+  closeLocalDb,
+  connectLocalDb,
+  getLocalDbFilePath,
+  seedLocalWorkspace,
+} from "./client";
+import { localSessions, localTeams, localUsers } from "./schema";
+```
+
+Append these tests:
+
+```ts
+describe("connectLocalDb", () => {
+  test("opens a migrated SQLite file and exposes a Drizzle client", () => {
+    const cwd = createTempDir();
+    const path = join(cwd, "state", "midday.sqlite");
+
+    const local = connectLocalDb({ path });
+
+    try {
+      const rows = local.db.select().from(localUsers).all();
+      const migrations = local.sqlite
+        .query("SELECT version FROM local_migrations ORDER BY version")
+        .all() as Array<{ version: number }>;
+
+      expect(local.path).toBe(path);
+      expect(rows).toEqual([]);
+      expect(migrations).toEqual([{ version: 1 }]);
+      expect(getLocalDbFilePath({ path })).toBe(path);
+    } finally {
+      local.close();
+      closeLocalDb();
+    }
+  });
+});
+
+describe("seedLocalWorkspace", () => {
+  test("creates and updates a local owner, team, membership, and session", () => {
+    const cwd = createTempDir();
+    const local = connectLocalDb({ path: join(cwd, "midday.sqlite") });
+
+    try {
+      const seeded = seedLocalWorkspace(local, {
+        email: "local@example.com",
+        name: "Local Owner",
+        sessionToken: "session_token",
+        teamId: "team_local",
+        teamName: "Local Team",
+        userId: "user_local",
+      });
+      seedLocalWorkspace(local, {
+        email: "local@example.com",
+        name: "Renamed Owner",
+        sessionToken: "session_token",
+        teamId: "team_local",
+        teamName: "Renamed Team",
+        userId: "user_local",
+      });
+
+      const users = local.db.select().from(localUsers).all();
+      const teams = local.db.select().from(localTeams).all();
+      const sessions = local.db.select().from(localSessions).all();
+
+      expect(seeded).toEqual({
+        sessionToken: "session_token",
+        teamId: "team_local",
+        userId: "user_local",
+      });
+      expect(users).toHaveLength(1);
+      expect(users[0]?.name).toBe("Renamed Owner");
+      expect(teams).toHaveLength(1);
+      expect(teams[0]?.name).toBe("Renamed Team");
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.token).toBe("session_token");
+    } finally {
+      local.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `rtk cmd /c bun test packages/db/src/local/client.test.ts`
+
+Expected: FAIL because `client.ts` does not exist.
+
+- [ ] **Step 3: Implement local client**
+
+Create `packages/db/src/local/client.ts`:
+
+```ts
+import { Database as BunDatabase } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { nanoid } from "nanoid";
+import { migrateLocalDb, type LocalMigrationResult } from "./migrations";
+import { resolveLocalDbPath, type ResolveLocalDbPathOptions } from "./path";
+import * as schema from "./schema";
+
+type LocalDbEnv = ResolveLocalDbPathOptions["env"];
+
+export type ConnectLocalDbOptions = {
+  cwd?: string;
+  env?: LocalDbEnv;
+  path?: string;
+};
+
+export type SeedLocalWorkspaceInput = {
+  baseCurrency?: string;
+  email?: string;
+  expiresAt?: Date | string | null;
+  name?: string | null;
+  now?: Date | string;
+  sessionToken?: string | null;
+  teamId?: string;
+  teamName?: string;
+  userId?: string;
+};
+
+export type SeedLocalWorkspaceResult = {
+  sessionToken: string | null;
+  teamId: string;
+  userId: string;
+};
+
+function createDrizzleClient(sqlite: BunDatabase) {
+  return drizzle(sqlite, { schema });
+}
+
+export type LocalDrizzleDatabase = ReturnType<typeof createDrizzleClient>;
+
+export type LocalDatabase = {
+  db: LocalDrizzleDatabase;
+  migrate: () => LocalMigrationResult;
+  path: string;
+  sqlite: BunDatabase;
+  close: () => void;
+};
+
+let localDb: LocalDatabase | undefined;
+
+function toIsoString(value: Date | string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function configureSqlite(sqlite: BunDatabase) {
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  sqlite.exec("PRAGMA journal_mode = WAL");
+  sqlite.exec("PRAGMA busy_timeout = 5000");
+}
+
+export function getLocalDbFilePath(options: ConnectLocalDbOptions = {}) {
+  if (options.path) {
+    return options.path;
+  }
+
+  return resolveLocalDbPath({ cwd: options.cwd, env: options.env });
+}
+
+export function connectLocalDb(
+  options: ConnectLocalDbOptions = {},
+): LocalDatabase {
+  const path = getLocalDbFilePath(options);
+  const sqlite = new BunDatabase(path, { create: true, readwrite: true });
+
+  configureSqlite(sqlite);
+
+  const local: LocalDatabase = {
+    db: createDrizzleClient(sqlite),
+    migrate: () => migrateLocalDb(sqlite),
+    path,
+    sqlite,
+    close: () => sqlite.close(),
+  };
+
+  local.migrate();
+  return local;
+}
+
+export function getLocalDb(options: ConnectLocalDbOptions = {}) {
+  localDb ??= connectLocalDb(options);
+  return localDb;
+}
+
+export function closeLocalDb() {
+  localDb?.close();
+  localDb = undefined;
+}
+
+export function seedLocalWorkspace(
+  local: LocalDatabase,
+  input: SeedLocalWorkspaceInput = {},
+): SeedLocalWorkspaceResult {
+  const userId = input.userId ?? `local_user_${nanoid(12)}`;
+  const teamId = input.teamId ?? `local_team_${nanoid(12)}`;
+  const sessionToken =
+    input.sessionToken === undefined
+      ? `local_session_${nanoid(32)}`
+      : input.sessionToken;
+  const now = toIsoString(input.now) ?? new Date().toISOString();
+  const expiresAt = toIsoString(input.expiresAt);
+  const email = input.email ?? "local@midday.local";
+  const teamName = input.teamName ?? "Local Workspace";
+
+  const seed = local.sqlite.transaction(() => {
+    local.sqlite
+      .query(
+        `INSERT INTO local_users (id, email, name, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          email = excluded.email,
+          name = excluded.name,
+          updated_at = excluded.updated_at`,
+      )
+      .run(userId, email, input.name ?? null, now, now);
+
+    local.sqlite
+      .query(
+        `INSERT INTO local_teams (id, name, base_currency, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          name = excluded.name,
+          base_currency = excluded.base_currency,
+          updated_at = excluded.updated_at`,
+      )
+      .run(teamId, teamName, input.baseCurrency ?? "USD", now, now);
+
+    local.sqlite
+      .query(
+        `INSERT INTO local_users_on_teams (user_id, team_id, role, created_at)
+        VALUES (?, ?, 'owner', ?)
+        ON CONFLICT(user_id, team_id) DO UPDATE SET role = excluded.role`,
+      )
+      .run(userId, teamId, now);
+
+    if (sessionToken) {
+      local.sqlite
+        .query(
+          `INSERT INTO local_sessions (
+            token,
+            user_id,
+            team_id,
+            expires_at,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(token) DO UPDATE SET
+            user_id = excluded.user_id,
+            team_id = excluded.team_id,
+            expires_at = excluded.expires_at,
+            updated_at = excluded.updated_at`,
+        )
+        .run(sessionToken, userId, teamId, expiresAt, now, now);
+    }
+  });
+
+  seed();
+
+  return { sessionToken, teamId, userId };
+}
+
+export { migrateLocalDb, resolveLocalDbPath, schema };
+export type { LocalMigrationResult, ResolveLocalDbPathOptions };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `rtk cmd /c bun test packages/db/src/local/client.test.ts`
+
+Expected: PASS for all local SQLite tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/db/src/local/client.ts packages/db/src/local/client.test.ts
+rtk git commit -m "feat(db): add local sqlite client"
+```
+
+---
+
+### Task 4: Package Export and Verification Script
+
+**Files:**
+- Modify: `packages/db/package.json`
+
+- [ ] **Step 1: Add package export and script**
+
+Modify `packages/db/package.json`:
+
+```json
+{
+  "scripts": {
+    "test:local": "bun test src/local/client.test.ts"
+  },
+  "exports": {
+    "./local-client": "./src/local/client.ts"
+  }
+}
+```
+
+Keep the existing scripts and exports; only insert the new entries.
+
+- [ ] **Step 2: Verify focused package script**
+
+Run: `rtk cmd /c bun run --filter @midday/db test:local`
+
+Expected: PASS for `packages/db/src/local/client.test.ts`.
+
+- [ ] **Step 3: Verify package typecheck**
+
+Run: `rtk cmd /c bun run --filter @midday/db typecheck`
+
+Expected: PASS, or a documented pre-existing failure outside `packages/db/src/local`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add packages/db/package.json
+rtk git commit -m "chore(db): expose local sqlite client"
+```
+
+---
+
+### Task 5: Phase Review
+
+**Files:**
+- Review: `packages/db/src/local/*`
+- Review: `packages/db/package.json`
+
+- [ ] **Step 1: Run complete focused verification**
+
+Run:
+
+```bash
+rtk cmd /c bun run --filter @midday/db test:local
+rtk cmd /c bun run --filter @midday/db typecheck
+rtk git diff --check
+rtk git status --short
+```
+
+Expected:
+- Local SQLite tests pass.
+- Typecheck passes or only reports pre-existing non-local failures.
+- `git diff --check` reports no whitespace errors.
+- `git status --short` is clean after commits.
+
+- [ ] **Step 2: Self-review against the goal**
+
+Confirm:
+- The existing Postgres client is not changed.
+- The new local client is available through `@midday/db/local-client`.
+- SQLite file location can be controlled by desktop runtime env.
+- Migrations are idempotent.
+- Local workspace seed can create and update local identity/session rows.
+
+- [ ] **Step 3: Record next phase blocker**
+
+The next phase should switch API/dashboard local runtime code away from import-time Supabase and external banking env requirements. This phase only creates the embedded database foundation required for that work.

--- a/docs/superpowers/plans/2026-06-14-local-first-tauri-phase-1.md
+++ b/docs/superpowers/plans/2026-06-14-local-first-tauri-phase-1.md
@@ -1,0 +1,918 @@
+# Local-First Tauri Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing Tauri desktop shell load a local Midday dashboard/API runtime instead of acting as a remote app launcher.
+
+**Architecture:** This phase adds a Rust local-service supervisor to `apps/desktop/src-tauri` and routes all desktop windows through one resolved local dashboard URL. Development mode starts or reuses local `apps/dashboard` and `apps/api` dev servers; the supervisor keeps a small process interface so packaging work can swap dev commands for Tauri `bundle.externalBin` sidecars without rewriting window logic.
+
+**Tech Stack:** Tauri 2, Rust 2024, Bun, Next standalone/dev server, Hono/tRPC API, existing `@midday/desktop` package.
+
+---
+
+## Scope Check
+
+The approved spec covers multiple independent subsystems: desktop service supervision, SQLite, local auth, local storage, job runner, query portability, integrations, and packaging. This plan intentionally implements only the first independently testable subsystem: desktop local service supervision and URL routing. Follow-on plans should cover SQLite, auth/session, storage, jobs, query portability, and packaging as separate work packets.
+
+## File Structure
+
+- Modify `apps/desktop/src-tauri/Cargo.toml`
+  - Add the small dependencies needed for robust localhost polling and error handling.
+- Create `apps/desktop/src-tauri/src/local_services.rs`
+  - Own all local desktop runtime configuration, dev process spawning, health polling, app URL resolution, and child shutdown.
+- Modify `apps/desktop/src-tauri/src/lib.rs`
+  - Replace direct environment URL switching with `local_services`.
+  - Keep existing window, tray, search, updater, and deep-link behavior.
+- Modify `apps/desktop/src-tauri/capabilities/default.json`
+  - Keep the local dashboard origin authorized for desktop windows.
+  - Keep hosted origins authorized only for explicitly named remote diagnostic scripts.
+  - Apply the capability to Windows as well as macOS.
+- Modify `apps/desktop/README.md`
+  - Document the local-first desktop startup modes and required sibling dev services.
+- Modify `apps/desktop/package.json`
+  - Add explicit scripts for local-first desktop development and remote fallback diagnostics.
+
+## Task 1: Local Service Config Resolver
+
+**Files:**
+- Create: `apps/desktop/src-tauri/src/local_services.rs`
+- Modify: `apps/desktop/src-tauri/Cargo.toml`
+
+- [ ] **Step 1: Add Rust dependencies**
+
+Modify `apps/desktop/src-tauri/Cargo.toml`:
+
+```toml
+[dependencies]
+tauri = { version = "2", features = ["macos-private-api", "tray-icon", "webview-data-url"] }
+tauri-plugin-opener = "2"
+tauri-plugin-deep-link = "2"
+tauri-plugin-global-shortcut = "2"
+
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+image = "0.24"
+tokio = { version = "1", features = ["time", "process", "io-util"] }
+tauri-plugin-updater = "2"
+tauri-plugin-dialog = "2.2.2"
+tauri-plugin-process = "2.2.1"
+tauri-plugin-upload = "2"
+tauri-plugin-fs = "2"
+ureq = "2"
+```
+
+- [ ] **Step 2: Write failing config tests**
+
+Create `apps/desktop/src-tauri/src/local_services.rs` with the config types, function signatures, and tests first:
+
+```rust
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DesktopRuntimeMode {
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalServiceConfig {
+    pub mode: DesktopRuntimeMode,
+    pub dashboard_url: String,
+    pub api_url: String,
+    pub manage_processes: bool,
+}
+
+pub fn resolve_config_from_env(env: &HashMap<String, String>) -> LocalServiceConfig {
+    let _ = env;
+    panic!("resolve_config_from_env is not implemented yet");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn defaults_to_local_runtime() {
+        let config = resolve_config_from_env(&env(&[]));
+
+        assert_eq!(config.mode, DesktopRuntimeMode::Local);
+        assert_eq!(config.dashboard_url, "http://localhost:3001");
+        assert_eq!(config.api_url, "http://localhost:3003");
+        assert!(config.manage_processes);
+    }
+
+    #[test]
+    fn allows_external_local_servers_without_process_management() {
+        let config = resolve_config_from_env(&env(&[
+            ("MIDDAY_DESKTOP_MANAGE_SERVICES", "false"),
+            ("MIDDAY_DASHBOARD_URL", "http://localhost:4101"),
+            ("MIDDAY_API_URL", "http://localhost:4103"),
+        ]));
+
+        assert_eq!(config.mode, DesktopRuntimeMode::Local);
+        assert_eq!(config.dashboard_url, "http://localhost:4101");
+        assert_eq!(config.api_url, "http://localhost:4103");
+        assert!(!config.manage_processes);
+    }
+
+    #[test]
+    fn keeps_remote_mode_available_for_diagnostics() {
+        let config = resolve_config_from_env(&env(&[
+            ("MIDDAY_DESKTOP_RUNTIME", "remote"),
+            ("MIDDAY_REMOTE_APP_URL", "https://app.midday.ai"),
+        ]));
+
+        assert_eq!(config.mode, DesktopRuntimeMode::Remote);
+        assert_eq!(config.dashboard_url, "https://app.midday.ai");
+        assert_eq!(config.api_url, "https://api.midday.ai");
+        assert!(!config.manage_processes);
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests and verify they fail**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml local_services --lib
+```
+
+Expected: the test binary runs and fails with `resolve_config_from_env is not implemented yet`.
+
+- [ ] **Step 4: Implement the config resolver**
+
+Replace `resolve_config_from_env` in `apps/desktop/src-tauri/src/local_services.rs`:
+
+```rust
+pub fn resolve_config_from_env(env: &HashMap<String, String>) -> LocalServiceConfig {
+    let runtime = env
+        .get("MIDDAY_DESKTOP_RUNTIME")
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_else(|| "local".to_string());
+
+    if runtime == "remote" {
+        return LocalServiceConfig {
+            mode: DesktopRuntimeMode::Remote,
+            dashboard_url: env
+                .get("MIDDAY_REMOTE_APP_URL")
+                .cloned()
+                .unwrap_or_else(|| "https://app.midday.ai".to_string()),
+            api_url: env
+                .get("MIDDAY_REMOTE_API_URL")
+                .cloned()
+                .unwrap_or_else(|| "https://api.midday.ai".to_string()),
+            manage_processes: false,
+        };
+    }
+
+    let manage_processes = env
+        .get("MIDDAY_DESKTOP_MANAGE_SERVICES")
+        .map(|value| value != "false" && value != "0")
+        .unwrap_or(true);
+
+    LocalServiceConfig {
+        mode: DesktopRuntimeMode::Local,
+        dashboard_url: env
+            .get("MIDDAY_DASHBOARD_URL")
+            .cloned()
+            .unwrap_or_else(|| "http://localhost:3001".to_string()),
+        api_url: env
+            .get("MIDDAY_API_URL")
+            .cloned()
+            .unwrap_or_else(|| "http://localhost:3003".to_string()),
+        manage_processes,
+    }
+}
+```
+
+- [ ] **Step 5: Add a process environment helper**
+
+Append this helper above the tests in `apps/desktop/src-tauri/src/local_services.rs`:
+
+```rust
+pub fn current_env() -> HashMap<String, String> {
+    std::env::vars().collect()
+}
+```
+
+- [ ] **Step 6: Run tests and verify they pass**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml local_services --lib
+```
+
+Expected: all `local_services` tests pass.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```powershell
+rtk git add apps/desktop/src-tauri/Cargo.toml apps/desktop/src-tauri/src/local_services.rs
+rtk git commit -m "feat(desktop): resolve local runtime config"
+```
+
+## Task 2: Local Health Polling
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/local_services.rs`
+
+- [ ] **Step 1: Write failing health URL tests**
+
+Append these tests inside the existing `#[cfg(test)] mod tests` block:
+
+```rust
+#[test]
+fn builds_health_urls_for_local_services() {
+    let config = resolve_config_from_env(&env(&[]));
+
+    assert_eq!(api_health_url(&config), Some("http://localhost:3003/health".to_string()));
+    assert_eq!(dashboard_health_url(&config), Some("http://localhost:3001".to_string()));
+}
+
+#[test]
+fn remote_runtime_has_no_local_health_urls() {
+    let config = resolve_config_from_env(&env(&[
+        ("MIDDAY_DESKTOP_RUNTIME", "remote"),
+        ("MIDDAY_REMOTE_APP_URL", "https://app.midday.ai"),
+    ]));
+
+    assert_eq!(api_health_url(&config), None);
+    assert_eq!(dashboard_health_url(&config), None);
+}
+```
+
+Add these function signatures above the tests:
+
+```rust
+pub fn api_health_url(config: &LocalServiceConfig) -> Option<String> {
+    let _ = config;
+    panic!("api_health_url is not implemented yet");
+}
+
+pub fn dashboard_health_url(config: &LocalServiceConfig) -> Option<String> {
+    let _ = config;
+    panic!("dashboard_health_url is not implemented yet");
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml local_services --lib
+```
+
+Expected: new health URL tests fail with an unimplemented panic.
+
+- [ ] **Step 3: Implement health URL helpers**
+
+Replace the two health URL functions:
+
+```rust
+pub fn api_health_url(config: &LocalServiceConfig) -> Option<String> {
+    match config.mode {
+        DesktopRuntimeMode::Local => Some(format!("{}/health", config.api_url.trim_end_matches('/'))),
+        DesktopRuntimeMode::Remote => None,
+    }
+}
+
+pub fn dashboard_health_url(config: &LocalServiceConfig) -> Option<String> {
+    match config.mode {
+        DesktopRuntimeMode::Local => Some(config.dashboard_url.trim_end_matches('/').to_string()),
+        DesktopRuntimeMode::Remote => None,
+    }
+}
+```
+
+- [ ] **Step 4: Add wait helper used by the Tauri startup path**
+
+Append this code above the tests:
+
+```rust
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+pub enum LocalServiceError {
+    Timeout { service: &'static str, url: String },
+    Request { service: &'static str, url: String, message: String },
+}
+
+impl std::fmt::Display for LocalServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LocalServiceError::Timeout { service, url } => {
+                write!(f, "{service} did not become ready at {url}")
+            }
+            LocalServiceError::Request {
+                service,
+                url,
+                message,
+            } => write!(f, "{service} health request failed at {url}: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for LocalServiceError {}
+
+fn is_ready(url: &str) -> Result<bool, String> {
+    match ureq::get(url).call() {
+        Ok(response) => Ok((200..500).contains(&response.status())),
+        Err(ureq::Error::Status(status, _)) => Ok((200..500).contains(&status)),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub async fn wait_for_url(
+    service: &'static str,
+    url: String,
+    timeout: Duration,
+) -> Result<(), LocalServiceError> {
+    let start = Instant::now();
+    let mut last_error: Option<String> = None;
+
+    while start.elapsed() < timeout {
+        match is_ready(&url) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(message) => last_error = Some(message),
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    if let Some(message) = last_error {
+        return Err(LocalServiceError::Request {
+            service,
+            url,
+            message,
+        });
+    }
+
+    Err(LocalServiceError::Timeout { service, url })
+}
+```
+
+- [ ] **Step 5: Run tests and verify they pass**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml local_services --lib
+```
+
+Expected: all `local_services` tests pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```powershell
+rtk git add apps/desktop/src-tauri/src/local_services.rs
+rtk git commit -m "feat(desktop): add local service health checks"
+```
+
+## Task 3: Development Process Supervisor
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/local_services.rs`
+
+- [ ] **Step 1: Write failing command-construction tests**
+
+Append these tests inside the existing test module:
+
+```rust
+#[test]
+fn builds_dashboard_dev_command() {
+    let command = dashboard_dev_command(&resolve_config_from_env(&env(&[])));
+
+    assert_eq!(command.program, "bun");
+    assert_eq!(command.args, vec!["run", "dev:dashboard"]);
+    assert!(command.env.iter().any(|(key, value)| {
+        key == "NEXT_PUBLIC_API_URL" && value == "http://localhost:3003"
+    }));
+    assert!(command.env.iter().any(|(key, value)| {
+        key == "API_INTERNAL_URL" && value == "http://localhost:3003"
+    }));
+}
+
+#[test]
+fn builds_api_dev_command() {
+    let command = api_dev_command(&resolve_config_from_env(&env(&[])));
+
+    assert_eq!(command.program, "bun");
+    assert_eq!(command.args, vec!["run", "dev:api"]);
+    assert!(command.env.iter().any(|(key, value)| key == "PORT" && value == "3003"));
+    assert!(command.env.iter().any(|(key, value)| {
+        key == "ALLOWED_API_ORIGINS" && value == "http://localhost:3001"
+    }));
+}
+```
+
+Add these structs and signatures above the tests:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceCommand {
+    pub program: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+}
+
+pub fn dashboard_dev_command(config: &LocalServiceConfig) -> ServiceCommand {
+    let _ = config;
+    panic!("dashboard_dev_command is not implemented yet");
+}
+
+pub fn api_dev_command(config: &LocalServiceConfig) -> ServiceCommand {
+    let _ = config;
+    panic!("api_dev_command is not implemented yet");
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml local_services --lib
+```
+
+Expected: command-construction tests fail with unimplemented panics.
+
+- [ ] **Step 3: Implement command construction**
+
+Replace `dashboard_dev_command` and `api_dev_command`:
+
+```rust
+fn port_from_url(url: &str, fallback: &str) -> String {
+    url.rsplit(':')
+        .next()
+        .and_then(|part| part.split('/').next())
+        .filter(|part| part.chars().all(|ch| ch.is_ascii_digit()))
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+pub fn dashboard_dev_command(config: &LocalServiceConfig) -> ServiceCommand {
+    ServiceCommand {
+        program: "bun".to_string(),
+        args: vec!["run".to_string(), "dev:dashboard".to_string()],
+        env: vec![
+            ("NEXT_PUBLIC_API_URL".to_string(), config.api_url.clone()),
+            ("API_INTERNAL_URL".to_string(), config.api_url.clone()),
+        ],
+    }
+}
+
+pub fn api_dev_command(config: &LocalServiceConfig) -> ServiceCommand {
+    ServiceCommand {
+        program: "bun".to_string(),
+        args: vec!["run".to_string(), "dev:api".to_string()],
+        env: vec![
+            ("PORT".to_string(), port_from_url(&config.api_url, "3003")),
+            (
+                "ALLOWED_API_ORIGINS".to_string(),
+                config.dashboard_url.clone(),
+            ),
+        ],
+    }
+}
+```
+
+- [ ] **Step 4: Add child process supervision**
+
+Append this code above the tests:
+
+```rust
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+
+pub struct LocalServiceManager {
+    config: LocalServiceConfig,
+    children: Vec<Child>,
+}
+
+impl LocalServiceManager {
+    pub fn new(config: LocalServiceConfig) -> Self {
+        Self {
+            config,
+            children: Vec::new(),
+        }
+    }
+
+    pub fn dashboard_url(&self) -> &str {
+        &self.config.dashboard_url
+    }
+
+    pub fn config(&self) -> &LocalServiceConfig {
+        &self.config
+    }
+
+    pub fn start_dev_services(&mut self, repo_root: PathBuf) -> Result<(), String> {
+        if self.config.mode == DesktopRuntimeMode::Remote || !self.config.manage_processes {
+            return Ok(());
+        }
+
+        let api = spawn_service(repo_root.clone(), api_dev_command(&self.config))?;
+        let dashboard = spawn_service(repo_root, dashboard_dev_command(&self.config))?;
+        self.children.push(api);
+        self.children.push(dashboard);
+
+        Ok(())
+    }
+
+    pub async fn wait_until_ready(&self) -> Result<(), String> {
+        if let Some(url) = api_health_url(&self.config) {
+            wait_for_url("api", url, Duration::from_secs(45))
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+
+        if let Some(url) = dashboard_health_url(&self.config) {
+            wait_for_url("dashboard", url, Duration::from_secs(90))
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+
+        Ok(())
+    }
+
+    pub fn shutdown(&mut self) {
+        for child in &mut self.children {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        self.children.clear();
+    }
+}
+
+impl Drop for LocalServiceManager {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn spawn_service(repo_root: PathBuf, command: ServiceCommand) -> Result<Child, String> {
+    let mut process = Command::new(&command.program);
+    process
+        .args(&command.args)
+        .current_dir(repo_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    for (key, value) in command.env {
+        process.env(key, value);
+    }
+
+    process
+        .spawn()
+        .map_err(|error| format!("failed to spawn {}: {}", command.program, error))
+}
+```
+
+- [ ] **Step 5: Run tests and verify they pass**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml local_services --lib
+```
+
+Expected: all `local_services` tests pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```powershell
+rtk git add apps/desktop/src-tauri/src/local_services.rs
+rtk git commit -m "feat(desktop): supervise local dev services"
+```
+
+## Task 4: Tauri Window Integration
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/lib.rs`
+- Modify: `apps/desktop/src-tauri/src/local_services.rs`
+
+- [ ] **Step 1: Add a repo-root helper**
+
+Append this helper above the tests in `apps/desktop/src-tauri/src/local_services.rs`:
+
+```rust
+pub fn repo_root_from_manifest() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+```
+
+- [ ] **Step 2: Register the module in lib.rs**
+
+At the top of `apps/desktop/src-tauri/src/lib.rs`, add:
+
+```rust
+mod local_services;
+```
+
+- [ ] **Step 3: Replace the old environment URL function**
+
+In `apps/desktop/src-tauri/src/lib.rs`, remove the body of `get_app_url` and replace it with:
+
+```rust
+fn get_app_url() -> String {
+    let config = local_services::resolve_config_from_env(&local_services::current_env());
+    println!("🌍 Desktop runtime: {:?}", config.mode);
+    println!("🌍 Dashboard URL: {}", config.dashboard_url);
+    config.dashboard_url
+}
+```
+
+This preserves existing callers while the rest of the integration is added.
+
+- [ ] **Step 4: Add service startup in Tauri setup**
+
+In `apps/desktop/src-tauri/src/lib.rs`, inside `.setup(move |app| {` and before creating `search_state`, add:
+
+```rust
+            let local_config =
+                local_services::resolve_config_from_env(&local_services::current_env());
+            let mut local_manager = local_services::LocalServiceManager::new(local_config.clone());
+
+            if local_config.manage_processes {
+                local_manager
+                    .start_dev_services(local_services::repo_root_from_manifest())
+                    .map_err(|error| format!("Failed to start local services: {error}"))?;
+            }
+
+            if matches!(local_config.mode, local_services::DesktopRuntimeMode::Local) {
+                tauri::async_runtime::block_on(local_manager.wait_until_ready())
+                    .map_err(|error| format!("Local services were not ready: {error}"))?;
+            }
+
+            app.manage(Mutex::new(local_manager));
+```
+
+- [ ] **Step 5: Import the extra type used by managed state**
+
+Confirm the existing import already includes `Mutex`:
+
+```rust
+use std::sync::{Arc, Mutex};
+```
+
+No change is needed if that import is already present.
+
+- [ ] **Step 6: Run Rust tests**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib
+```
+
+Expected: Rust library tests pass.
+
+- [ ] **Step 7: Run desktop type/build check**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --no-run
+```
+
+Expected: Cargo compiles all test targets without Rust type errors.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```powershell
+rtk git add apps/desktop/src-tauri/src/lib.rs apps/desktop/src-tauri/src/local_services.rs
+rtk git commit -m "feat(desktop): load local dashboard runtime"
+```
+
+## Task 5: Local-First Capabilities And Scripts
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/capabilities/default.json`
+- Modify: `apps/desktop/package.json`
+- Modify: `apps/desktop/README.md`
+
+- [ ] **Step 1: Make local dashboard the first authorized origin**
+
+In `apps/desktop/src-tauri/capabilities/default.json`, replace the `remote.urls` array with:
+
+```json
+  "remote": {
+    "urls": [
+      "http://localhost:3001/**",
+      "https://beta.midday.ai/**",
+      "https://app.midday.ai/**"
+    ]
+  },
+```
+
+- [ ] **Step 2: Apply default capability on Windows**
+
+In `apps/desktop/src-tauri/capabilities/default.json`, replace the `platforms` array with:
+
+```json
+  "platforms": ["macOS", "windows", "linux"]
+```
+
+- [ ] **Step 3: Add explicit package scripts**
+
+In `apps/desktop/package.json`, replace the `scripts` block with:
+
+```json
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "tauri": "tauri",
+    "tauri:dev": "MIDDAY_DESKTOP_RUNTIME=local MIDDAY_DESKTOP_MANAGE_SERVICES=false MIDDAY_DASHBOARD_URL=http://localhost:3001 MIDDAY_API_URL=http://localhost:3003 tauri dev --config src-tauri/tauri.dev.conf.json",
+    "tauri:dev:managed": "MIDDAY_DESKTOP_RUNTIME=local MIDDAY_DESKTOP_MANAGE_SERVICES=true MIDDAY_DASHBOARD_URL=http://localhost:3001 MIDDAY_API_URL=http://localhost:3003 tauri dev --config src-tauri/tauri.dev.conf.json",
+    "tauri:remote:staging": "MIDDAY_DESKTOP_RUNTIME=remote MIDDAY_REMOTE_APP_URL=https://beta.midday.ai MIDDAY_REMOTE_API_URL=https://api.midday.ai tauri dev --config src-tauri/tauri.staging.conf.json",
+    "tauri:remote:prod": "MIDDAY_DESKTOP_RUNTIME=remote MIDDAY_REMOTE_APP_URL=https://app.midday.ai MIDDAY_REMOTE_API_URL=https://api.midday.ai tauri dev",
+    "tauri:build:dev": "tauri build --config src-tauri/tauri.dev.conf.json",
+    "tauri:build:staging": "tauri build --config src-tauri/tauri.staging.conf.json",
+    "tauri:build:prod": "tauri build"
+  },
+```
+
+- [ ] **Step 4: Update README startup instructions**
+
+Replace the "Environment Configuration" and "Running the App" sections in `apps/desktop/README.md` with:
+
+```markdown
+## Runtime Configuration
+
+The desktop app is local-first by default. It opens the local dashboard at
+`http://localhost:3001`, and the dashboard talks to the local API at
+`http://localhost:3003`.
+
+### Development With Existing Dev Servers
+
+Run the dashboard and API in separate terminals from the repository root:
+
+```bash
+bun run dev:api
+bun run dev:dashboard
+```
+
+Then run the desktop shell:
+
+```bash
+bun run --filter @midday/desktop tauri:dev
+```
+
+### Development With Desktop-Managed Services
+
+The desktop shell can also start the dashboard and API dev servers:
+
+```bash
+bun run --filter @midday/desktop tauri:dev:managed
+```
+
+This mode is the Phase 1 bridge toward packaged sidecars. The packaged build
+will replace dev commands with bundled sidecar binaries.
+
+### Remote Diagnostics
+
+Remote mode is kept only for diagnosing hosted app behavior:
+
+```bash
+bun run --filter @midday/desktop tauri:remote:staging
+bun run --filter @midday/desktop tauri:remote:prod
+```
+```
+
+- [ ] **Step 5: Run JSON/package validation**
+
+Run:
+
+```powershell
+rtk cmd /c bun run --filter @midday/desktop build
+```
+
+Expected: TypeScript and Vite build for `@midday/desktop` pass.
+
+- [ ] **Step 6: Run Rust compilation**
+
+Run:
+
+```powershell
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --no-run
+```
+
+Expected: Cargo compiles desktop Rust targets.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```powershell
+rtk git add apps/desktop/src-tauri/capabilities/default.json apps/desktop/package.json apps/desktop/README.md
+rtk git commit -m "docs(desktop): document local-first startup"
+```
+
+## Task 6: Manual Smoke Verification
+
+**Files:**
+- No source changes expected.
+
+- [ ] **Step 1: Start API and dashboard externally**
+
+Run from repository root in terminal 1:
+
+```powershell
+rtk cmd /c bun run dev:api
+```
+
+Expected: API starts on `http://localhost:3003`.
+
+Run from repository root in terminal 2:
+
+```powershell
+rtk cmd /c bun run dev:dashboard
+```
+
+Expected: Dashboard starts on `http://localhost:3001`.
+
+- [ ] **Step 2: Start desktop in external-server mode**
+
+Run from repository root in terminal 3:
+
+```powershell
+rtk cmd /c bun run --filter @midday/desktop tauri:dev
+```
+
+Expected: Tauri opens a Midday window loading `http://localhost:3001`, not `https://app.midday.ai`.
+
+- [ ] **Step 3: Verify search window still uses local dashboard**
+
+Press the existing global shortcut:
+
+```text
+Shift+Alt+K
+```
+
+Expected: the search window opens against `http://localhost:3001/desktop/search`.
+
+- [ ] **Step 4: Stop all services**
+
+Close the Tauri app window and stop the dev server terminals with:
+
+```text
+Ctrl+C
+```
+
+Expected: no orphaned `bun` process remains for the dashboard or API after the terminals are stopped.
+
+- [ ] **Step 5: Check final worktree**
+
+Run:
+
+```powershell
+rtk git status --short
+```
+
+Expected: no uncommitted changes.
+
+## Phase 1 Completion Criteria
+
+- `apps/desktop` resolves local dashboard/API URLs through `local_services`.
+- Tauri no longer uses `MIDDAY_ENV` to choose `https://app.midday.ai` as the normal production path.
+- Local dashboard origin remains authorized in Tauri capabilities on Windows, macOS, and Linux.
+- Remote hosted modes are renamed as diagnostics.
+- Rust tests for config and command construction pass.
+- Desktop build and Rust compile checks pass.
+- Manual smoke confirms the desktop app loads localhost.
+
+## Follow-On Plans
+
+After this plan is implemented and verified, create separate implementation plans for:
+
+1. SQLite schema/client foundation.
+2. Local auth/session replacement for Supabase Auth.
+3. Local file storage replacement for Supabase Storage.
+4. SQLite-backed job runner replacement for Redis/BullMQ/Trigger paths.
+5. Query portability and feature parity passes.
+6. Packaged Tauri sidecars using `bundle.externalBin` and target-triple binaries.

--- a/docs/superpowers/plans/2026-06-14-local-runtime-bootstrap.md
+++ b/docs/superpowers/plans/2026-06-14-local-runtime-bootstrap.md
@@ -1,0 +1,427 @@
+# Local Runtime Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let desktop-managed API and dashboard services start in explicit local-first mode without requiring Supabase or external banking/storage provider secrets at import time.
+
+**Architecture:** Add a shared local-runtime predicate and stable local identity constants, have Tauri set those env vars for managed services, and gate Supabase/banking auth bootstrap behind local-mode shims. This does not port the full Postgres query layer yet; it removes the next startup blockers and establishes the local session identity used by the SQLite foundation.
+
+**Tech Stack:** Tauri Rust service manager, Next.js dashboard server/client modules, `@t3-oss/env-core` `skipValidation`, Bun tests.
+
+---
+
+## File Structure
+
+- Modify `packages/utils/src/envs.ts`
+  - Add `isLocalDesktopRuntime(env)` plus `LOCAL_DESKTOP_USER_ID`, `LOCAL_DESKTOP_TEAM_ID`, and `LOCAL_DESKTOP_SESSION_TOKEN`.
+- Create `packages/utils/src/envs.test.ts`
+  - Verify local runtime detection for server and `NEXT_PUBLIC_` env flags.
+- Modify `packages/db/src/local/client.ts`
+  - Reuse the shared local identity constants for SQLite seeding.
+- Modify `apps/desktop/src-tauri/src/local_services.rs`
+  - Add local runtime env vars to dashboard/API service commands.
+- Modify `packages/banking/src/env.ts` and `packages/banking/package.json`
+  - Skip provider env validation only in local desktop mode.
+- Create `packages/supabase/src/client/local.ts`
+  - Provide a small local Supabase-compatible auth stub.
+- Modify `packages/supabase/src/client/server.ts`, `packages/supabase/src/client/client.ts`, `packages/supabase/src/client/middleware.ts`, and `packages/supabase/package.json`
+  - Return local stub clients in desktop-local mode before reading Supabase env vars/cookies.
+- Modify `apps/api/src/services/supabase.ts`
+  - Return the local stub in desktop-local mode.
+- Modify `apps/api/src/utils/auth.ts`
+  - Return a local session for the stable local token and make remote JWKS lazy so missing Supabase URL does not crash imports.
+
+---
+
+### Task 1: Shared Local Runtime Helper
+
+**Files:**
+- Modify: `packages/utils/src/envs.ts`
+- Create: `packages/utils/src/envs.test.ts`
+- Modify: `packages/db/src/local/client.ts`
+
+- [ ] **Step 1: Add failing helper tests**
+
+Create `packages/utils/src/envs.test.ts` with:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  isLocalDesktopRuntime,
+  LOCAL_DESKTOP_SESSION_TOKEN,
+  LOCAL_DESKTOP_TEAM_ID,
+  LOCAL_DESKTOP_USER_ID,
+} from "./envs";
+
+describe("isLocalDesktopRuntime", () => {
+  test("detects server-side local desktop runtime", () => {
+    expect(isLocalDesktopRuntime({ MIDDAY_DESKTOP_RUNTIME: "local" })).toBe(
+      true,
+    );
+    expect(isLocalDesktopRuntime({ MIDDAY_LOCAL_FIRST: "true" })).toBe(true);
+  });
+
+  test("detects client-exposed local desktop runtime", () => {
+    expect(
+      isLocalDesktopRuntime({ NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME: "local" }),
+    ).toBe(true);
+    expect(isLocalDesktopRuntime({ NEXT_PUBLIC_MIDDAY_LOCAL_FIRST: "1" })).toBe(
+      true,
+    );
+  });
+
+  test("does not treat remote desktop runtime as local", () => {
+    expect(isLocalDesktopRuntime({ MIDDAY_DESKTOP_RUNTIME: "remote" })).toBe(
+      false,
+    );
+    expect(isLocalDesktopRuntime({})).toBe(false);
+  });
+
+  test("exports stable local identity constants", () => {
+    expect(LOCAL_DESKTOP_USER_ID).toBe("local_user");
+    expect(LOCAL_DESKTOP_TEAM_ID).toBe("local_team");
+    expect(LOCAL_DESKTOP_SESSION_TOKEN).toBe("local_session");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cmd /c bun test packages/utils/src/envs.test.ts`
+
+Expected: FAIL because the helper and constants do not exist.
+
+- [ ] **Step 3: Implement helper and constants**
+
+Append to `packages/utils/src/envs.ts`:
+
+```ts
+type LocalRuntimeEnv = Partial<
+  Pick<
+    NodeJS.ProcessEnv,
+    | "MIDDAY_DESKTOP_RUNTIME"
+    | "MIDDAY_LOCAL_FIRST"
+    | "NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME"
+    | "NEXT_PUBLIC_MIDDAY_LOCAL_FIRST"
+  >
+>;
+
+export const LOCAL_DESKTOP_USER_ID = "local_user";
+export const LOCAL_DESKTOP_TEAM_ID = "local_team";
+export const LOCAL_DESKTOP_SESSION_TOKEN = "local_session";
+
+function isEnabled(value: string | undefined) {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+export function isLocalDesktopRuntime(env: LocalRuntimeEnv = process.env) {
+  const runtime =
+    env.MIDDAY_DESKTOP_RUNTIME ?? env.NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME;
+
+  return (
+    runtime?.toLowerCase() === "local" ||
+    isEnabled(env.MIDDAY_LOCAL_FIRST) ||
+    isEnabled(env.NEXT_PUBLIC_MIDDAY_LOCAL_FIRST)
+  );
+}
+```
+
+- [ ] **Step 4: Reuse constants in SQLite seed**
+
+In `packages/db/src/local/client.ts`, replace local default constants with imports:
+
+```ts
+import {
+  LOCAL_DESKTOP_SESSION_TOKEN,
+  LOCAL_DESKTOP_TEAM_ID,
+  LOCAL_DESKTOP_USER_ID,
+} from "@midday/utils/envs";
+```
+
+- [ ] **Step 5: Verify**
+
+Run:
+
+```bash
+rtk cmd /c bun test packages/utils/src/envs.test.ts
+rtk cmd /c bun run --filter @midday/db test:local
+rtk cmd /c bun run --filter @midday/db typecheck
+```
+
+Expected: PASS.
+
+---
+
+### Task 2: Tauri Local Runtime Env Injection
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/local_services.rs`
+
+- [ ] **Step 1: Add failing Rust assertions**
+
+Extend `builds_dashboard_dev_command` and `builds_api_dev_command` to assert:
+
+```rust
+assert!(command
+    .env
+    .iter()
+    .any(|(key, value)| key == "MIDDAY_DESKTOP_RUNTIME" && value == "local"));
+assert!(command
+    .env
+    .iter()
+    .any(|(key, value)| key == "MIDDAY_LOCAL_FIRST" && value == "true"));
+```
+
+For dashboard only, also assert:
+
+```rust
+assert!(command.env.iter().any(|(key, value)| {
+    key == "NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME" && value == "local"
+}));
+assert!(command.env.iter().any(|(key, value)| {
+    key == "NEXT_PUBLIC_MIDDAY_LOCAL_FIRST" && value == "true"
+}));
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib`
+
+Expected: FAIL because the env vars are not present.
+
+- [ ] **Step 3: Add command env vars**
+
+Add a helper in `local_services.rs`:
+
+```rust
+fn local_runtime_env() -> Vec<(String, String)> {
+    vec![
+        ("MIDDAY_DESKTOP_RUNTIME".to_string(), "local".to_string()),
+        ("MIDDAY_LOCAL_FIRST".to_string(), "true".to_string()),
+    ]
+}
+```
+
+Extend API command env with `local_runtime_env()`.
+
+Extend dashboard command env with `local_runtime_env()` and:
+
+```rust
+("NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME".to_string(), "local".to_string()),
+("NEXT_PUBLIC_MIDDAY_LOCAL_FIRST".to_string(), "true".to_string()),
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib`
+
+Expected: PASS.
+
+---
+
+### Task 3: Local Banking Env Gate
+
+**Files:**
+- Modify: `packages/banking/src/env.ts`
+- Modify: `packages/banking/package.json`
+
+- [ ] **Step 1: Add dependency and local skip**
+
+Add `@midday/utils` to `packages/banking/package.json` dependencies.
+
+Modify `packages/banking/src/env.ts`:
+
+```ts
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
+```
+
+Add to `createEnv` options:
+
+```ts
+skipValidation: isLocalDesktopRuntime(),
+```
+
+- [ ] **Step 2: Verify local import without provider secrets**
+
+Run:
+
+```bash
+rtk cmd /c "set MIDDAY_DESKTOP_RUNTIME=local&& bun -e \"await import('./packages/banking/src/env.ts'); console.log('banking local env ok')\""
+```
+
+Expected: prints `banking local env ok`.
+
+---
+
+### Task 4: Local Supabase Auth Stub
+
+**Files:**
+- Create: `packages/supabase/src/client/local.ts`
+- Modify: `packages/supabase/src/client/server.ts`
+- Modify: `packages/supabase/src/client/client.ts`
+- Modify: `packages/supabase/src/client/middleware.ts`
+- Modify: `packages/supabase/package.json`
+
+- [ ] **Step 1: Implement local stub**
+
+Create `packages/supabase/src/client/local.ts`:
+
+```ts
+import {
+  isLocalDesktopRuntime,
+  LOCAL_DESKTOP_SESSION_TOKEN,
+  LOCAL_DESKTOP_TEAM_ID,
+  LOCAL_DESKTOP_USER_ID,
+} from "@midday/utils/envs";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const localUser = {
+  id: LOCAL_DESKTOP_USER_ID,
+  email: "local@midday.local",
+  user_metadata: {
+    full_name: "Local User",
+    team_id: LOCAL_DESKTOP_TEAM_ID,
+  },
+  app_metadata: {},
+  aud: "authenticated",
+  created_at: "2020-01-01T00:00:00.000Z",
+};
+
+const localSession = {
+  access_token: LOCAL_DESKTOP_SESSION_TOKEN,
+  refresh_token: LOCAL_DESKTOP_SESSION_TOKEN,
+  token_type: "bearer",
+  expires_in: 31_536_000,
+  expires_at: Math.floor(Date.now() / 1000) + 31_536_000,
+  user: localUser,
+};
+
+function createLocalChannel() {
+  return {
+    on() {
+      return this;
+    },
+    subscribe(callback?: (status: string) => void) {
+      callback?.("SUBSCRIBED");
+      return this;
+    },
+    unsubscribe: async () => "ok",
+  };
+}
+
+export function createLocalSupabaseClient() {
+  return {
+    auth: {
+      getClaims: async () => ({
+        data: { claims: { sub: LOCAL_DESKTOP_USER_ID } },
+        error: null,
+      }),
+      getSession: async () => ({ data: { session: localSession }, error: null }),
+      getUser: async () => ({ data: { user: localUser }, error: null }),
+      signOut: async () => ({ error: null }),
+      verifyOtp: async () => ({ data: { session: localSession, user: localUser }, error: null }),
+      exchangeCodeForSession: async () => ({
+        data: { session: localSession, user: localUser },
+        error: null,
+      }),
+      mfa: {
+        challenge: async () => ({ data: { id: "local_mfa_challenge" }, error: null }),
+        enroll: async () => ({ data: { id: "local_mfa_factor" }, error: null }),
+        getAuthenticatorAssuranceLevel: async () => ({
+          data: { currentLevel: "aal1", nextLevel: "aal1" },
+          error: null,
+        }),
+        listFactors: async () => ({ data: { all: [], totp: [] }, error: null }),
+        unenroll: async () => ({ data: {}, error: null }),
+        verify: async () => ({ data: {}, error: null }),
+      },
+    },
+    channel: () => createLocalChannel(),
+    removeChannel: async () => ({ error: null }),
+  } as unknown as SupabaseClient;
+}
+
+export { isLocalDesktopRuntime };
+```
+
+- [ ] **Step 2: Wire server/client/middleware**
+
+In server and browser Supabase client modules, return `createLocalSupabaseClient()` first when `isLocalDesktopRuntime()` is true.
+
+In middleware, return:
+
+```ts
+return {
+  response,
+  isAuthenticated: true,
+  supabase: createLocalSupabaseClient(),
+};
+```
+
+- [ ] **Step 3: Add package dependency and export**
+
+Add `@midday/utils` dependency and `./local-client`: `./src/client/local.ts` export to `packages/supabase/package.json`.
+
+- [ ] **Step 4: Verify local import**
+
+Run:
+
+```bash
+rtk cmd /c "set MIDDAY_DESKTOP_RUNTIME=local&& bun -e \"const { createClient } = await import('./packages/supabase/src/client/server.ts'); const supabase = await createClient(); const { data } = await supabase.auth.getSession(); console.log(data.session.access_token)\""
+```
+
+Expected: prints `local_session`.
+
+---
+
+### Task 5: Local API Auth and Supabase Service Stub
+
+**Files:**
+- Modify: `apps/api/src/services/supabase.ts`
+- Modify: `apps/api/src/utils/auth.ts`
+
+- [ ] **Step 1: Make API Supabase service local-aware**
+
+In `apps/api/src/services/supabase.ts`, import the local stub and return it when `isLocalDesktopRuntime()` is true.
+
+- [ ] **Step 2: Make token verification local-aware and JWKS lazy**
+
+In `apps/api/src/utils/auth.ts`:
+- Import `isLocalDesktopRuntime` and the local identity constants.
+- Remove top-level `JWKS = createRemoteJWKSet(new URL(...))`.
+- Add a lazy `getRemoteJwks()` function that returns `null` when `SUPABASE_URL` is missing.
+- At the top of `verifyAccessToken`, return the local session when local runtime is enabled and the token equals `LOCAL_DESKTOP_SESSION_TOKEN`.
+
+- [ ] **Step 3: Verify local API auth without Supabase URL**
+
+Run:
+
+```bash
+rtk cmd /c "set MIDDAY_DESKTOP_RUNTIME=local&& set SUPABASE_URL=&& bun -e \"const { verifyAccessToken } = await import('./apps/api/src/utils/auth.ts'); console.log(JSON.stringify(await verifyAccessToken('local_session')))\""
+```
+
+Expected JSON includes `"id":"local_user"` and `"teamId":"local_team"`.
+
+---
+
+### Task 6: Final Verification
+
+Run:
+
+```bash
+rtk cmd /c bun test packages/utils/src/envs.test.ts
+rtk cmd /c bun run --filter @midday/db test:local
+rtk cmd /c bun run --filter @midday/db typecheck
+rtk cmd /c bun run --filter @midday/banking typecheck
+rtk cmd /c bun run --filter @midday/supabase typecheck
+rtk cmd /c bun run --filter @midday/api typecheck
+rtk cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib
+rtk git diff --check
+rtk git status --short
+```
+
+Expected:
+- All focused tests pass.
+- Typecheck passes for touched packages, or any pre-existing non-touched failures are documented with file paths.
+- Rust desktop tests pass.
+- Worktree is clean after commits.

--- a/docs/superpowers/specs/2026-06-14-local-first-tauri-design.md
+++ b/docs/superpowers/specs/2026-06-14-local-first-tauri-design.md
@@ -1,0 +1,213 @@
+# Local-First Midday Desktop Design
+
+Date: 2026-06-14
+
+## Decision
+
+Build the local-first desktop app on the existing Tauri app instead of starting over with Electron. The original goal named Electron, but the user approved Tauri if it works and is more efficient/easy. In this repository, Tauri is already the efficient path because `apps/desktop` already handles the desktop shell: main window, search window, tray, global shortcut, deep links, updater, save dialogs, downloads, and external-link routing.
+
+Electron remains a fallback only if a spike proves Tauri cannot package or supervise the required local services. The implementation should not rewrite the UI into a new Electron renderer while the Tauri path is viable.
+
+## Current Repo Evidence
+
+- `apps/desktop` is a Tauri 2 app that currently loads `http://localhost:3001`, `https://beta.midday.ai`, or `https://app.midday.ai`.
+- `apps/dashboard` is a Next 16 app with `output: "standalone"`, server components, server actions, cookies, redirects, and tRPC clients. It should be hosted by a local dashboard server, not converted to a static-only web app.
+- `apps/api` is a Hono/tRPC API that already contains most product behavior behind stable HTTP/tRPC contracts.
+- `packages/db` uses Drizzle over PostgreSQL via `pg`, with Postgres-specific schema and query features such as `pgEnum`, `pgPolicy`, `jsonb`, `vector`, `tsvector`, `pg_trgm`, replica handling, and raw SQL fragments.
+- `packages/supabase` is used for auth/session, storage, cached session queries, upload helpers, and middleware.
+- `apps/worker`, `packages/job-client`, and some older `packages/jobs` flows depend on Redis/BullMQ or Trigger.dev for background processing and schedulers.
+
+## Product Requirements
+
+The desktop app must preserve Midday's existing UI and workflows while changing the runtime model:
+
+- App shell runs locally as a desktop app.
+- Core user data is stored in an embedded local SQLite database.
+- Supabase is removed from the desktop runtime path.
+- Vault, inbox, transaction, invoice, report, customer, team, tag, category, tracker, notification, API key, OAuth app, and settings data live locally.
+- Files are stored in a local application data directory, not Supabase Storage.
+- The AI assistant can remain online.
+- External integrations may call provider APIs online, but Midday remains local-first: the source of truth is the local database and local file store.
+- Public sharing features remain in scope through explicit publish/export flows that copy only the artifact needed for the public link.
+- UI routes and visual behavior should remain the same unless a cloud-only feature has to become an explicit local-first equivalent.
+
+## Architecture
+
+The desktop product should run as three coordinated local pieces:
+
+1. `apps/desktop`: Tauri host and supervisor.
+2. `apps/dashboard`: local Next standalone dashboard server.
+3. `apps/api`: local Bun/Hono/tRPC API sidecar.
+
+Tauri launches and supervises the local dashboard and API sidecars, waits for health checks, then opens the main webview against the local dashboard URL. The dashboard talks to the local API through `NEXT_PUBLIC_API_URL` and `API_INTERNAL_URL`, matching the current architecture.
+
+For development, Tauri can continue using local dev servers. For production, the build should package:
+
+- a Tauri binary,
+- the Next standalone dashboard output,
+- a compiled Bun API executable or bundled Bun runtime entrypoint,
+- SQLite migrations and seed data,
+- desktop assets and local storage directories.
+
+The dashboard and API should bind to loopback only. Ports should be allocated by Tauri at startup and passed to sidecars through environment variables to avoid collisions.
+
+## Local Data Layer
+
+Add a SQLite path beside the current Postgres path before removing Postgres:
+
+- Create a SQLite schema module using `drizzle-orm/sqlite-core`.
+- Add a local client module using either `bun:sqlite` plus `drizzle-orm/bun-sqlite` for the Bun sidecar, or `better-sqlite3` if packaging requires a Node-compatible fallback.
+- Store the database under the OS app data directory, for example `Midday/data/midday.sqlite`.
+- Run migrations on local API startup before serving requests.
+- Enable SQLite pragmas for local app behavior: foreign keys, WAL, busy timeout, and sensible synchronous mode.
+
+Postgres-specific features need direct replacements:
+
+- `pgEnum`: text columns with TypeScript/zod validation and check constraints where useful.
+- `jsonb`: SQLite text JSON with helper functions and query wrappers.
+- `uuid`: string IDs generated in application code.
+- `numeric`: integer minor units for money where feasible, or text decimal helpers where precision is required.
+- `pgPolicy`: remove from DB schema and enforce authorization in API procedures because the local database has one trusted local user/session boundary.
+- `vector` and embedding tables: keep data as JSON blobs initially, then add a local vector extension only if needed.
+- `pg_trgm`, `similarity`, `word_similarity`: replace with local fuzzy matching helpers and SQLite FTS5 where search quality matters.
+- Replicas and `executeOnReplica`: no-op on desktop and always use the local primary database.
+
+The first implementation should preserve existing query function names where possible, so API routers and UI code do not need broad rewrites.
+
+## Local Auth And Session
+
+Replace Supabase Auth with a desktop-local identity provider:
+
+- On first launch, create a local user and default team.
+- Keep the current team/user/session shapes used by tRPC context.
+- Issue a local signed session token or secure random bearer token scoped to loopback requests.
+- Store session state in the local database plus secure OS storage when needed.
+- Keep login/onboarding UI visually close to the current flow, but adapt copy and behavior for local account setup.
+- MFA and OTP UI should be hidden or replaced by local device lock/security settings, because Supabase MFA/OTP does not apply locally.
+
+The API should still use `protectedProcedure`, `session`, `teamId`, and `userId` internally so feature routers stay familiar.
+
+## Local File Storage
+
+Replace Supabase Storage with a local file service:
+
+- Store files under the OS app data directory, for example `Midday/files/vault/...`.
+- Keep existing logical path arrays in database rows.
+- Provide local API endpoints for upload, download, proxy, thumbnail, and delete.
+- Replace signed URLs with short-lived loopback URLs or authenticated file routes.
+- Keep the existing upload components, but route uploads through local API endpoints instead of Supabase resumable upload endpoints.
+- Preserve native save/open behavior through the existing Tauri file helpers.
+
+## Jobs And Schedulers
+
+Replace Redis/BullMQ/Trigger.dev in the desktop runtime with a local durable job runner:
+
+- Add a SQLite `jobs` table with queue name, job name, payload JSON, status, attempts, scheduled time, result, error, and timestamps.
+- Implement a local job client with the same surface as `triggerJob`, `triggerJobAndWait`, `getJobStatus`, and job cancellation where used.
+- Run an in-process worker inside the local API sidecar for document processing, transaction import/export, recurring invoices, enrichment, inbox processing, notifications, and scheduled syncs.
+- For recurring schedules, store schedules in SQLite and tick from the local process while the app is running.
+- On startup, resume pending and scheduled jobs.
+
+This preserves UI expectations around job status without requiring Redis.
+
+## Online Integrations
+
+External integrations remain online but local-first:
+
+- Bank providers, Gmail, Outlook, Slack, Xero, QuickBooks, Fortnox, Stripe, Google APIs, and similar services authenticate through browser/deep-link or localhost callback flows.
+- Tokens and connection metadata are stored locally and encrypted.
+- Provider webhooks that cannot reach a local desktop app should be replaced with polling/manual sync for the first desktop version.
+- Public customer portals, public invoice links, public report links, and share links require an online destination because external users cannot fetch content from an offline desktop. Preserve these features through a narrow publish bridge:
+  - local export/download always works from the desktop file store,
+  - publish actions upload only the selected invoice, report, portal, or shared artifact needed for the public URL,
+  - the local SQLite database remains the source of truth,
+  - unpublished edits stay local until the user republishes,
+  - Supabase is not used for this bridge.
+- The AI assistant remains online and may call the local API for context through explicit local app mediation.
+
+## Dashboard Changes
+
+Keep UI components and route structure intact. Most dashboard work should be integration rewiring:
+
+- Point tRPC clients to the local API URL supplied by Tauri.
+- Replace Supabase session reads in server actions, middleware, and components with the local session provider.
+- Replace upload hooks with local upload endpoints.
+- Replace realtime Supabase hooks with local invalidation, polling, or local event streams.
+- Keep desktop-specific code in `@midday/desktop-client`, extending it for local service status and native file paths as needed.
+
+Avoid broad UI redesign. Visual regressions are out of scope except where a cloud-only screen must become a local-first equivalent.
+
+## API Changes
+
+Keep the Hono/tRPC API as the main business logic layer:
+
+- Add a desktop/local runtime mode.
+- Switch DB client imports to a runtime-selected local SQLite client for desktop.
+- Replace Supabase admin clients with local auth and storage services.
+- Remove Redis, Sentry, CORS, and cloud health assumptions from desktop mode.
+- Keep remote API behavior available if needed for the hosted product until the desktop migration is complete.
+
+## Migration Phases
+
+1. Desktop supervisor baseline:
+   Tauri launches local dashboard and API, allocates ports, waits for health, and loads the local dashboard.
+
+2. SQLite foundation:
+   Add SQLite schema/client/migrations and a small seed that creates a local user/team.
+
+3. Local auth/session:
+   Replace Supabase session usage in dashboard and API context with local sessions.
+
+4. Local storage:
+   Replace Supabase Storage upload/download/signed URL usage with local file APIs.
+
+5. Query portability:
+   Port Drizzle schema and query modules from Postgres assumptions to SQLite-compatible logic.
+
+6. Jobs:
+   Replace BullMQ/Trigger paths with the local SQLite-backed job runner.
+
+7. Feature passes:
+   Verify transactions, invoices, vault/documents, inbox, tracker, reports, customers, apps/integrations, notifications, API keys, MCP, and AI assistant.
+
+8. Packaging:
+   Package the Tauri app with local sidecars, migrations, assets, and update behavior.
+
+9. Parity verification:
+   Run typechecks, focused tests, desktop startup smoke tests, and browser/Tauri visual checks for the preserved UI.
+
+## Testing And Verification
+
+Completion requires evidence across the real product surface:
+
+- `bun` or `turbo` typecheck for touched packages.
+- Unit tests for local DB schema helpers, auth/session, storage, and job runner.
+- Query parity tests for high-value database modules.
+- API smoke test against local SQLite.
+- Dashboard smoke test against local API.
+- Tauri startup test that confirms local services launch, health checks pass, and the main window loads.
+- Upload/download test using local file storage.
+- Import/export test for transactions and invoices.
+- Job runner test for at least one scheduled and one immediate job.
+- Visual checks for dashboard pages and search window.
+
+## Risks
+
+- Full Postgres-to-SQLite query parity is the largest effort because many queries use Postgres SQL features directly.
+- Public sharing and inbound webhooks are not fully local concepts. The desktop app preserves them through explicit publish flows and provider polling/manual sync rather than hidden cloud database state.
+- Next standalone packaging plus Bun API sidecar must be tested on Windows first because this is the user's primary environment.
+- Some provider OAuth apps may reject localhost or custom scheme redirects without updated provider configuration.
+- Maintaining the hosted app and desktop app in one codebase will require clear runtime boundaries to avoid regressions.
+
+## Success Criteria
+
+The goal is not complete until the current desktop build proves all of the following:
+
+- Tauri app runs Midday locally without loading `app.midday.ai`.
+- Supabase is not required for desktop auth, storage, or data.
+- SQLite is the desktop source of truth.
+- Existing dashboard UI and primary workflows remain available.
+- Public links, customer portals, and invoice/report sharing work through explicit publish actions without using Supabase as the source of truth.
+- AI assistant still works through its online provider path.
+- Local files, jobs, and scheduled workflows survive app restart.
+- The app can be packaged and launched on Windows from a clean install.

--- a/packages/banking/package.json
+++ b/packages/banking/package.json
@@ -20,6 +20,7 @@
     "@midday/cache": "workspace:*",
     "@midday/location": "workspace:*",
     "@midday/logger": "workspace:*",
+    "@midday/utils": "workspace:*",
     "@t3-oss/env-core": "^0.13.11",
     "axios": "^1.14.0",
     "change-case": "catalog:",

--- a/packages/banking/src/env.ts
+++ b/packages/banking/src/env.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "@t3-oss/env-core";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { z } from "zod";
 
 export const env = createEnv({
@@ -20,4 +21,5 @@ export const env = createEnv({
     LOGO_DEV_TOKEN: z.string().min(1),
   },
   runtimeEnv: process.env,
+  skipValidation: isLocalDesktopRuntime(),
 });

--- a/packages/bot/src/instance.test.ts
+++ b/packages/bot/src/instance.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const originalEnv = {
+  MIDDAY_DESKTOP_RUNTIME: process.env.MIDDAY_DESKTOP_RUNTIME,
+  MIDDAY_LOCAL_FIRST: process.env.MIDDAY_LOCAL_FIRST,
+  WHATSAPP_ACCESS_TOKEN: process.env.WHATSAPP_ACCESS_TOKEN,
+  TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN,
+  SENDBLUE_API_KEY: process.env.SENDBLUE_API_KEY,
+  SENDBLUE_API_SECRET: process.env.SENDBLUE_API_SECRET,
+};
+
+beforeEach(() => {
+  process.env.MIDDAY_DESKTOP_RUNTIME = "local";
+  process.env.MIDDAY_LOCAL_FIRST = "true";
+  delete process.env.WHATSAPP_ACCESS_TOKEN;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.SENDBLUE_API_KEY;
+  delete process.env.SENDBLUE_API_SECRET;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("bot local runtime", () => {
+  test("imports a no-op bot without external adapter secrets", async () => {
+    const { bot } = await import("./instance");
+
+    await expect(bot.initialize()).resolves.toBeUndefined();
+    expect(bot.getAdapter("slack")).toBeNull();
+  });
+});

--- a/packages/bot/src/instance.ts
+++ b/packages/bot/src/instance.ts
@@ -3,6 +3,7 @@ import { createRedisState } from "@chat-adapter/state-redis";
 import { createTelegramAdapter } from "@chat-adapter/telegram";
 import { createWhatsAppAdapter } from "@chat-adapter/whatsapp";
 import { resolveRedisUrl } from "@midday/cache/shared-redis";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { Chat } from "chat";
 import { createSendblueAdapter } from "chat-adapter-sendblue";
 
@@ -23,4 +24,25 @@ export function createMiddayBot() {
   });
 }
 
-export const bot = createMiddayBot();
+function createLocalBot(): ReturnType<typeof createMiddayBot> {
+  const registerHandler = () => {};
+  const webhook = async () => new Response(null, { status: 204 });
+
+  return {
+    getAdapter: () => null,
+    initialize: async () => {},
+    onAssistantContextChanged: registerHandler,
+    onAssistantThreadStarted: registerHandler,
+    onNewMention: registerHandler,
+    onNewMessage: registerHandler,
+    onSubscribedMessage: registerHandler,
+    webhooks: {
+      sendblue: webhook,
+      slack: webhook,
+      telegram: webhook,
+      whatsapp: webhook,
+    },
+  } as unknown as ReturnType<typeof createMiddayBot>;
+}
+
+export const bot = isLocalDesktopRuntime() ? createLocalBot() : createMiddayBot();

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,6 +5,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "test": "bun test --exit",
+    "test:local": "bun test src/local/client.test.ts",
     "eval:matching:db": "bun run src/scripts/matching-eval-db.ts",
     "eval:progress": "bun run src/scripts/matching-progress.ts",
     "eval:similar": "bun run src/scripts/eval-similar-transactions.ts",
@@ -22,6 +23,7 @@
   },
   "exports": {
     "./client": "./src/client.ts",
+    "./local-client": "./src/local/client.ts",
     "./job-client": "./src/job-client.ts",
     "./worker-client": "./src/worker-client.ts",
     "./queries": "./src/queries/index.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "test": "bun test --exit",
-    "test:local": "bun test src/local/client.test.ts",
+    "test:local": "bun test src/local/client.test.ts src/local/queries.test.ts",
     "eval:matching:db": "bun run src/scripts/matching-eval-db.ts",
     "eval:progress": "bun run src/scripts/matching-progress.ts",
     "eval:similar": "bun run src/scripts/eval-similar-transactions.ts",
@@ -24,6 +24,7 @@
   "exports": {
     "./client": "./src/client.ts",
     "./local-client": "./src/local/client.ts",
+    "./local-queries": "./src/local/queries.ts",
     "./job-client": "./src/job-client.ts",
     "./worker-client": "./src/worker-client.ts",
     "./queries": "./src/queries/index.ts",

--- a/packages/db/src/job-client.ts
+++ b/packages/db/src/job-client.ts
@@ -1,6 +1,8 @@
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import type { Database } from "./client";
+import { getLocalDb } from "./local/client";
 import * as schema from "./schema";
 
 const isDevelopment = process.env.NODE_ENV === "development";
@@ -12,6 +14,13 @@ const isDevelopment = process.env.NODE_ENV === "development";
  * - Separate disconnect function for lifecycle management
  */
 export const createJobDb = () => {
+  if (isLocalDesktopRuntime()) {
+    return {
+      db: getLocalDb().db as unknown as Database,
+      disconnect: async () => {},
+    };
+  }
+
   const jobPool = new Pool({
     connectionString: process.env.DATABASE_PRIMARY_POOLER_URL!,
     max: 1,

--- a/packages/db/src/local/client.test.ts
+++ b/packages/db/src/local/client.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { resolveLocalDbPath } from "./path";
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "midday-local-db-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveLocalDbPath", () => {
+  test("uses a workspace-local default path and creates the parent directory", () => {
+    const cwd = createTempDir();
+
+    const dbPath = resolveLocalDbPath({ cwd, env: {} });
+
+    expect(dbPath).toBe(join(cwd, ".midday", "midday.sqlite"));
+    expect(existsSync(dirname(dbPath))).toBe(true);
+  });
+
+  test("uses MIDDAY_SQLITE_PATH before the desktop data directory", () => {
+    const cwd = createTempDir();
+    const desktopDataDir = join(cwd, "desktop-data");
+
+    const dbPath = resolveLocalDbPath({
+      cwd,
+      env: {
+        MIDDAY_DESKTOP_DATA_DIR: desktopDataDir,
+        MIDDAY_SQLITE_PATH: "custom/local.sqlite",
+      },
+    });
+
+    expect(dbPath).toBe(join(cwd, "custom", "local.sqlite"));
+    expect(existsSync(dirname(dbPath))).toBe(true);
+  });
+
+  test("uses MIDDAY_DESKTOP_DATA_DIR when no explicit SQLite path is set", () => {
+    const cwd = createTempDir();
+    const desktopDataDir = join(cwd, "desktop-data");
+
+    const dbPath = resolveLocalDbPath({
+      cwd,
+      env: { MIDDAY_DESKTOP_DATA_DIR: desktopDataDir },
+    });
+
+    expect(dbPath).toBe(join(desktopDataDir, "midday.sqlite"));
+    expect(existsSync(dirname(dbPath))).toBe(true);
+  });
+});

--- a/packages/db/src/local/client.test.ts
+++ b/packages/db/src/local/client.test.ts
@@ -3,8 +3,15 @@ import { Database as BunDatabase } from "bun:sqlite";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import {
+  closeLocalDb,
+  connectLocalDb,
+  getLocalDbFilePath,
+  seedLocalWorkspace,
+} from "./client";
 import { migrateLocalDb } from "./migrations";
 import { resolveLocalDbPath } from "./path";
+import { localSessions, localTeams, localUsers } from "./schema";
 
 const tempDirs: string[] = [];
 
@@ -15,6 +22,10 @@ function createTempDir() {
 }
 
 afterEach(() => {
+  closeLocalDb();
+  // Drizzle-held SQLite statements can keep WAL files locked until GC on Windows.
+  Bun.gc(true);
+
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -57,6 +68,73 @@ describe("resolveLocalDbPath", () => {
 
     expect(dbPath).toBe(join(desktopDataDir, "midday.sqlite"));
     expect(existsSync(dirname(dbPath))).toBe(true);
+  });
+});
+
+describe("connectLocalDb", () => {
+  test("opens a migrated SQLite file and exposes a Drizzle client", () => {
+    const cwd = createTempDir();
+    const path = join(cwd, "state", "midday.sqlite");
+
+    const local = connectLocalDb({ path });
+
+    try {
+      const rows = local.db.select().from(localUsers).all();
+      const migrations = local.sqlite
+        .query("SELECT version FROM local_migrations ORDER BY version")
+        .all() as Array<{ version: number }>;
+
+      expect(local.path).toBe(path);
+      expect(rows).toEqual([]);
+      expect(migrations).toEqual([{ version: 1 }]);
+      expect(getLocalDbFilePath({ path })).toBe(path);
+    } finally {
+      local.close();
+    }
+  });
+});
+
+describe("seedLocalWorkspace", () => {
+  test("creates and updates a local owner, team, membership, and session", () => {
+    const cwd = createTempDir();
+    const local = connectLocalDb({ path: join(cwd, "midday.sqlite") });
+
+    try {
+      const seeded = seedLocalWorkspace(local, {
+        email: "local@example.com",
+        name: "Local Owner",
+        sessionToken: "session_token",
+        teamId: "team_local",
+        teamName: "Local Team",
+        userId: "user_local",
+      });
+      seedLocalWorkspace(local, {
+        email: "local@example.com",
+        name: "Renamed Owner",
+        sessionToken: "session_token",
+        teamId: "team_local",
+        teamName: "Renamed Team",
+        userId: "user_local",
+      });
+
+      const users = local.db.select().from(localUsers).all();
+      const teams = local.db.select().from(localTeams).all();
+      const sessions = local.db.select().from(localSessions).all();
+
+      expect(seeded).toEqual({
+        sessionToken: "session_token",
+        teamId: "team_local",
+        userId: "user_local",
+      });
+      expect(users).toHaveLength(1);
+      expect(users[0]?.name).toBe("Renamed Owner");
+      expect(teams).toHaveLength(1);
+      expect(teams[0]?.name).toBe("Renamed Team");
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.token).toBe("session_token");
+    } finally {
+      local.close();
+    }
   });
 });
 

--- a/packages/db/src/local/client.test.ts
+++ b/packages/db/src/local/client.test.ts
@@ -7,6 +7,7 @@ import {
   closeLocalDb,
   connectLocalDb,
   getLocalDbFilePath,
+  getLocalDb,
   seedLocalWorkspace,
 } from "./client";
 import { migrateLocalDb } from "./migrations";
@@ -92,6 +93,23 @@ describe("connectLocalDb", () => {
       local.close();
     }
   });
+
+  test("opens a new singleton after the previous singleton was closed directly", () => {
+    const cwd = createTempDir();
+    const path = join(cwd, "state", "midday.sqlite");
+    const first = getLocalDb({ path });
+
+    first.close();
+
+    const second = getLocalDb({ path });
+
+    try {
+      expect(second).not.toBe(first);
+      expect(second.db.select().from(localUsers).all()).toEqual([]);
+    } finally {
+      second.close();
+    }
+  });
 });
 
 describe("seedLocalWorkspace", () => {
@@ -132,6 +150,26 @@ describe("seedLocalWorkspace", () => {
       expect(teams[0]?.name).toBe("Renamed Team");
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.token).toBe("session_token");
+    } finally {
+      local.close();
+    }
+  });
+
+  test("is idempotent with default local workspace values", () => {
+    const cwd = createTempDir();
+    const local = connectLocalDb({ path: join(cwd, "midday.sqlite") });
+
+    try {
+      const first = seedLocalWorkspace(local);
+      const second = seedLocalWorkspace(local);
+      const users = local.db.select().from(localUsers).all();
+      const teams = local.db.select().from(localTeams).all();
+      const sessions = local.db.select().from(localSessions).all();
+
+      expect(second).toEqual(first);
+      expect(users).toHaveLength(1);
+      expect(teams).toHaveLength(1);
+      expect(sessions).toHaveLength(1);
     } finally {
       local.close();
     }

--- a/packages/db/src/local/client.test.ts
+++ b/packages/db/src/local/client.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { migrateLocalDb } from "./migrations";
 import { resolveLocalDbPath } from "./path";
 
 const tempDirs: string[] = [];
@@ -55,5 +57,53 @@ describe("resolveLocalDbPath", () => {
 
     expect(dbPath).toBe(join(desktopDataDir, "midday.sqlite"));
     expect(existsSync(dirname(dbPath))).toBe(true);
+  });
+});
+
+describe("migrateLocalDb", () => {
+  test("creates the local bootstrap tables and records the migration", () => {
+    const cwd = createTempDir();
+    const sqlite = new BunDatabase(join(cwd, "midday.sqlite"), {
+      create: true,
+      readwrite: true,
+    });
+
+    try {
+      const result = migrateLocalDb(sqlite);
+      const tables = sqlite
+        .query("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+        .all() as Array<{ name: string }>;
+      const versions = sqlite
+        .query("SELECT version FROM local_migrations ORDER BY version")
+        .all() as Array<{ version: number }>;
+
+      expect(result.applied).toEqual([1]);
+      expect(tables.map((table) => table.name)).toContain("local_meta");
+      expect(tables.map((table) => table.name)).toContain("local_sessions");
+      expect(versions).toEqual([{ version: 1 }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("is idempotent after migrations have already run", () => {
+    const cwd = createTempDir();
+    const sqlite = new BunDatabase(join(cwd, "midday.sqlite"), {
+      create: true,
+      readwrite: true,
+    });
+
+    try {
+      migrateLocalDb(sqlite);
+      const result = migrateLocalDb(sqlite);
+      const versions = sqlite
+        .query("SELECT version FROM local_migrations ORDER BY version")
+        .all() as Array<{ version: number }>;
+
+      expect(result.applied).toEqual([]);
+      expect(versions).toEqual([{ version: 1 }]);
+    } finally {
+      sqlite.close();
+    }
   });
 });

--- a/packages/db/src/local/client.ts
+++ b/packages/db/src/local/client.ts
@@ -1,0 +1,179 @@
+import { Database as BunDatabase } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { nanoid } from "nanoid";
+import { migrateLocalDb, type LocalMigrationResult } from "./migrations";
+import { resolveLocalDbPath, type ResolveLocalDbPathOptions } from "./path";
+import * as schema from "./schema";
+
+type LocalDbEnv = ResolveLocalDbPathOptions["env"];
+
+export type ConnectLocalDbOptions = {
+  cwd?: string;
+  env?: LocalDbEnv;
+  path?: string;
+};
+
+export type SeedLocalWorkspaceInput = {
+  baseCurrency?: string;
+  email?: string;
+  expiresAt?: Date | string | null;
+  name?: string | null;
+  now?: Date | string;
+  sessionToken?: string | null;
+  teamId?: string;
+  teamName?: string;
+  userId?: string;
+};
+
+export type SeedLocalWorkspaceResult = {
+  sessionToken: string | null;
+  teamId: string;
+  userId: string;
+};
+
+function createDrizzleClient(sqlite: BunDatabase) {
+  return drizzle(sqlite, { schema });
+}
+
+export type LocalDrizzleDatabase = ReturnType<typeof createDrizzleClient>;
+
+export type LocalDatabase = {
+  db: LocalDrizzleDatabase;
+  migrate: () => LocalMigrationResult;
+  path: string;
+  sqlite: BunDatabase;
+  close: () => void;
+};
+
+let localDb: LocalDatabase | undefined;
+
+function toIsoString(value: Date | string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function configureSqlite(sqlite: BunDatabase) {
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  sqlite.exec("PRAGMA journal_mode = WAL");
+  sqlite.exec("PRAGMA busy_timeout = 5000");
+}
+
+export function getLocalDbFilePath(options: ConnectLocalDbOptions = {}) {
+  if (options.path) {
+    return resolveLocalDbPath({
+      cwd: options.cwd,
+      env: { MIDDAY_SQLITE_PATH: options.path },
+    });
+  }
+
+  return resolveLocalDbPath({ cwd: options.cwd, env: options.env });
+}
+
+export function connectLocalDb(
+  options: ConnectLocalDbOptions = {},
+): LocalDatabase {
+  const path = getLocalDbFilePath(options);
+  const sqlite = new BunDatabase(path, { create: true, readwrite: true });
+
+  configureSqlite(sqlite);
+
+  const local: LocalDatabase = {
+    db: createDrizzleClient(sqlite),
+    migrate: () => migrateLocalDb(sqlite),
+    path,
+    sqlite,
+    close: () => sqlite.close(),
+  };
+
+  local.migrate();
+  return local;
+}
+
+export function getLocalDb(options: ConnectLocalDbOptions = {}) {
+  localDb ??= connectLocalDb(options);
+  return localDb;
+}
+
+export function closeLocalDb() {
+  localDb?.close();
+  localDb = undefined;
+}
+
+export function seedLocalWorkspace(
+  local: LocalDatabase,
+  input: SeedLocalWorkspaceInput = {},
+): SeedLocalWorkspaceResult {
+  const userId = input.userId ?? `local_user_${nanoid(12)}`;
+  const teamId = input.teamId ?? `local_team_${nanoid(12)}`;
+  const sessionToken =
+    input.sessionToken === undefined
+      ? `local_session_${nanoid(32)}`
+      : input.sessionToken;
+  const now = toIsoString(input.now) ?? new Date().toISOString();
+  const expiresAt = toIsoString(input.expiresAt);
+  const email = input.email ?? "local@midday.local";
+  const teamName = input.teamName ?? "Local Workspace";
+
+  const seed = local.sqlite.transaction(() => {
+    local.sqlite
+      .query(
+        `INSERT INTO local_users (id, email, name, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          email = excluded.email,
+          name = excluded.name,
+          updated_at = excluded.updated_at`,
+      )
+      .run(userId, email, input.name ?? null, now, now);
+
+    local.sqlite
+      .query(
+        `INSERT INTO local_teams (id, name, base_currency, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          name = excluded.name,
+          base_currency = excluded.base_currency,
+          updated_at = excluded.updated_at`,
+      )
+      .run(teamId, teamName, input.baseCurrency ?? "USD", now, now);
+
+    local.sqlite
+      .query(
+        `INSERT INTO local_users_on_teams (user_id, team_id, role, created_at)
+        VALUES (?, ?, 'owner', ?)
+        ON CONFLICT(user_id, team_id) DO UPDATE SET role = excluded.role`,
+      )
+      .run(userId, teamId, now);
+
+    if (sessionToken) {
+      local.sqlite
+        .query(
+          `INSERT INTO local_sessions (
+            token,
+            user_id,
+            team_id,
+            expires_at,
+            created_at,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(token) DO UPDATE SET
+            user_id = excluded.user_id,
+            team_id = excluded.team_id,
+            expires_at = excluded.expires_at,
+            updated_at = excluded.updated_at`,
+        )
+        .run(sessionToken, userId, teamId, expiresAt, now, now);
+    }
+  });
+
+  seed();
+
+  return { sessionToken, teamId, userId };
+}
+
+export { migrateLocalDb, resolveLocalDbPath, schema };
+export type { LocalMigrationResult, ResolveLocalDbPathOptions };

--- a/packages/db/src/local/client.ts
+++ b/packages/db/src/local/client.ts
@@ -1,11 +1,14 @@
 import { Database as BunDatabase } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
-import { nanoid } from "nanoid";
 import { migrateLocalDb, type LocalMigrationResult } from "./migrations";
 import { resolveLocalDbPath, type ResolveLocalDbPathOptions } from "./path";
 import * as schema from "./schema";
 
 type LocalDbEnv = ResolveLocalDbPathOptions["env"];
+
+const DEFAULT_LOCAL_USER_ID = "local_user";
+const DEFAULT_LOCAL_TEAM_ID = "local_team";
+const DEFAULT_LOCAL_SESSION_TOKEN = "local_session";
 
 export type ConnectLocalDbOptions = {
   cwd?: string;
@@ -77,15 +80,28 @@ export function connectLocalDb(
 ): LocalDatabase {
   const path = getLocalDbFilePath(options);
   const sqlite = new BunDatabase(path, { create: true, readwrite: true });
+  let closed = false;
+  let local: LocalDatabase;
 
   configureSqlite(sqlite);
 
-  const local: LocalDatabase = {
+  local = {
     db: createDrizzleClient(sqlite),
     migrate: () => migrateLocalDb(sqlite),
     path,
     sqlite,
-    close: () => sqlite.close(),
+    close: () => {
+      if (closed) {
+        return;
+      }
+
+      sqlite.close();
+      closed = true;
+
+      if (localDb === local) {
+        localDb = undefined;
+      }
+    },
   };
 
   local.migrate();
@@ -106,11 +122,11 @@ export function seedLocalWorkspace(
   local: LocalDatabase,
   input: SeedLocalWorkspaceInput = {},
 ): SeedLocalWorkspaceResult {
-  const userId = input.userId ?? `local_user_${nanoid(12)}`;
-  const teamId = input.teamId ?? `local_team_${nanoid(12)}`;
+  const userId = input.userId ?? DEFAULT_LOCAL_USER_ID;
+  const teamId = input.teamId ?? DEFAULT_LOCAL_TEAM_ID;
   const sessionToken =
     input.sessionToken === undefined
-      ? `local_session_${nanoid(32)}`
+      ? DEFAULT_LOCAL_SESSION_TOKEN
       : input.sessionToken;
   const now = toIsoString(input.now) ?? new Date().toISOString();
   const expiresAt = toIsoString(input.expiresAt);

--- a/packages/db/src/local/client.ts
+++ b/packages/db/src/local/client.ts
@@ -1,14 +1,15 @@
 import { Database as BunDatabase } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
+import {
+  LOCAL_DESKTOP_SESSION_TOKEN,
+  LOCAL_DESKTOP_TEAM_ID,
+  LOCAL_DESKTOP_USER_ID,
+} from "@midday/utils/envs";
 import { migrateLocalDb, type LocalMigrationResult } from "./migrations";
 import { resolveLocalDbPath, type ResolveLocalDbPathOptions } from "./path";
 import * as schema from "./schema";
 
 type LocalDbEnv = ResolveLocalDbPathOptions["env"];
-
-const DEFAULT_LOCAL_USER_ID = "local_user";
-const DEFAULT_LOCAL_TEAM_ID = "local_team";
-const DEFAULT_LOCAL_SESSION_TOKEN = "local_session";
 
 export type ConnectLocalDbOptions = {
   cwd?: string;
@@ -122,11 +123,11 @@ export function seedLocalWorkspace(
   local: LocalDatabase,
   input: SeedLocalWorkspaceInput = {},
 ): SeedLocalWorkspaceResult {
-  const userId = input.userId ?? DEFAULT_LOCAL_USER_ID;
-  const teamId = input.teamId ?? DEFAULT_LOCAL_TEAM_ID;
+  const userId = input.userId ?? LOCAL_DESKTOP_USER_ID;
+  const teamId = input.teamId ?? LOCAL_DESKTOP_TEAM_ID;
   const sessionToken =
     input.sessionToken === undefined
-      ? DEFAULT_LOCAL_SESSION_TOKEN
+      ? LOCAL_DESKTOP_SESSION_TOKEN
       : input.sessionToken;
   const now = toIsoString(input.now) ?? new Date().toISOString();
   const expiresAt = toIsoString(input.expiresAt);

--- a/packages/db/src/local/migrations.ts
+++ b/packages/db/src/local/migrations.ts
@@ -1,0 +1,106 @@
+import type { Database as BunDatabase } from "bun:sqlite";
+
+export type LocalMigration = {
+  name: string;
+  statements: string[];
+  version: number;
+};
+
+export type LocalMigrationResult = {
+  applied: number[];
+  version: number;
+};
+
+export const LOCAL_MIGRATIONS: LocalMigration[] = [
+  {
+    version: 1,
+    name: "bootstrap_local_identity",
+    statements: [
+      `CREATE TABLE IF NOT EXISTS local_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )`,
+      `CREATE TABLE IF NOT EXISTS local_users (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL UNIQUE,
+        name TEXT,
+        avatar_url TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )`,
+      `CREATE TABLE IF NOT EXISTS local_teams (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        base_currency TEXT NOT NULL DEFAULT 'USD',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )`,
+      `CREATE TABLE IF NOT EXISTS local_users_on_teams (
+        user_id TEXT NOT NULL REFERENCES local_users(id) ON DELETE CASCADE,
+        team_id TEXT NOT NULL REFERENCES local_teams(id) ON DELETE CASCADE,
+        role TEXT NOT NULL DEFAULT 'owner',
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (user_id, team_id)
+      )`,
+      `CREATE INDEX IF NOT EXISTS local_users_on_teams_team_id_idx
+        ON local_users_on_teams(team_id)`,
+      `CREATE TABLE IF NOT EXISTS local_sessions (
+        token TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL REFERENCES local_users(id) ON DELETE CASCADE,
+        team_id TEXT NOT NULL REFERENCES local_teams(id) ON DELETE CASCADE,
+        expires_at TEXT,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )`,
+      `CREATE INDEX IF NOT EXISTS local_sessions_user_id_idx
+        ON local_sessions(user_id)`,
+      `CREATE INDEX IF NOT EXISTS local_sessions_team_id_idx
+        ON local_sessions(team_id)`,
+    ],
+  },
+];
+
+function getCurrentVersion(sqlite: BunDatabase) {
+  const row = sqlite
+    .query("SELECT COALESCE(MAX(version), 0) AS version FROM local_migrations")
+    .get() as { version: number } | null;
+
+  return row?.version ?? 0;
+}
+
+export function migrateLocalDb(sqlite: BunDatabase): LocalMigrationResult {
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  sqlite.exec(`CREATE TABLE IF NOT EXISTS local_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+  )`);
+
+  const currentVersion = getCurrentVersion(sqlite);
+  const applied: number[] = [];
+
+  for (const migration of LOCAL_MIGRATIONS) {
+    if (migration.version <= currentVersion) {
+      continue;
+    }
+
+    const applyMigration = sqlite.transaction(() => {
+      for (const statement of migration.statements) {
+        sqlite.exec(statement);
+      }
+
+      sqlite
+        .query("INSERT INTO local_migrations (version, name) VALUES (?, ?)")
+        .run(migration.version, migration.name);
+    });
+
+    applyMigration();
+    applied.push(migration.version);
+  }
+
+  return {
+    applied,
+    version: LOCAL_MIGRATIONS.at(-1)?.version ?? 0,
+  };
+}

--- a/packages/db/src/local/path.ts
+++ b/packages/db/src/local/path.ts
@@ -3,9 +3,11 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 
 export const DEFAULT_LOCAL_DB_RELATIVE_PATH = join(".midday", "midday.sqlite");
 
-type LocalDbPathEnv = Pick<
+type LocalDbPathEnv = Partial<
+  Pick<
   NodeJS.ProcessEnv,
   "MIDDAY_DESKTOP_DATA_DIR" | "MIDDAY_SQLITE_PATH"
+  >
 >;
 
 export type ResolveLocalDbPathOptions = {

--- a/packages/db/src/local/path.ts
+++ b/packages/db/src/local/path.ts
@@ -1,0 +1,34 @@
+import { mkdirSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+export const DEFAULT_LOCAL_DB_RELATIVE_PATH = join(".midday", "midday.sqlite");
+
+type LocalDbPathEnv = Pick<
+  NodeJS.ProcessEnv,
+  "MIDDAY_DESKTOP_DATA_DIR" | "MIDDAY_SQLITE_PATH"
+>;
+
+export type ResolveLocalDbPathOptions = {
+  cwd?: string;
+  ensureDir?: boolean;
+  env?: LocalDbPathEnv;
+};
+
+export function resolveLocalDbPath(options: ResolveLocalDbPathOptions = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const explicitPath = env.MIDDAY_SQLITE_PATH?.trim();
+  const desktopDataDir = env.MIDDAY_DESKTOP_DATA_DIR?.trim();
+  const dbPath =
+    explicitPath ||
+    (desktopDataDir
+      ? join(desktopDataDir, "midday.sqlite")
+      : DEFAULT_LOCAL_DB_RELATIVE_PATH);
+  const resolvedPath = isAbsolute(dbPath) ? dbPath : resolve(cwd, dbPath);
+
+  if (options.ensureDir !== false) {
+    mkdirSync(dirname(resolvedPath), { recursive: true });
+  }
+
+  return resolvedPath;
+}

--- a/packages/db/src/local/queries.test.ts
+++ b/packages/db/src/local/queries.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  closeLocalDb,
+  connectLocalDb,
+  seedLocalWorkspace,
+} from "./client";
+import {
+  getLocalOverviewSummary,
+  getLocalTeamById,
+  getLocalTeamMembersByTeamId,
+  getLocalTeamsByUserId,
+  getLocalUserById,
+  hasLocalTeamAccess,
+  switchLocalUserTeam,
+  updateLocalTeamById,
+  updateLocalUser,
+} from "./queries";
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "midday-local-queries-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  closeLocalDb();
+  Bun.gc(true);
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("local identity queries", () => {
+  test("reads the seeded local user, team, and membership", () => {
+    const local = connectLocalDb({
+      path: join(createTempDir(), "midday.sqlite"),
+    });
+
+    try {
+      seedLocalWorkspace(local, {
+        baseCurrency: "SEK",
+        email: "owner@example.com",
+        name: "Local Owner",
+        teamName: "Local Team",
+      });
+
+      const user = getLocalUserById(local, "local_user");
+      const team = getLocalTeamById(local, "local_team");
+      const teams = getLocalTeamsByUserId(local, "local_user");
+      const members = getLocalTeamMembersByTeamId(local, "local_team");
+
+      expect(user).toMatchObject({
+        id: "local_user",
+        fullName: "Local Owner",
+        email: "owner@example.com",
+        teamId: "local_team",
+        team: { id: "local_team", name: "Local Team", baseCurrency: "SEK" },
+      });
+      expect(team).toMatchObject({
+        id: "local_team",
+        name: "Local Team",
+        baseCurrency: "SEK",
+        plan: "pro",
+      });
+      expect(teams).toHaveLength(1);
+      expect(teams[0]).toMatchObject({
+        id: "local_team",
+        name: "Local Team",
+        role: "owner",
+      });
+      expect(members).toEqual([
+        {
+          id: "local_user:local_team",
+          role: "owner",
+          teamId: "local_team",
+          user: {
+            id: "local_user",
+            fullName: "Local Owner",
+            avatarUrl: null,
+            email: "owner@example.com",
+          },
+        },
+      ]);
+      expect(hasLocalTeamAccess(local, "local_team", "local_user")).toBe(true);
+    } finally {
+      local.close();
+    }
+  });
+
+  test("updates local user and team profile fields", () => {
+    const local = connectLocalDb({
+      path: join(createTempDir(), "midday.sqlite"),
+    });
+
+    try {
+      seedLocalWorkspace(local);
+
+      expect(
+        updateLocalUser(local, {
+          id: "local_user",
+          fullName: "Renamed Owner",
+        }),
+      ).toMatchObject({ fullName: "Renamed Owner" });
+
+      expect(
+        updateLocalTeamById(local, {
+          id: "local_team",
+          data: { baseCurrency: "EUR", name: "Renamed Team" },
+        }),
+      ).toMatchObject({ baseCurrency: "EUR", name: "Renamed Team" });
+
+      expect(getLocalUserById(local, "local_user")).toMatchObject({
+        fullName: "Renamed Owner",
+        team: { baseCurrency: "EUR", name: "Renamed Team" },
+      });
+    } finally {
+      local.close();
+    }
+  });
+
+  test("returns empty overview summary with team currency", () => {
+    const local = connectLocalDb({
+      path: join(createTempDir(), "midday.sqlite"),
+    });
+
+    try {
+      seedLocalWorkspace(local, { baseCurrency: "GBP" });
+
+      expect(
+        getLocalOverviewSummary(local, { teamId: "local_team" }),
+      ).toMatchObject({
+        cashBalance: { accountCount: 0, currency: "GBP", totalBalance: 0 },
+        inboxPending: { count: 0 },
+        openInvoices: { count: 0, currency: "GBP", totalAmount: 0 },
+        runway: 0,
+        transactionsToReview: { count: 0 },
+        unbilledTime: {
+          currency: "GBP",
+          projectCount: 0,
+          totalAmount: 0,
+          totalDuration: 0,
+        },
+      });
+    } finally {
+      local.close();
+    }
+  });
+
+  test("switches the active team through the local session", () => {
+    const local = connectLocalDb({
+      path: join(createTempDir(), "midday.sqlite"),
+    });
+
+    try {
+      seedLocalWorkspace(local);
+      seedLocalWorkspace(local, {
+        sessionToken: null,
+        teamId: "second_team",
+        teamName: "Second Team",
+      });
+
+      const result = switchLocalUserTeam(local, {
+        userId: "local_user",
+        teamId: "second_team",
+      });
+
+      expect(result).toEqual({
+        id: "local_user",
+        previousTeamId: "local_team",
+        teamId: "second_team",
+      });
+      expect(getLocalUserById(local, "local_user")).toMatchObject({
+        teamId: "second_team",
+        team: { name: "Second Team" },
+      });
+    } finally {
+      local.close();
+    }
+  });
+});

--- a/packages/db/src/local/queries.ts
+++ b/packages/db/src/local/queries.ts
@@ -1,0 +1,405 @@
+import { LOCAL_DESKTOP_SESSION_TOKEN } from "@midday/utils/envs";
+import { getLocalDb, seedLocalWorkspace, type LocalDatabase } from "./client";
+
+export type LocalUserProfile = {
+  id: string;
+  fullName: string | null;
+  email: string;
+  avatarUrl: string | null;
+  locale: string | null;
+  timeFormat: number | null;
+  dateFormat: string | null;
+  weekStartsOnMonday: boolean | null;
+  timezone: string | null;
+  timezoneAutoSync: boolean | null;
+  teamId: string | null;
+  team: LocalTeamProfile | null;
+};
+
+export type LocalTeamProfile = {
+  id: string;
+  name: string;
+  logoUrl: string | null;
+  email: string | null;
+  inboxId: string | null;
+  plan: "trial" | "starter" | "pro";
+  subscriptionStatus: string | null;
+  canceledAt: string | null;
+  baseCurrency: string;
+  countryCode: string | null;
+  fiscalYearStartMonth: number | null;
+  exportSettings: null;
+  stripeAccountId: string | null;
+  stripeConnectStatus: string | null;
+  createdAt?: string;
+};
+
+export type LocalTeamMember = {
+  id: string;
+  role: LocalTeamRole;
+  teamId: string;
+  user: {
+    id: string;
+    fullName: string | null;
+    avatarUrl: string | null;
+    email: string;
+  } | null;
+};
+
+type LocalUserRow = {
+  id: string;
+  email: string;
+  name: string | null;
+  avatar_url: string | null;
+};
+
+type LocalTeamRow = {
+  id: string;
+  name: string;
+  base_currency: string;
+  created_at: string | null;
+};
+
+type LocalMembershipRow = {
+  role: string;
+  team_id: string;
+};
+
+type LocalTeamRole = "owner" | "member";
+
+export type LocalOverviewSummary = {
+  openInvoices: {
+    count: number;
+    totalAmount: number;
+    currency: string;
+  };
+  unbilledTime: {
+    totalDuration: number;
+    totalAmount: number;
+    projectCount: number;
+    currency: string;
+  };
+  inboxPending: {
+    count: number;
+  };
+  transactionsToReview: {
+    count: number;
+  };
+  cashBalance: {
+    totalBalance: number;
+    currency: string;
+    accountCount: number;
+  };
+  runway: number;
+};
+
+function toLocalTeam(row: LocalTeamRow): LocalTeamProfile {
+  return {
+    id: row.id,
+    name: row.name,
+    logoUrl: null,
+    email: null,
+    inboxId: null,
+    plan: "pro",
+    subscriptionStatus: null,
+    canceledAt: null,
+    baseCurrency: row.base_currency,
+    countryCode: null,
+    fiscalYearStartMonth: null,
+    exportSettings: null,
+    stripeAccountId: null,
+    stripeConnectStatus: null,
+    createdAt: row.created_at ?? undefined,
+  };
+}
+
+function toLocalTeamRole(role: string | null | undefined): LocalTeamRole {
+  return role === "member" ? "member" : "owner";
+}
+
+function getLocalTeamRow(local: LocalDatabase, teamId: string) {
+  return local.sqlite
+    .query("SELECT id, name, base_currency, created_at FROM local_teams WHERE id = ?")
+    .get(teamId) as LocalTeamRow | null;
+}
+
+function getActiveTeamRowForUser(local: LocalDatabase, userId: string) {
+  const sessionTeam = local.sqlite
+    .query(
+      `SELECT t.id, t.name, t.base_currency, t.created_at
+      FROM local_sessions s
+      INNER JOIN local_teams t ON t.id = s.team_id
+      WHERE s.user_id = ? AND s.token = ?
+      LIMIT 1`,
+    )
+    .get(userId, LOCAL_DESKTOP_SESSION_TOKEN) as LocalTeamRow | null;
+
+  if (sessionTeam) {
+    return sessionTeam;
+  }
+
+  return local.sqlite
+    .query(
+      `SELECT t.id, t.name, t.base_currency, t.created_at
+      FROM local_users_on_teams m
+      INNER JOIN local_teams t ON t.id = m.team_id
+      WHERE m.user_id = ?
+      ORDER BY m.created_at
+      LIMIT 1`,
+    )
+    .get(userId) as LocalTeamRow | null;
+}
+
+export function getSeededLocalDb() {
+  const local = getLocalDb();
+  seedLocalWorkspace(local);
+  return local;
+}
+
+export function getLocalUserById(local: LocalDatabase, userId: string) {
+  const user = local.sqlite
+    .query("SELECT id, email, name, avatar_url FROM local_users WHERE id = ?")
+    .get(userId) as LocalUserRow | null;
+
+  if (!user) {
+    return undefined;
+  }
+
+  const teamRow = getActiveTeamRowForUser(local, user.id);
+  const team = teamRow ? toLocalTeam(teamRow) : null;
+
+  return {
+    id: user.id,
+    fullName: user.name,
+    email: user.email,
+    avatarUrl: user.avatar_url,
+    locale: null,
+    timeFormat: null,
+    dateFormat: null,
+    weekStartsOnMonday: null,
+    timezone: null,
+    timezoneAutoSync: true,
+    teamId: team?.id ?? null,
+    team,
+  } satisfies LocalUserProfile;
+}
+
+export function updateLocalUser(
+  local: LocalDatabase,
+  data: {
+    id: string;
+    avatarUrl?: string | null;
+    email?: string | null;
+    fullName?: string | null;
+  },
+) {
+  const current = getLocalUserById(local, data.id);
+
+  if (!current) {
+    return undefined;
+  }
+
+  local.sqlite
+    .query(
+      `UPDATE local_users
+      SET email = ?, name = ?, avatar_url = ?, updated_at = ?
+      WHERE id = ?`,
+    )
+    .run(
+      data.email ?? current.email,
+      data.fullName === undefined ? current.fullName : data.fullName,
+      data.avatarUrl === undefined ? current.avatarUrl : data.avatarUrl,
+      new Date().toISOString(),
+      data.id,
+    );
+
+  return getLocalUserById(local, data.id);
+}
+
+export function switchLocalUserTeam(
+  local: LocalDatabase,
+  params: { userId: string; teamId: string },
+) {
+  const previousTeamId = getLocalUserById(local, params.userId)?.teamId ?? null;
+
+  if (!hasLocalTeamAccess(local, params.teamId, params.userId)) {
+    throw new Error("User is not a member of the target team");
+  }
+
+  local.sqlite
+    .query(
+      `UPDATE local_sessions
+      SET team_id = ?, updated_at = ?
+      WHERE token = ? AND user_id = ?`,
+    )
+    .run(
+      params.teamId,
+      new Date().toISOString(),
+      LOCAL_DESKTOP_SESSION_TOKEN,
+      params.userId,
+    );
+
+  return {
+    id: params.userId,
+    teamId: params.teamId,
+    previousTeamId,
+  };
+}
+
+export function hasLocalTeamAccess(
+  local: LocalDatabase,
+  teamId: string,
+  userId: string,
+) {
+  const membership = local.sqlite
+    .query(
+      `SELECT team_id
+      FROM local_users_on_teams
+      WHERE team_id = ? AND user_id = ?
+      LIMIT 1`,
+    )
+    .get(teamId, userId) as { team_id: string } | null;
+
+  return !!membership;
+}
+
+export function getLocalTeamById(local: LocalDatabase, teamId: string) {
+  const row = getLocalTeamRow(local, teamId);
+  return row ? toLocalTeam(row) : undefined;
+}
+
+export function updateLocalTeamById(
+  local: LocalDatabase,
+  params: {
+    id: string;
+    data: {
+      baseCurrency?: string | null;
+      name?: string | null;
+    };
+  },
+) {
+  const current = getLocalTeamById(local, params.id);
+
+  if (!current) {
+    return undefined;
+  }
+
+  local.sqlite
+    .query(
+      `UPDATE local_teams
+      SET name = ?, base_currency = ?, updated_at = ?
+      WHERE id = ?`,
+    )
+    .run(
+      params.data.name ?? current.name,
+      params.data.baseCurrency ?? current.baseCurrency,
+      new Date().toISOString(),
+      params.id,
+    );
+
+  return getLocalTeamById(local, params.id);
+}
+
+export function getLocalTeamMembersByTeamId(
+  local: LocalDatabase,
+  teamId: string,
+) {
+  const rows = local.sqlite
+    .query(
+      `SELECT
+        m.role,
+        m.team_id,
+        u.id AS user_id,
+        u.name AS user_name,
+        u.avatar_url AS avatar_url,
+        u.email AS user_email
+      FROM local_users_on_teams m
+      LEFT JOIN local_users u ON u.id = m.user_id
+      WHERE m.team_id = ?
+      ORDER BY m.created_at`,
+    )
+    .all(teamId) as Array<{
+    avatar_url: string | null;
+    role: string;
+    team_id: string;
+    user_email: string | null;
+    user_id: string | null;
+    user_name: string | null;
+  }>;
+
+  return rows.map((row) => ({
+    id: `${row.user_id ?? "unknown"}:${row.team_id}`,
+    role: toLocalTeamRole(row.role),
+    teamId: row.team_id,
+    user: row.user_id
+      ? {
+          id: row.user_id,
+          fullName: row.user_name,
+          avatarUrl: row.avatar_url,
+          email: row.user_email ?? "",
+        }
+      : null,
+  })) satisfies LocalTeamMember[];
+}
+
+export function getLocalTeamsByUserId(local: LocalDatabase, userId: string) {
+  const rows = local.sqlite
+    .query(
+      `SELECT
+        m.role,
+        t.id,
+        t.name,
+        t.base_currency,
+        t.created_at
+      FROM local_users_on_teams m
+      INNER JOIN local_teams t ON t.id = m.team_id
+      WHERE m.user_id = ?
+      ORDER BY m.created_at`,
+    )
+    .all(userId) as Array<LocalTeamRow & { role: string }>;
+
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    plan: "pro" as const,
+    role: toLocalTeamRole(row.role),
+    createdAt: row.created_at,
+    canceledAt: null,
+    updatedAt: row.created_at,
+    logoUrl: null,
+  }));
+}
+
+export function getLocalOverviewSummary(
+  local: LocalDatabase,
+  params: { currency?: string; teamId: string },
+): LocalOverviewSummary {
+  const team = getLocalTeamById(local, params.teamId);
+  const currency = params.currency ?? team?.baseCurrency ?? "USD";
+
+  return {
+    openInvoices: {
+      count: 0,
+      totalAmount: 0,
+      currency,
+    },
+    unbilledTime: {
+      totalDuration: 0,
+      totalAmount: 0,
+      projectCount: 0,
+      currency,
+    },
+    inboxPending: {
+      count: 0,
+    },
+    transactionsToReview: {
+      count: 0,
+    },
+    cashBalance: {
+      totalBalance: 0,
+      currency,
+      accountCount: 0,
+    },
+    runway: 0,
+  };
+}

--- a/packages/db/src/local/runtime-clients.test.ts
+++ b/packages/db/src/local/runtime-clients.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { closeLocalDb } from "./client";
+
+const originalEnv = {
+  DATABASE_PRIMARY_POOLER_URL: process.env.DATABASE_PRIMARY_POOLER_URL,
+  DATABASE_PRIMARY_URL: process.env.DATABASE_PRIMARY_URL,
+  MIDDAY_DESKTOP_RUNTIME: process.env.MIDDAY_DESKTOP_RUNTIME,
+  MIDDAY_LOCAL_FIRST: process.env.MIDDAY_LOCAL_FIRST,
+  MIDDAY_SQLITE_PATH: process.env.MIDDAY_SQLITE_PATH,
+};
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "midday-local-runtime-db-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  process.env.MIDDAY_DESKTOP_RUNTIME = "local";
+  process.env.MIDDAY_LOCAL_FIRST = "true";
+  delete process.env.DATABASE_PRIMARY_POOLER_URL;
+  delete process.env.DATABASE_PRIMARY_URL;
+});
+
+afterEach(() => {
+  closeLocalDb();
+  Bun.gc(true);
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("local runtime database clients", () => {
+  test("worker client imports without Postgres connection strings", async () => {
+    const { getWorkerPoolStats } = await import("@midday/db/worker-client");
+
+    expect(getWorkerPoolStats()).toEqual({ total: 0, idle: 0, waiting: 0 });
+  });
+
+  test("job client uses local SQLite in local desktop mode", async () => {
+    const cwd = createTempDir();
+    process.env.MIDDAY_SQLITE_PATH = join(cwd, "midday.sqlite");
+
+    const { createJobDb } = await import("@midday/db/job-client");
+    const { disconnect } = createJobDb();
+
+    await disconnect();
+
+    expect(existsSync(process.env.MIDDAY_SQLITE_PATH)).toBe(true);
+  });
+});

--- a/packages/db/src/local/schema.ts
+++ b/packages/db/src/local/schema.ts
@@ -1,0 +1,80 @@
+import { sql } from "drizzle-orm";
+import {
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+export const localMeta = sqliteTable("local_meta", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+});
+
+export const localMigrations = sqliteTable("local_migrations", {
+  version: integer("version").primaryKey(),
+  name: text("name").notNull(),
+  appliedAt: text("applied_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+});
+
+export const localUsers = sqliteTable(
+  "local_users",
+  {
+    id: text("id").primaryKey(),
+    email: text("email").notNull(),
+    name: text("name"),
+    avatarUrl: text("avatar_url"),
+    createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [uniqueIndex("local_users_email_idx").on(table.email)],
+);
+
+export const localTeams = sqliteTable("local_teams", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  baseCurrency: text("base_currency").notNull().default("USD"),
+  createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+});
+
+export const localUsersOnTeams = sqliteTable(
+  "local_users_on_teams",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => localUsers.id, { onDelete: "cascade" }),
+    teamId: text("team_id")
+      .notNull()
+      .references(() => localTeams.id, { onDelete: "cascade" }),
+    role: text("role").notNull().default("owner"),
+    createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.teamId] }),
+    index("local_users_on_teams_team_id_idx").on(table.teamId),
+  ],
+);
+
+export const localSessions = sqliteTable(
+  "local_sessions",
+  {
+    token: text("token").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => localUsers.id, { onDelete: "cascade" }),
+    teamId: text("team_id")
+      .notNull()
+      .references(() => localTeams.id, { onDelete: "cascade" }),
+    expiresAt: text("expires_at"),
+    createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    index("local_sessions_user_id_idx").on(table.userId),
+    index("local_sessions_team_id_idx").on(table.teamId),
+  ],
+);

--- a/packages/db/src/worker-client.ts
+++ b/packages/db/src/worker-client.ts
@@ -1,17 +1,20 @@
 import { createLoggerWithContext } from "@midday/logger";
+import { isLocalDesktopRuntime } from "@midday/utils/envs";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import type { Database } from "./client";
+import { closeLocalDb, getLocalDb } from "./local/client";
 import * as schema from "./schema";
 
 const isDevelopment = process.env.NODE_ENV === "development";
 const logger = createLoggerWithContext("db:worker");
 const DB_POOL_EVENT_LOGGING = process.env.DB_POOL_EVENT_LOGGING === "true";
+const isLocalRuntime = isLocalDesktopRuntime();
 
 const connectionString =
   process.env.DATABASE_PRIMARY_POOLER_URL ?? process.env.DATABASE_PRIMARY_URL;
 
-if (!connectionString) {
+if (!isLocalRuntime && !connectionString) {
   throw new Error(
     "Missing database connection string: set DATABASE_PRIMARY_POOLER_URL or DATABASE_PRIMARY_URL",
   );
@@ -20,17 +23,19 @@ if (!connectionString) {
 /**
  * Worker database client with connection pool optimized for BullMQ concurrent jobs
  */
-const workerPool = new Pool({
-  connectionString,
-  max: isDevelopment ? 10 : 50,
-  idleTimeoutMillis: isDevelopment ? 5000 : 60000,
-  connectionTimeoutMillis: 15000,
-  maxUses: isDevelopment ? 200 : 3000,
-  keepAlive: true,
-  keepAliveInitialDelayMillis: 10_000,
-  ssl: isDevelopment ? false : { rejectUnauthorized: false },
-  allowExitOnIdle: true,
-});
+const workerPool = isLocalRuntime
+  ? null
+  : new Pool({
+      connectionString,
+      max: isDevelopment ? 10 : 50,
+      idleTimeoutMillis: isDevelopment ? 5000 : 60000,
+      connectionTimeoutMillis: 15000,
+      maxUses: isDevelopment ? 200 : 3000,
+      keepAlive: true,
+      keepAliveInitialDelayMillis: 10_000,
+      ssl: isDevelopment ? false : { rejectUnauthorized: false },
+      allowExitOnIdle: true,
+    });
 
 function getPgErrorDetails(error: unknown) {
   const details: Record<string, unknown> = {};
@@ -61,6 +66,14 @@ function getPgErrorDetails(error: unknown) {
 }
 
 function getPoolStatsSnapshot() {
+  if (!workerPool) {
+    return {
+      total: 0,
+      idle: 0,
+      waiting: 0,
+    };
+  }
+
   return {
     total: workerPool.totalCount,
     idle: workerPool.idleCount,
@@ -68,59 +81,69 @@ function getPoolStatsSnapshot() {
   };
 }
 
-workerPool.on("error", (err) => {
-  logger.error("Worker pool: idle client error", {
-    ...getPgErrorDetails(err),
-    stats: getPoolStatsSnapshot(),
-  });
-});
-
-if (DB_POOL_EVENT_LOGGING) {
-  workerPool.on("connect", () => {
-    logger.info("Worker pool: client connected", {
+if (workerPool) {
+  workerPool.on("error", (err) => {
+    logger.error("Worker pool: idle client error", {
+      ...getPgErrorDetails(err),
       stats: getPoolStatsSnapshot(),
     });
   });
 
-  workerPool.on("acquire", () => {
-    logger.info("Worker pool: client acquired", {
-      stats: getPoolStatsSnapshot(),
+  if (DB_POOL_EVENT_LOGGING) {
+    workerPool.on("connect", () => {
+      logger.info("Worker pool: client connected", {
+        stats: getPoolStatsSnapshot(),
+      });
     });
-  });
 
-  workerPool.on("remove", () => {
-    logger.info("Worker pool: client removed", {
-      stats: getPoolStatsSnapshot(),
+    workerPool.on("acquire", () => {
+      logger.info("Worker pool: client acquired", {
+        stats: getPoolStatsSnapshot(),
+      });
     });
-  });
+
+    workerPool.on("remove", () => {
+      logger.info("Worker pool: client removed", {
+        stats: getPoolStatsSnapshot(),
+      });
+    });
+  }
 }
 
-const workerDrizzle = drizzle(workerPool, {
-  schema,
-  casing: "snake_case",
-});
+const workerDrizzle = workerPool
+  ? drizzle(workerPool, {
+      schema,
+      casing: "snake_case",
+    })
+  : null;
 
 // Shared query helpers call `db.executeOnReplica(...)`. Workers don't use
 // replicas, so route those reads through the primary pool via the normal
 // drizzle `execute` and return the rows in the same shape replicas.ts does.
-const workerDb = Object.assign(workerDrizzle, {
-  executeOnReplica: async <
-    TRow extends Record<string, unknown> = Record<string, unknown>,
-  >(
-    query: Parameters<typeof workerDrizzle.execute>[0],
-  ): Promise<TRow[]> => {
-    const result = await workerDrizzle.execute(query);
-    if (Array.isArray(result)) {
-      return result as TRow[];
-    }
-    return (result as { rows: TRow[] }).rows;
-  },
-});
+const workerDb = workerDrizzle
+  ? Object.assign(workerDrizzle, {
+      executeOnReplica: async <
+        TRow extends Record<string, unknown> = Record<string, unknown>,
+      >(
+        query: Parameters<typeof workerDrizzle.execute>[0],
+      ): Promise<TRow[]> => {
+        const result = await workerDrizzle.execute(query);
+        if (Array.isArray(result)) {
+          return result as TRow[];
+        }
+        return (result as { rows: TRow[] }).rows;
+      },
+    })
+  : null;
 
 /**
  * Get the shared worker database instance
  */
 export const getWorkerDb = (): Database => {
+  if (isLocalRuntime) {
+    return getLocalDb().db as unknown as Database;
+  }
+
   return workerDb as unknown as Database;
 };
 
@@ -132,5 +155,10 @@ export const getWorkerPoolStats = () => {
  * Cleanup function to close database connections gracefully
  */
 export const closeWorkerDb = async (): Promise<void> => {
-  await workerPool.end();
+  if (isLocalRuntime) {
+    closeLocalDb();
+    return;
+  }
+
+  await workerPool?.end();
 };

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@midday/banking": "workspace:*",
+    "@midday/utils": "workspace:*",
     "@supabase/postgrest-js": "^2.101.1",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
@@ -25,6 +26,7 @@
   "exports": {
     "./server": "./src/client/server.ts",
     "./client": "./src/client/client.ts",
+    "./local-client": "./src/client/local.ts",
     "./client-query": "./src/queries/client.ts",
     "./job": "./src/client/job.ts",
     "./mutations": "./src/mutations/index.ts",

--- a/packages/supabase/src/client/client.ts
+++ b/packages/supabase/src/client/client.ts
@@ -1,7 +1,12 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { Database } from "../types";
+import { createLocalSupabaseClient, isLocalDesktopRuntime } from "./local";
 
 export const createClient = () => {
+  if (isLocalDesktopRuntime()) {
+    return createLocalSupabaseClient();
+  }
+
   return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,

--- a/packages/supabase/src/client/local.ts
+++ b/packages/supabase/src/client/local.ts
@@ -1,0 +1,98 @@
+import {
+  isLocalDesktopRuntime,
+  LOCAL_DESKTOP_SESSION_TOKEN,
+  LOCAL_DESKTOP_TEAM_ID,
+  LOCAL_DESKTOP_USER_ID,
+} from "@midday/utils/envs";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const localUser = {
+  id: LOCAL_DESKTOP_USER_ID,
+  email: "local@midday.local",
+  user_metadata: {
+    full_name: "Local User",
+    team_id: LOCAL_DESKTOP_TEAM_ID,
+  },
+  app_metadata: {},
+  aud: "authenticated",
+  created_at: "2020-01-01T00:00:00.000Z",
+};
+
+const localSession = {
+  access_token: LOCAL_DESKTOP_SESSION_TOKEN,
+  refresh_token: LOCAL_DESKTOP_SESSION_TOKEN,
+  token_type: "bearer",
+  expires_in: 31_536_000,
+  expires_at: Math.floor(Date.now() / 1000) + 31_536_000,
+  user: localUser,
+};
+
+function createLocalChannel() {
+  return {
+    on() {
+      return this;
+    },
+    subscribe(callback?: (status: string) => void) {
+      callback?.("SUBSCRIBED");
+      return this;
+    },
+    unsubscribe: async () => "ok",
+  };
+}
+
+export function createLocalSupabaseClient() {
+  return {
+    auth: {
+      exchangeCodeForSession: async () => ({
+        data: { session: localSession, user: localUser },
+        error: null,
+      }),
+      getClaims: async () => ({
+        data: { claims: { sub: LOCAL_DESKTOP_USER_ID } },
+        error: null,
+      }),
+      getSession: async () => ({
+        data: { session: localSession },
+        error: null,
+      }),
+      getUser: async () => ({
+        data: { user: localUser },
+        error: null,
+      }),
+      signInWithOAuth: async () => ({
+        data: { provider: "local", url: null },
+        error: null,
+      }),
+      signInWithOtp: async () => ({ data: {}, error: null }),
+      signOut: async () => ({ error: null }),
+      verifyOtp: async () => ({
+        data: { session: localSession, user: localUser },
+        error: null,
+      }),
+      mfa: {
+        challenge: async () => ({
+          data: { id: "local_mfa_challenge" },
+          error: null,
+        }),
+        enroll: async () => ({
+          data: { id: "local_mfa_factor" },
+          error: null,
+        }),
+        getAuthenticatorAssuranceLevel: async () => ({
+          data: { currentLevel: "aal1", nextLevel: "aal1" },
+          error: null,
+        }),
+        listFactors: async () => ({
+          data: { all: [], totp: [] },
+          error: null,
+        }),
+        unenroll: async () => ({ data: {}, error: null }),
+        verify: async () => ({ data: {}, error: null }),
+      },
+    },
+    channel: () => createLocalChannel(),
+    removeChannel: async () => ({ error: null }),
+  } as unknown as SupabaseClient;
+}
+
+export { isLocalDesktopRuntime };

--- a/packages/supabase/src/client/middleware.ts
+++ b/packages/supabase/src/client/middleware.ts
@@ -1,10 +1,19 @@
 import { createServerClient } from "@supabase/ssr";
 import type { NextRequest, NextResponse } from "next/server";
+import { createLocalSupabaseClient, isLocalDesktopRuntime } from "./local";
 
 export async function updateSession(
   request: NextRequest,
   response: NextResponse,
 ) {
+  if (isLocalDesktopRuntime()) {
+    return {
+      response,
+      isAuthenticated: true,
+      supabase: createLocalSupabaseClient(),
+    };
+  }
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,

--- a/packages/supabase/src/client/server.ts
+++ b/packages/supabase/src/client/server.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import type { Database } from "../types";
+import { createLocalSupabaseClient, isLocalDesktopRuntime } from "./local";
 
 type CreateClientOptions = {
   admin?: boolean;
@@ -8,6 +9,10 @@ type CreateClientOptions = {
 };
 
 export async function createClient(options?: CreateClientOptions) {
+  if (isLocalDesktopRuntime()) {
+    return createLocalSupabaseClient();
+  }
+
   const { admin = false, ...rest } = options ?? {};
   const cookieStore = await cookies();
 

--- a/packages/utils/src/envs.test.ts
+++ b/packages/utils/src/envs.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isLocalDesktopRuntime,
+  LOCAL_DESKTOP_SESSION_TOKEN,
+  LOCAL_DESKTOP_TEAM_ID,
+  LOCAL_DESKTOP_USER_ID,
+} from "./envs";
+
+describe("isLocalDesktopRuntime", () => {
+  test("detects server-side local desktop runtime", () => {
+    expect(isLocalDesktopRuntime({ MIDDAY_DESKTOP_RUNTIME: "local" })).toBe(
+      true,
+    );
+    expect(isLocalDesktopRuntime({ MIDDAY_LOCAL_FIRST: "true" })).toBe(true);
+  });
+
+  test("detects client-exposed local desktop runtime", () => {
+    expect(
+      isLocalDesktopRuntime({ NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME: "local" }),
+    ).toBe(true);
+    expect(isLocalDesktopRuntime({ NEXT_PUBLIC_MIDDAY_LOCAL_FIRST: "1" })).toBe(
+      true,
+    );
+  });
+
+  test("does not treat remote desktop runtime as local", () => {
+    expect(isLocalDesktopRuntime({ MIDDAY_DESKTOP_RUNTIME: "remote" })).toBe(
+      false,
+    );
+    expect(isLocalDesktopRuntime({})).toBe(false);
+  });
+
+  test("exports stable local identity constants", () => {
+    expect(LOCAL_DESKTOP_USER_ID).toBe("local_user");
+    expect(LOCAL_DESKTOP_TEAM_ID).toBe("local_team");
+    expect(LOCAL_DESKTOP_SESSION_TOKEN).toBe("local_session");
+  });
+});

--- a/packages/utils/src/envs.ts
+++ b/packages/utils/src/envs.ts
@@ -62,3 +62,24 @@ export function getApiUrl() {
 
   return "http://localhost:3002";
 }
+
+type LocalRuntimeEnv = Record<string, string | undefined>;
+
+export const LOCAL_DESKTOP_USER_ID = "local_user";
+export const LOCAL_DESKTOP_TEAM_ID = "local_team";
+export const LOCAL_DESKTOP_SESSION_TOKEN = "local_session";
+
+function isEnabled(value: string | undefined) {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+export function isLocalDesktopRuntime(env: LocalRuntimeEnv = process.env) {
+  const runtime =
+    env.MIDDAY_DESKTOP_RUNTIME ?? env.NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME;
+
+  return (
+    runtime?.toLowerCase() === "local" ||
+    isEnabled(env.MIDDAY_LOCAL_FIRST) ||
+    isEnabled(env.NEXT_PUBLIC_MIDDAY_LOCAL_FIRST)
+  );
+}

--- a/turbo.json
+++ b/turbo.json
@@ -80,6 +80,7 @@
       "passThroughEnv": [
         "ALLOWED_API_ORIGINS",
         "API_INTERNAL_URL",
+        "FILE_KEY_SECRET",
         "MIDDAY_DESKTOP_DATA_DIR",
         "MIDDAY_DESKTOP_RUNTIME",
         "MIDDAY_LOCAL_FIRST",

--- a/turbo.json
+++ b/turbo.json
@@ -77,6 +77,18 @@
     },
     "dev": {
       "inputs": ["$TURBO_DEFAULT$", ".env"],
+      "passThroughEnv": [
+        "ALLOWED_API_ORIGINS",
+        "API_INTERNAL_URL",
+        "MIDDAY_DESKTOP_DATA_DIR",
+        "MIDDAY_DESKTOP_RUNTIME",
+        "MIDDAY_LOCAL_FIRST",
+        "MIDDAY_SQLITE_PATH",
+        "NEXT_PUBLIC_API_URL",
+        "NEXT_PUBLIC_MIDDAY_DESKTOP_RUNTIME",
+        "NEXT_PUBLIC_MIDDAY_LOCAL_FIRST",
+        "PORT"
+      ],
       "persistent": true,
       "cache": false
     },


### PR DESCRIPTION
## Summary

- Add a Tauri local runtime configuration and service bootstrap path for desktop mode.
- Add embedded SQLite bootstrap, migrations, local client helpers, and local identity/team/dashboard shell query helpers.
- Stub or bypass external hosted services in local desktop mode where needed for initial startup.
- Serve the initial authenticated dashboard shell from local SQLite while preserving the existing UI surface.

## Validation

- `bun run --filter @midday/db test:local`
- `bun test apps/api/src/__tests__/trpc/local-desktop.test.ts --timeout 30000`
- `bun test packages/utils/src/envs.test.ts packages/bot/src/instance.test.ts apps/api/src/composio/client.test.ts apps/api/src/services/resend.test.ts packages/db/src/local/runtime-clients.test.ts`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib`
- `bun run --filter @midday/db typecheck`
- `bun run --filter @midday/api typecheck`
- `bun run --filter @midday/dashboard typecheck`
- `bun run --filter @midday/supabase typecheck`
- `bun run --filter @midday/banking typecheck`
- `bun run --filter @midday/bot typecheck`

## Notes

This is a phase branch. It establishes the local-first desktop shell and SQLite bootstrap path, but deeper feature data such as transactions, invoices CRUD, inbox, reports, documents, customers, and banking still need SQLite-backed implementations in follow-up work.
